### PR TITLE
:goal_net: Feat: Better error message runContractCall CHA-67

### DIFF
--- a/.changeset/tasty-toes-cough.md
+++ b/.changeset/tasty-toes-cough.md
@@ -1,0 +1,5 @@
+---
+"@tevm/vm": patch
+---
+
+Added better error message when contract code does not exist when running vm.runContractCall

--- a/vm/vm/src/actions/contractCall/runContractCallHandler.js
+++ b/vm/vm/src/actions/contractCall/runContractCallHandler.js
@@ -21,7 +21,7 @@ export class ContractDoesNotExistError extends Error {
 	 */
 	constructor(contractAddress) {
 		super(
-			`Contract ${contractAddress} does not exist no bytecode found at address`,
+			`Contract ${contractAddress} does not exist because no bytecode was found at the address`,
 		)
 	}
 }

--- a/vm/vm/src/actions/contractCall/runContractCallHandler.js
+++ b/vm/vm/src/actions/contractCall/runContractCallHandler.js
@@ -2,7 +2,29 @@ import { putAccountHandler } from '../putAccount/putAccountHandler.js'
 import { runCallHandler } from '../runCall/runCallHandler.js'
 import { defaultCaller } from './defaultCaller.js'
 import { defaultGasLimit } from './defaultGasLimit.js'
+import { Address } from '@ethereumjs/util'
 import { decodeFunctionResult, encodeFunctionData, toHex } from 'viem'
+
+export class ContractDoesNotExistError extends Error {
+	/**
+	 * @type {'ContractDoesNotExistError'}
+	 * @override
+	 */
+	name = 'ContractDoesNotExistError'
+	/**
+	 * @type {'ContractDoesNotExistError'}
+	 */
+	_tag = 'ContractDoesNotExistError'
+
+	/**
+	 * @param {string} contractAddress
+	 */
+	constructor(contractAddress) {
+		super(
+			`Contract ${contractAddress} does not exist no bytecode found at address`,
+		)
+	}
+}
 
 /**
  * @type {import("./RunContractCallHandlerGeneric.js").RunContractCallHandlerGeneric}
@@ -25,7 +47,14 @@ export const runContractCallHandler = async (
 		})
 	}
 
-	console.log(args)
+	// check early if contract exists
+	const contract = await tevm._evm.stateManager.getContractCode(
+		Address.fromString(contractAddress),
+	)
+	if (contract.length === 0) {
+		throw new ContractDoesNotExistError(contractAddress)
+	}
+
 	const result = await runCallHandler(tevm, {
 		to: contractAddress,
 		caller: caller,


### PR DESCRIPTION
## Description

Check first that code exists at address. Since we are caching the code it will not create extra requests

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced error messaging for contract call failures when the contract code is missing, providing users with clearer guidance on the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->