### PR TITLE
:sparkles: Feat: Add viem client extension

### DIFF
--- a/.changeset/rude-dragons-sing.md
+++ b/.changeset/rude-dragons-sing.md
@@ -3,3 +3,6 @@
 ---
 
 Added viem client for interacting with evmts vm
+
+Enhanced the `@tevm/vm` package by introducing the `viem` client extension. This new feature allows for more sophisticated interactions with the `tevm` virtual machine, including the ability to handle `NonVerboseTevmJsonRpcRequest` types and utilize the `superjson` library for serialization. The update includes new methods for tevm requests, script execution, and account management, as well as additional test coverage to ensure functionality. This extension is a step towards more flexible and powerful vm operations, paving the way for future enhancements.
+

--- a/.changeset/rude-dragons-sing.md
+++ b/.changeset/rude-dragons-sing.md
@@ -1,0 +1,5 @@
+---
+"@tevm/vm": minor
+---
+
+Added viem client for interacting with evmts vm

--- a/vm/vm/package.json
+++ b/vm/vm/package.json
@@ -28,6 +28,11 @@
 			"import": "./dist/index.js",
 			"default": "./dist/index.cjs",
 			"types": "./types/index.d.ts"
+		},
+		"./viem": {
+			"import": "./src/viem/index.js",
+			"default": "./dist/viem/index.cjs",
+			"types": "./types/viem/index.d.ts"
 		}
 	},
 	"main": "dist/index.cjs",

--- a/vm/vm/src/jsonrpc/TevmJsonRpcRequest.ts
+++ b/vm/vm/src/jsonrpc/TevmJsonRpcRequest.ts
@@ -10,3 +10,10 @@ export type TevmJsonRpcRequest =
 	| TevmPutContractCodeRequest
 	| TevmCallRequest
 	| TevmScriptRequest
+
+export type NonVerboseTevmJsonRpcRequest =
+	| Pick<TevmContractCallRequest, 'method' | 'params'>
+	| Pick<TevmPutAccountRequest, 'method' | 'params'>
+	| Pick<TevmPutContractCodeRequest, 'method' | 'params'>
+	| Pick<TevmCallRequest, 'method' | 'params'>
+	| Pick<TevmScriptRequest, 'method' | 'params'>

--- a/vm/vm/src/jsonrpc/createJsonRpcClient.ts
+++ b/vm/vm/src/jsonrpc/createJsonRpcClient.ts
@@ -1,5 +1,8 @@
 import type { Tevm } from '../Tevm.js'
-import type { TevmJsonRpcRequest } from './TevmJsonRpcRequest.js'
+import type {
+	NonVerboseTevmJsonRpcRequest,
+	TevmJsonRpcRequest,
+} from './TevmJsonRpcRequest.js'
 import type { TevmContractCallResponse } from './contractCall/TevmContractCallResponse.js'
 import {
 	tevmCall,
@@ -21,22 +24,26 @@ export class UnknownMethodError extends Error {
 	}
 }
 
-export type BackendReturnType<T extends TevmJsonRpcRequest> = T extends {
-	method: 'tevm_call'
-}
-	? TevmCallResponse
-	: T extends { method: 'tevm_contractCall' }
-	? TevmContractCallResponse<
-			T['params']['abi'],
-			T['params']['functionName'] & string
-	  >
-	: T extends { method: 'tevm_putAccount' }
-	? TevmPutAccountResponse
-	: T extends { method: 'tevm_putContractCode' }
-	? TevmPutContractCodeResponse
-	: T extends { method: 'tevm_script' }
-	? TevmScriptResponse<T['params']['abi'], T['params']['functionName'] & string>
-	: never
+export type BackendReturnType<T extends NonVerboseTevmJsonRpcRequest> =
+	T extends {
+		method: 'tevm_call'
+	}
+		? TevmCallResponse
+		: T extends { method: 'tevm_contractCall' }
+		? TevmContractCallResponse<
+				T['params']['abi'],
+				T['params']['functionName'] & string
+		  >
+		: T extends { method: 'tevm_putAccount' }
+		? TevmPutAccountResponse
+		: T extends { method: 'tevm_putContractCode' }
+		? TevmPutContractCodeResponse
+		: T extends { method: 'tevm_script' }
+		? TevmScriptResponse<
+				T['params']['abi'],
+				T['params']['functionName'] & string
+		  >
+		: never
 
 /**
  * Creates a vanillajs jsonrpc handler for tevm requests

--- a/vm/vm/src/viem/index.js
+++ b/vm/vm/src/viem/index.js
@@ -1,0 +1,1 @@
+export { tevmViemExtension } from './tevmViemExtension.js'

--- a/vm/vm/src/viem/tevmViemExtension.js
+++ b/vm/vm/src/viem/tevmViemExtension.js
@@ -1,0 +1,61 @@
+import { parse, stringify } from 'superjson'
+
+/**
+ * @type {import('./types.js').ViemTevmExtension}
+ */
+export const tevmViemExtension = () => {
+	return (client) => {
+		/**
+		 * @type {import('./types.js').ViemTevmClient['tevmRequest']}
+		 */
+		const tevmRequest = async (request) => {
+			return /** @type {any} */ (
+				parse(
+					JSON.stringify(
+						await client.request({
+							method: /** @type {any}*/ (request.method),
+							params: /** @type {any}*/ (JSON.parse(stringify(request.params))),
+						}),
+					),
+				)
+			)
+		}
+		return {
+			tevmRequest,
+			runScript: async (action) => {
+				return /** @type {any} */ (
+					tevmRequest({
+						method: 'tevm_script',
+						params: /** @type any*/ (action),
+					})
+				)
+			},
+			putAccount: async (action) => {
+				return tevmRequest({
+					method: 'tevm_putAccount',
+					params: action,
+				})
+			},
+			putContractCode: async (action) => {
+				return tevmRequest({
+					method: 'tevm_putContractCode',
+					params: action,
+				})
+			},
+			runCall: async (action) => {
+				return tevmRequest({
+					method: 'tevm_call',
+					params: action,
+				})
+			},
+			runContractCall: async (action) => {
+				return /** @type {any} */ (
+					tevmRequest({
+						method: 'tevm_contractCall',
+						params: /** @type {any}*/ (action),
+					})
+				)
+			},
+		}
+	}
+}

--- a/vm/vm/src/viem/tevmViemExtension.spec.ts
+++ b/vm/vm/src/viem/tevmViemExtension.spec.ts
@@ -1,0 +1,62 @@
+import { tevmViemExtension } from './tevmViemExtension.js'
+import { beforeEach, describe, expect, it, jest } from 'bun:test'
+import { stringify } from 'superjson'
+
+describe('tevmViemExtension', () => {
+	let mockClient: any
+
+	beforeEach(() => {
+		mockClient = { request: jest.fn() }
+	})
+
+	it('tevmRequest should call client.request and parse the response', async () => {
+		const mockResponse = JSON.parse(stringify({ balance: 420n }))
+		mockClient.request.mockResolvedValue(mockResponse)
+
+		const decorated = tevmViemExtension()(mockClient)
+		const params = { account: '0x420', balance: 420n } as const
+		const response = await decorated.putAccount(params)
+
+		expect((mockClient.request as jest.Mock).mock.lastCall[0]).toEqual({
+			method: 'tevm_putAccount',
+			params: JSON.parse(stringify(params)),
+		})
+		expect(response.balance).toEqual(420n)
+	})
+
+	it('runScript should call client.request with "tevm_script" and parse the response', async () => {
+		const mockResponse = JSON.parse(stringify({ gasUsed: 420n }))
+		mockClient.request.mockResolvedValue(mockResponse)
+
+		const decorated = tevmViemExtension()(mockClient)
+		const params = {
+			abi: [{ type: 'function', name: 'testFunction', inputs: [] }],
+			functionName: 'testFunction',
+			args: [],
+			deployedBytecode: '0x420',
+			caller: '0x69',
+		} as const
+		const response = await decorated.runScript(params)
+
+		expect((mockClient.request as jest.Mock).mock.lastCall[0]).toEqual({
+			method: 'tevm_script',
+			params: JSON.parse(stringify(params)),
+		})
+		expect(response.gasUsed).toEqual(420n)
+	})
+
+	it('putAccount should call client.request with "tevm_putAccount" and parse the response', async () => {
+		const mockResponse = JSON.parse(stringify({ balance: 420n }))
+		mockClient.request.mockResolvedValue(mockResponse)
+
+		const decorated = tevmViemExtension()(mockClient)
+		const params = { balance: 420n, account: '0x420' } as const
+		const response = await decorated.putAccount(params)
+
+		expect((mockClient.request as jest.Mock).mock.lastCall[0]).toEqual({
+			method: 'tevm_putAccount',
+			params: JSON.parse(stringify(params)),
+		})
+		expect(response.balance).toEqual(420n)
+	})
+})

--- a/vm/vm/src/viem/types.ts
+++ b/vm/vm/src/viem/types.ts
@@ -1,0 +1,37 @@
+import type { Abi } from 'abitype'
+import type { NonVerboseTevmJsonRpcRequest } from '../jsonrpc/TevmJsonRpcRequest.js'
+import type { BackendReturnType } from '../jsonrpc/createJsonRpcClient.js'
+import type { RunScriptAction } from '../actions/runScript/RunScriptAction.js'
+import type { RunScriptResult } from '../actions/runScript/RunScriptResult.js'
+import type { PutAccountAction, PutContractCodeAction, RunCallAction } from '../actions/index.js'
+import type { TevmPutAccountResponse } from '../jsonrpc/putAccount/TevmPutAccountResponse.js'
+import type { TevmPutContractCodeResponse } from '../jsonrpc/putContractCode/TevmPutContractCodeResponse.js'
+import type { TevmCallResponse } from '../jsonrpc/runCall/TevmCallResponse.js'
+import type { RunContractCallAction } from '../actions/contractCall/RunContractCallAction.js'
+import type { RunContractCallResult } from '../actions/contractCall/RunContractCallResult.js'
+
+export type ViemTevmClient = {
+  tevmRequest<T extends NonVerboseTevmJsonRpcRequest>(r: T): Promise<BackendReturnType<T>['result']>
+  runScript<
+    TAbi extends Abi | readonly unknown[] = Abi,
+    TFunctionName extends string = string,
+  >(
+    action: RunScriptAction<TAbi, TFunctionName>,
+  ): Promise<RunScriptResult<TAbi, TFunctionName>>
+  putAccount(action: PutAccountAction): Promise<TevmPutAccountResponse['result']>
+  putContractCode(
+    action: PutContractCodeAction,
+  ): Promise<TevmPutContractCodeResponse['result']>
+  runCall(action: RunCallAction): Promise<TevmCallResponse['result']>
+  runContractCall<
+    TAbi extends Abi | readonly unknown[] = Abi,
+    TFunctionName extends string = string,
+  >(
+    action: RunContractCallAction<TAbi, TFunctionName>,
+  ): Promise<RunContractCallResult<TAbi, TFunctionName>>
+}
+
+export type ViemTevmClientDecorator = (client: Pick<import('viem').Client, 'request'>) => ViemTevmClient
+
+export type ViemTevmExtension = () => ViemTevmClientDecorator
+

--- a/vm/vm/tsup.config.ts
+++ b/vm/vm/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
 	name: packageJson.name,
-	entry: ['src/index.ts'],
+	entry: ['src/index.ts', 'src/viem/index.js'],
 	outDir: 'dist',
 	format: ['esm', 'cjs'],
 	splitting: false,


### PR DESCRIPTION
## Description

Add viem extension for vm. When calling client.extend it will add actions to interact with tevm.

Current naive version requires the tevm rpc to be the same rpc url as the viem client

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new type for more streamlined JSON-RPC requests.
  - Added new functionalities to handle various `tevm` requests through a dedicated extension module.

- **Refactor**
  - Updated JSON-RPC client creation logic to accommodate new request types.
  - Expanded the entry points for the build process to include the new `viem` module.

- **Tests**
  - Implemented test cases for the new `tevmViemExtension` module to ensure correct operation of `tevm` requests.

- **Documentation**
  - No visible changes; internal documentation updates to reflect new types and functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->