### PR TITLE
:sparkles: Feat(vm): Add writeContractOptimistic extension

### DIFF
--- a/.changeset/quiet-cats-rest.md
+++ b/.changeset/quiet-cats-rest.md
@@ -1,0 +1,5 @@
+---
+"@tevm/vm": minor
+---
+
+Added optimistic updates to the viem extension writeContractOptimistic. It takes same parameters as writeContract but returns two functions. One to unpack the writeContract result and the other to unpack the optimistic result. This is the most naive implementation and will be expanded over time.

--- a/vm/vm/src/viem/index.js
+++ b/vm/vm/src/viem/index.js
@@ -1,1 +1,2 @@
 export { tevmViemExtension } from './tevmViemExtension.js'
+export { tevmViemExtensionOptimistic } from './tevmViemExtensionOptimistic.js'

--- a/vm/vm/src/viem/tevmViemExtension.spec.ts
+++ b/vm/vm/src/viem/tevmViemExtension.spec.ts
@@ -1,4 +1,5 @@
 import { tevmViemExtension } from './tevmViemExtension.js'
+import { tevmViemExtensionOptimistic } from './tevmViemExtensionOptimistic.js'
 import { beforeEach, describe, expect, it, jest } from 'bun:test'
 import { stringify } from 'superjson'
 
@@ -58,5 +59,32 @@ describe('tevmViemExtension', () => {
 			params: JSON.parse(stringify(params)),
 		})
 		expect(response.balance).toEqual(420n)
+	})
+
+	it('writeContractOptimistic should write a contract call and optimistically execute it against the vm', async () => {
+		const client = {
+			request: jest.fn(),
+			writeContract: jest.fn(),
+		}
+
+		const mockRequestResponse = JSON.parse(stringify({ gasUsed: 420n }))
+		const mockWriteContractResponse = '0x420420420'
+
+		client.request.mockResolvedValue(mockRequestResponse)
+		client.writeContract.mockResolvedValue(mockWriteContractResponse)
+
+		const decorated = tevmViemExtensionOptimistic()(client)
+		const params = {
+			abi: [{ type: 'function', name: 'testFunction', inputs: [] }],
+			functionName: 'testFunction',
+			args: [],
+			caller: '0x69',
+			address: '0x4206942069',
+			account: {} as any,
+			chain: {} as any,
+		} as const
+		const response = await decorated.writeContractOptimistic(params)
+		expect(await response.result()).toEqual(mockWriteContractResponse)
+		expect(await response.optimisticResult()).toEqual({ gasUsed: 420n } as any)
 	})
 })

--- a/vm/vm/src/viem/tevmViemExtension.spec.ts
+++ b/vm/vm/src/viem/tevmViemExtension.spec.ts
@@ -84,6 +84,21 @@ describe('tevmViemExtension', () => {
 			chain: {} as any,
 		} as const
 		const response = await decorated.writeContractOptimistic(params)
+
+		expect((client.request as jest.Mock).mock.lastCall[0]).toEqual({
+			method: 'tevm_contractCall',
+			params: JSON.parse(stringify(params)),
+		})
+		expect((client.writeContract as jest.Mock).mock.lastCall[0]).toEqual({
+			abi: params.abi,
+			functionName: params.functionName,
+			args: params.args,
+			caller: params.caller,
+			address: params.address,
+			account: params.account,
+			chain: params.chain,
+		})
+
 		expect(await response.result()).toEqual(mockWriteContractResponse)
 		expect(await response.optimisticResult()).toEqual({ gasUsed: 420n } as any)
 	})

--- a/vm/vm/src/viem/tevmViemExtensionOptimistic.js
+++ b/vm/vm/src/viem/tevmViemExtensionOptimistic.js
@@ -10,15 +10,13 @@ export const tevmViemExtensionOptimistic = () => {
 				/**
 				 * @type {import('./types.js').ViemTevmClient['tevmRequest']}
 				 */
-				const tevmRequest = async (request) => {
+				const tevmRequest = async ({ method, params }) => {
 					return /** @type {any} */ (
 						parse(
 							JSON.stringify(
 								await client.request({
-									method: /** @type {any}*/ (request.method),
-									params: /** @type {any}*/ (
-										JSON.parse(stringify(request.params))
-									),
+									method: /** @type {any}*/ (method),
+									params: /** @type {any}*/ (JSON.parse(stringify(params))),
 								}),
 							),
 						)

--- a/vm/vm/src/viem/tevmViemExtensionOptimistic.js
+++ b/vm/vm/src/viem/tevmViemExtensionOptimistic.js
@@ -1,0 +1,66 @@
+import { parse, stringify } from 'superjson'
+
+/**
+ * @type {import('./types.js').ViemTevmOptimisticExtension}
+ */
+export const tevmViemExtensionOptimistic = () => {
+	return (client) => {
+		return {
+			writeContractOptimistic: async (action) => {
+				/**
+				 * @type {import('./types.js').ViemTevmClient['tevmRequest']}
+				 */
+				const tevmRequest = async (request) => {
+					return /** @type {any} */ (
+						parse(
+							JSON.stringify(
+								await client.request({
+									method: /** @type {any}*/ (request.method),
+									params: /** @type {any}*/ (
+										JSON.parse(stringify(request.params))
+									),
+								}),
+							),
+						)
+					)
+				}
+
+				const writeContractResult = client.writeContract(action)
+				const optimisticResult = tevmRequest({
+					method: 'tevm_contractCall',
+					params: /** @type {any}*/ (action),
+				})
+
+				// wait for one of the two results to come back
+				// This allows us to reject right away if the optimistic result fails
+				const error = await Promise.race([
+					writeContractResult,
+					optimisticResult,
+				])
+					.then(() => undefined)
+					.catch((err) => err)
+
+				// If error wait for all the promises to resolve before throwing
+				// We may want to consider using async generators or event emitters in future
+				if (error) {
+					const errors = await Promise.allSettled([
+						writeContractResult,
+						optimisticResult,
+					]).then((results) => {
+						return results.filter((result) => result.status === 'rejected')
+					})
+					if (errors.length === 1) {
+						throw errors[0]
+					}
+					throw new AggregateError(errors)
+				}
+
+				// Return the result as soon as at least 1 of them is available
+				return {
+					optimisticResult: () => optimisticResult,
+					result: () => writeContractResult,
+				}
+			},
+		}
+	}
+}

--- a/vm/vm/src/viem/types.ts
+++ b/vm/vm/src/viem/types.ts
@@ -13,6 +13,7 @@ import type { TevmPutAccountResponse } from '../jsonrpc/putAccount/TevmPutAccoun
 import type { TevmPutContractCodeResponse } from '../jsonrpc/putContractCode/TevmPutContractCodeResponse.js'
 import type { TevmCallResponse } from '../jsonrpc/runCall/TevmCallResponse.js'
 import type { Abi } from 'abitype'
+import type { Account, Chain, Transport, WriteContractParameters, WriteContractReturnType } from 'viem'
 
 export type ViemTevmClient = {
 	tevmRequest<T extends NonVerboseTevmJsonRpcRequest>(
@@ -39,8 +40,31 @@ export type ViemTevmClient = {
 	): Promise<RunContractCallResult<TAbi, TFunctionName>>
 }
 
+export type ViemTevmOptimisticClient<
+	TChain extends Chain | undefined = Chain,
+	TAccount extends Account | undefined = Account | undefined,
+> = {
+	writeContractOptimistic<
+		TAbi extends Abi | readonly unknown[] = Abi,
+		TFunctionName extends string = string,
+		TChainOverride extends Chain | undefined = Chain | undefined
+	>(
+		action: WriteContractParameters<TAbi, TFunctionName, TChain, TAccount, TChainOverride>
+	): Promise<{ optimisticResult: () => Promise<RunContractCallResult<TAbi, TFunctionName>>, result: () => Promise<WriteContractReturnType> }>
+}
+
 export type ViemTevmClientDecorator = (
 	client: Pick<import('viem').Client, 'request'>,
 ) => ViemTevmClient
 
+export type ViemTevmOptimisticClientDecorator = <TTransport extends Transport = Transport, TChain extends Chain | undefined = Chain | undefined, TAccount extends Account | undefined = Account | undefined>(
+	client: Pick<import('viem').WalletClient<
+		TTransport,
+		TChain,
+		TAccount
+	>, 'request' | 'writeContract'>,
+) => ViemTevmOptimisticClient<TChain, TAccount>
+
 export type ViemTevmExtension = () => ViemTevmClientDecorator
+
+export type ViemTevmOptimisticExtension = () => ViemTevmOptimisticClientDecorator

--- a/vm/vm/src/viem/types.ts
+++ b/vm/vm/src/viem/types.ts
@@ -13,7 +13,13 @@ import type { TevmPutAccountResponse } from '../jsonrpc/putAccount/TevmPutAccoun
 import type { TevmPutContractCodeResponse } from '../jsonrpc/putContractCode/TevmPutContractCodeResponse.js'
 import type { TevmCallResponse } from '../jsonrpc/runCall/TevmCallResponse.js'
 import type { Abi } from 'abitype'
-import type { Account, Chain, Transport, WriteContractParameters, WriteContractReturnType } from 'viem'
+import type {
+	Account,
+	Chain,
+	Transport,
+	WriteContractParameters,
+	WriteContractReturnType,
+} from 'viem'
 
 export type ViemTevmClient = {
 	tevmRequest<T extends NonVerboseTevmJsonRpcRequest>(
@@ -47,24 +53,37 @@ export type ViemTevmOptimisticClient<
 	writeContractOptimistic<
 		TAbi extends Abi | readonly unknown[] = Abi,
 		TFunctionName extends string = string,
-		TChainOverride extends Chain | undefined = Chain | undefined
+		TChainOverride extends Chain | undefined = Chain | undefined,
 	>(
-		action: WriteContractParameters<TAbi, TFunctionName, TChain, TAccount, TChainOverride>
-	): Promise<{ optimisticResult: () => Promise<RunContractCallResult<TAbi, TFunctionName>>, result: () => Promise<WriteContractReturnType> }>
+		action: WriteContractParameters<
+			TAbi,
+			TFunctionName,
+			TChain,
+			TAccount,
+			TChainOverride
+		>,
+	): Promise<{
+		optimisticResult: () => Promise<RunContractCallResult<TAbi, TFunctionName>>
+		result: () => Promise<WriteContractReturnType>
+	}>
 }
 
 export type ViemTevmClientDecorator = (
 	client: Pick<import('viem').Client, 'request'>,
 ) => ViemTevmClient
 
-export type ViemTevmOptimisticClientDecorator = <TTransport extends Transport = Transport, TChain extends Chain | undefined = Chain | undefined, TAccount extends Account | undefined = Account | undefined>(
-	client: Pick<import('viem').WalletClient<
-		TTransport,
-		TChain,
-		TAccount
-	>, 'request' | 'writeContract'>,
+export type ViemTevmOptimisticClientDecorator = <
+	TTransport extends Transport = Transport,
+	TChain extends Chain | undefined = Chain | undefined,
+	TAccount extends Account | undefined = Account | undefined,
+>(
+	client: Pick<
+		import('viem').WalletClient<TTransport, TChain, TAccount>,
+		'request' | 'writeContract'
+	>,
 ) => ViemTevmOptimisticClient<TChain, TAccount>
 
 export type ViemTevmExtension = () => ViemTevmClientDecorator
 
-export type ViemTevmOptimisticExtension = () => ViemTevmOptimisticClientDecorator
+export type ViemTevmOptimisticExtension =
+	() => ViemTevmOptimisticClientDecorator


### PR DESCRIPTION
## Description

Adds a writeContractOptimistic action to viem client. This action will write to a contract while also executing the contract call against the optimistic chain

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optimistic execution mode for contract write operations, enhancing the virtual machine's capabilities.

- **Tests**
  - Added test coverage for the new optimistic contract write functionality.

- **Documentation**
  - Updated type declarations to reflect the new optimistic execution features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->