### PR TITLE
:sparkles: Feat(config): Add cachedir as a config option

### DIFF
--- a/.changeset/breezy-dryers-burn.md
+++ b/.changeset/breezy-dryers-burn.md
@@ -1,0 +1,5 @@
+---
+"@tevm/config": minor
+---
+
+Added `cacheDir` as a config option that defaults to '.tevm'. Cache dir is where the tevm build cache is stored

--- a/bundler/config/docs/modules/defaultConfig.md
+++ b/bundler/config/docs/modules/defaultConfig.md
@@ -20,6 +20,7 @@ The default CompilerConfig
 
 | Name | Type |
 | :------ | :------ |
+| `cacheDir` | `string` |
 | `debug` | `boolean` |
 | `foundryProject` | `boolean` |
 | `libs` | `never`[] |

--- a/bundler/config/docs/modules/defineConfig.md
+++ b/bundler/config/docs/modules/defineConfig.md
@@ -49,4 +49,4 @@ export default defineConfig(() => ({
 
 #### Defined in
 
-[bundler/config/src/types.ts:76](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L76)
+[bundler/config/src/types.ts:84](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L84)

--- a/bundler/config/docs/modules/types.md
+++ b/bundler/config/docs/modules/types.md
@@ -25,9 +25,10 @@ When resolved with defaults it is a [ResolvedCompilerConfig](types.md#resolvedco
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `cacheDir?` | `string` | Location of the tevm cache folder |
 | `debug?` | `boolean` | If debug is true tevm will write the .d.ts files in the ts server and publish extra debug info to a debug file |
 | `foundryProject?` | `boolean` \| `string` | If set to true it will resolve forge remappings and libs Set to "path/to/forge/executable" to use a custom forge executable |
-| `libs?` | readonly `string`[] | Sets directories to search for solidity imports in Read autoamtically for forge projects if forge: true |
+`libs?` | readonly `string`[] | Sets directories to search for solidity imports in Read automatically for forge projects if forge: true |
 | `remappings?` | `ReadonlyRecord`\<`string`\> | Remap the location of contracts |
 
 #### Defined in
@@ -50,7 +51,7 @@ ___
 
 #### Defined in
 
-[bundler/config/src/types.ts:35](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L35)
+[bundler/config/src/types.ts:39](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L39)
 
 ___
 
@@ -91,7 +92,7 @@ export default defineConfig({
 
 #### Defined in
 
-[bundler/config/src/types.ts:76](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L76)
+[bundler/config/src/types.ts:84](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L84)
 
 ___
 
@@ -101,7 +102,7 @@ ___
 
 #### Defined in
 
-[bundler/config/src/types.ts:62](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L62)
+[bundler/config/src/types.ts:70](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L70)
 
 ___
 
@@ -116,11 +117,12 @@ See [CompilerConfig](types.md#compilerconfig)
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `cacheDir` | `string` | Location of the tevm cache folder |
 | `debug?` | `boolean` | If debug is true tevm will write the .d.ts files in the ts server and publish extra debug info to a debug file |
 | `foundryProject` | `boolean` \| `string` | If set to true it will resolve forge remappings and libs Set to "path/to/forge/executable" to use a custom forge executable |
-| `libs` | readonly `string`[] | Sets directories to search for solidity imports in Read autoamtically for forge projects if forge: true |
+`libs` | readonly `string`[] | Sets directories to search for solidity imports in Read automatically for forge projects if forge: true |
 | `remappings` | `ReadonlyRecord`\<`string`\> | Remap the location of contracts |
 
 #### Defined in
 
-[bundler/config/src/types.ts:41](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L41)
+[bundler/config/src/types.ts:45](https://github.com/evmts/tevm-monorepo/blob/main/bundler/config/src/types.ts#L45)

--- a/bundler/config/src/config/mergeConfigs.js
+++ b/bundler/config/src/config/mergeConfigs.js
@@ -24,4 +24,8 @@ export const mergeConfigs = (configs) =>
 			.reverse()
 			.find((config) => config.foundryProject !== undefined)?.foundryProject,
 		libs: [...new Set(configs.flatMap((config) => config.libs ?? []))],
+		debug: configs.reverse().find((config) => config.debug !== undefined)
+			?.debug,
+		cacheDir: configs.reverse().find((config) => config.cacheDir !== undefined)
+			?.cacheDir,
 	})

--- a/bundler/config/src/config/mergeConfigs.spec.ts
+++ b/bundler/config/src/config/mergeConfigs.spec.ts
@@ -6,7 +6,7 @@ describe(mergeConfigs.name, () => {
 	it('should correctly merge multiple configurations', () => {
 		const config1 = { remappings: { key1: 'value1' }, libs: ['lib1', 'lib2'] }
 		const config2 = { remappings: { key2: 'value2' }, libs: ['lib3'] }
-		const config3 = { foundryProject: 'forge' }
+		const config3 = { foundryProject: 'forge', debug: true, cacheDir: 'cache' }
 
 		const result = runSync(mergeConfigs([config1, config2, config3]))
 
@@ -14,6 +14,8 @@ describe(mergeConfigs.name, () => {
 			remappings: { key1: 'value1', key2: 'value2' },
 			libs: ['lib3', 'lib1', 'lib2'],
 			foundryProject: 'forge',
+			debug: true,
+			cacheDir: 'cache',
 		})
 	})
 

--- a/bundler/config/src/config/validateUserConfig.js
+++ b/bundler/config/src/config/validateUserConfig.js
@@ -70,6 +70,7 @@ const SCompilerConfig = struct({
 	libs: optional(union(array(string), SUndefined)),
 	remappings: optional(union(record(string, string), SUndefined)),
 	debug: optional(union(boolean, SUndefined)),
+	cacheDir: optional(union(string, SUndefined)),
 })
 
 /**

--- a/bundler/config/src/config/withDefaults.js
+++ b/bundler/config/src/config/withDefaults.js
@@ -8,6 +8,7 @@ export const defaultConfig = {
 	remappings: {},
 	libs: [],
 	debug: false,
+	cacheDir: '.tevm',
 }
 
 /**
@@ -30,6 +31,7 @@ export const withDefaults = (config) =>
 		},
 		libs: [...defaultConfig.libs, ...(config.libs ?? [])],
 		debug: config.debug ?? defaultConfig.debug,
+		cacheDir: config.cacheDir ?? defaultConfig.cacheDir,
 	}).pipe(
 		tap((configWithDefaults) =>
 			logDebug(

--- a/bundler/config/src/config/withDefaults.spec.ts
+++ b/bundler/config/src/config/withDefaults.spec.ts
@@ -19,6 +19,7 @@ describe(withDefaults.name, () => {
 			remappings: { foo: 'bar' },
 			libs: ['lib1', 'lib2'],
 			debug: false,
+			cacheDir: defaultConfig.cacheDir,
 		})
 		expect(
 			runSync(
@@ -31,6 +32,7 @@ describe(withDefaults.name, () => {
 			remappings: defaultConfig.remappings,
 			libs: defaultConfig.libs,
 			debug: false,
+			cacheDir: defaultConfig.cacheDir,
 		})
 		expect(
 			runSync(
@@ -43,6 +45,7 @@ describe(withDefaults.name, () => {
 			remappings: { foo: 'bar' },
 			libs: defaultConfig.libs,
 			debug: false,
+			cacheDir: defaultConfig.cacheDir,
 		})
 		expect(
 			runSync(
@@ -55,6 +58,7 @@ describe(withDefaults.name, () => {
 			remappings: defaultConfig.remappings,
 			libs: ['lib1', 'lib2'],
 			debug: false,
+			cacheDir: defaultConfig.cacheDir,
 		})
 	})
 })

--- a/bundler/config/src/defineConfig.spec.ts
+++ b/bundler/config/src/defineConfig.spec.ts
@@ -49,6 +49,7 @@ describe(defineConfig.name, () => {
 			foundryProject: 'forge',
 			libs: ['lib1', 'lib2'],
 			debug: false,
+			cacheDir: defaultConfig.cacheDir,
 		})
 		expect(mockExecSync).toHaveBeenCalledWith('forge config --json', {
 			cwd: './',
@@ -74,6 +75,7 @@ describe(defineConfig.name, () => {
 			foundryProject: true,
 			libs: ['lib1', 'lib2'],
 			debug: false,
+			cacheDir: defaultConfig.cacheDir,
 		})
 		expect(mockExecSync).toHaveBeenCalledWith('forge config --json', {
 			cwd: './',

--- a/bundler/config/src/fixtures/basic/tsconfig.json
+++ b/bundler/config/src/fixtures/basic/tsconfig.json
@@ -7,6 +7,7 @@
     "plugins": [
       {
         "name": "@tevm/ts-plugin",
+        "cacheDir": ".cache",
         "libs": [
           "mylib"
         ]

--- a/bundler/config/src/loadConfig.spec.ts
+++ b/bundler/config/src/loadConfig.spec.ts
@@ -17,6 +17,7 @@ describe(loadConfig.name, () => {
 			),
 		}).toMatchInlineSnapshot(`
 			{
+			  "cacheDir": ".tevm",
 			  "debug": false,
 			  "foundryProject": false,
 			  "libs": [],
@@ -38,6 +39,7 @@ describe(loadConfig.name, () => {
 			runSync(loadConfig(join(__dirname, 'fixtures/jsonc'))),
 		).toMatchInlineSnapshot(`
 			{
+			  "cacheDir": ".tevm",
 			  "debug": false,
 			  "foundryProject": false,
 			  "libs": [],
@@ -51,6 +53,7 @@ describe(loadConfig.name, () => {
 			runSync(loadConfig(join(__dirname, 'fixtures/withFoundry'))),
 		).toMatchInlineSnapshot(`
 			{
+			  "cacheDir": ".tevm",
 			  "debug": false,
 			  "foundryProject": false,
 			  "libs": [],

--- a/bundler/config/src/types.ts
+++ b/bundler/config/src/types.ts
@@ -27,6 +27,10 @@ export type CompilerConfig = {
 	 * If debug is true tevm will write the .d.ts files in the ts server and publish extra debug info to a debug file
 	 */
 	debug?: boolean | undefined
+	/**
+	 * Location of the tevm cache folder
+	 */
+	cacheDir?: string | undefined
 }
 
 /*
@@ -57,6 +61,10 @@ export type ResolvedCompilerConfig = {
 	 * If debug is true tevm will write the .d.ts files in the ts server and publish extra debug info to a debug file
 	 */
 	debug?: boolean | undefined
+	/**
+	 * Location of the tevm cache folder
+	 */
+	cacheDir: string
 }
 
 export type DefineConfigErrorType =

--- a/bundler/config/vitest.config.ts
+++ b/bundler/config/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 			lines: 100,
 			statements: 100,
 			functions: 100,
-			branches: 97.93,
+			branches: 98.01,
 			thresholdAutoUpdate: true,
 		},
 	},


### PR DESCRIPTION
## Description

Added `cacheDir` as a config option that defaults to `.tevm`

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `cacheDir` configuration option to specify the cache directory.

- **Documentation**
  - Updated documentation to reflect the new `cacheDir` property.
  - Corrected a hyperlink in the configuration documentation.

- **Refactor**
  - Enhanced configuration merging to incorporate the `debug` and `cacheDir` settings.
  - Updated validation logic to include the new `cacheDir` field.

- **Tests**
  - Expanded test suites to cover the new `cacheDir` and `debug` properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->