### PR TITLE
:memo: Docs: Generate viem docs

### DIFF
--- a/vm/vm/docs/README.md
+++ b/vm/vm/docs/README.md
@@ -1,4 +1,4 @@
-@tevm/vm / [Exports](modules.md)
+@tevm/vm / [Modules](modules.md)
 
 <p align="center">
   <a href="https://tevm.dev/">

--- a/vm/vm/docs/modules.md
+++ b/vm/vm/docs/modules.md
@@ -1,182 +1,30 @@
-[@tevm/vm](README.md) / Exports
+[@tevm/vm](README.md) / Modules
 
 # @tevm/vm
 
 ## Table of contents
 
-### Type Aliases
+### Modules
 
-- [Client](undefined)
-- [CreateEVMOptions](undefined)
-- [Tevm](undefined)
+- [index](undefined)
+- [viem](undefined)
 
-### Functions
+## Modules
 
-- [createClient](undefined)
-- [createTevm](undefined)
+### index
 
-## Type Aliases
-
-### Client
-
-Ƭ **Client**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `putAccount` | Method putAccount |
-| `putContractCode` | Method putContractCode |
-| `request` | Method request |
-| `runCall` | Method runCall |
-| `runContractCall` | Method runContractCall |
-| `runScript` | Method runScript |
+• **index**: Module index
 
 #### Defined in
 
-[client/createClient.ts:17](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/client/createClient.ts#L17)
+[index.ts:1](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/index.ts#L1)
 
 ___
 
-### CreateEVMOptions
+### viem
 
-Ƭ **CreateEVMOptions**: `Object`
-
-Options for creating an Tevm instance
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `customPrecompiles?` | CustomPrecompile[] |
-| `fork?` | ForkOptions |
+• **viem**: Module viem
 
 #### Defined in
 
-[Tevm.ts:38](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/Tevm.ts#L38)
-
-___
-
-### Tevm
-
-Ƭ **Tevm**: `Object`
-
-A local EVM instance running in JavaScript. Similar to Anvil in your browser
-
-**`Example`**
-
-```ts
-import { Tevm } from "tevm"
-import { createPublicClient, http } from "viem"
-import { MyERC721 } from './MyERC721.sol'
-
-const tevm = Tevm.create({
-	fork: {
-	  url: "https://mainnet.optimism.io",
-	},
-})
-
-const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
-
-await tevm.runContractCall(
-  MyERC721.write.mint({
-    caller: address,
-  }),
-)
-
-const balance = await tevm.runContractCall(
- MyERC721.read.balanceOf({
- caller: address,
- }),
- )
- console.log(balance) // 1n
- ```
-
-#### Type declaration
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `_evm` | EVM | Internal instance of the EVM. Can be used for lower level operations but is not guaranteed to stay stable between versions |
-| `createHttpHandler` | Function | - |
-| `createJsonRpcClient` | Function | - |
-| `putAccount` | Function | - |
-| `putContractCode` | Function | - |
-| `request` | Function | - |
-| `runCall` | Function | - |
-| `runContractCall` | Function | - |
-| `runScript` | Function | - |
-
-#### Defined in
-
-[Tevm.ts:96](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/Tevm.ts#L96)
-
-## Functions
-
-### createClient
-
-▸ **createClient**(`rpcUrl`): Client
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `rpcUrl` | string |
-
-#### Returns
-
-Client
-
-#### Defined in
-
-[client/createClient.ts:38](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/client/createClient.ts#L38)
-
-___
-
-### createTevm
-
-▸ **createTevm**(`options?`): Promise\<Tevm\>
-
-A local EVM instance running in JavaScript. Similar to Anvil in your browser
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `options?` | CreateEVMOptions |
-
-#### Returns
-
-Promise\<Tevm\>
-
-**`Example`**
-
-```ts
-import { Tevm } from "tevm"
-import { createPublicClient, http } from "viem"
-import { MyERC721 } from './MyERC721.sol'
-
-const tevm = Tevm.create({
-	fork: {
-	  url: "https://mainnet.optimism.io",
-	},
-})
-
-const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
-
-await tevm.runContractCall(
-  MyERC721.write.mint({
-    caller: address,
-  }),
-)
-
-const balance = await tevm.runContractCall(
- MyERC721.read.balanceOf({
- caller: address,
- }),
- )
- console.log(balance) // 1n
- ```
-
-#### Defined in
-
-[createTevm.js:47](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/createTevm.js#L47)
+[viem/index.js:1](https://github.com/evmts/tevm-monorepo/blob/main/vm/vm/src/viem/index.js#L1)

--- a/vm/vm/src/createTevm.js
+++ b/vm/vm/src/createTevm.js
@@ -206,9 +206,9 @@ export const createTevm = async (options = {}) => {
 		putContractCode,
 		runCall,
 		runContractCall,
-		...(
-			options.fork?.url ? { forkUrl: options.fork.url } : { forkUrl: options.fork?.url }
-		)
+		...(options.fork?.url
+			? { forkUrl: options.fork.url }
+			: { forkUrl: options.fork?.url }),
 	}
 
 	return tevm

--- a/vm/vm/src/jsonrpc/createHttpHandler.ts
+++ b/vm/vm/src/jsonrpc/createHttpHandler.ts
@@ -1,8 +1,6 @@
 import type { Tevm } from '../Tevm.js'
 import type { TevmJsonRpcRequest } from '../jsonrpc/TevmJsonRpcRequest.js'
-import {
-	createJsonRpcClient,
-} from './createJsonRpcClient.js'
+import { createJsonRpcClient } from './createJsonRpcClient.js'
 import type { IncomingMessage, ServerResponse } from 'http'
 import { parse, stringify } from 'superjson'
 
@@ -44,7 +42,10 @@ export function createHttpHandler(tevm: Tevm) {
 							'Content-Type': 'application/json',
 						},
 					}).then((response) => {
-						res.writeHead(response.status, Object.fromEntries(response.headers.entries()))
+						res.writeHead(
+							response.status,
+							Object.fromEntries(response.headers.entries()),
+						)
 						res.end(response.body)
 					})
 				}

--- a/vm/vm/typedoc.json
+++ b/vm/vm/typedoc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://typedoc.org/schema.json",
 	"out": "./docs",
-	"entryPoints": ["./src/index.ts"],
+	"entryPoints": ["./src/index.ts", "./src/viem/index.js"],
 	"plugin": ["typedoc-plugin-markdown"],
 	"gitRevision": "main"
 }


### PR DESCRIPTION
## Description

Forgot to add viem entrypoint to typedoc in previous prs

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Exports to Modules" link in the `@tevm/vm` documentation for clearer navigation.
	- Restructured the documentation to prioritize module descriptions over type aliases and functions.
	- Replaced and reorganized certain sections to reflect updated module naming and organization.

- **Refactor**
	- Modified object spread syntax for more robust `forkUrl` assignment in the codebase.
	- Enhanced import statement for `createJsonRpcClient` for improved code clarity.
	- Streamlined the `res.writeHead` method invocation to enhance readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->