### PR TITLE
:zap: Feat: Replace existsSync with exists in async bundler routines

### DIFF
--- a/.changeset/smooth-fishes-study.md
+++ b/.changeset/smooth-fishes-study.md
@@ -1,0 +1,9 @@
+---
+"@tevm/resolutions": patch
+"@tevm/compiler": patch
+"@tevm/bun-plugin": patch
+"@tevm/base": patch
+"@tevm/bundler-cache": patch
+---
+
+Improved peformance of bundler operations by utilzing more async methods rather than syncronous methods for file system access

--- a/bundler/bun/src/bunFileAccessObject.js
+++ b/bundler/bun/src/bunFileAccessObject.js
@@ -4,7 +4,7 @@ import { mkdir, stat, writeFile } from 'fs/promises'
 
 /**
  * A adapter around the bun file api to make it compatible with @tevm/base FileAccessObject type
- * @type {import("@tevm/base").FileAccessObject & { exists: (filePath: string) => Promise<boolean> }}
+ * @type {import("@tevm/base").FileAccessObject}
  */
 export const bunFileAccesObject = {
 	existsSync,

--- a/bundler/compiler/src/compiler/compileContracts.spec.ts
+++ b/bundler/compiler/src/compiler/compileContracts.spec.ts
@@ -2,7 +2,7 @@ import type { FileAccessObject } from '../types.js'
 import { compileContract } from './compileContracts.js'
 import type { ResolvedCompilerConfig } from '@tevm/config'
 import { existsSync, readFileSync } from 'fs'
-import { readFile } from 'fs/promises'
+import { access, readFile } from 'fs/promises'
 import { join } from 'path'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -20,6 +20,14 @@ describe('compileContract', () => {
 		existsSync,
 		readFile,
 		readFileSync,
+		exists: async (path: string) => {
+			try {
+				await access(path)
+				return true
+			} catch (e) {
+				return false
+			}
+		},
 	}
 
 	it('should successfully compile a contract without errors', async () => {

--- a/bundler/compiler/src/compiler/compileContractsSync.spec.ts
+++ b/bundler/compiler/src/compiler/compileContractsSync.spec.ts
@@ -20,6 +20,7 @@ describe('compileContractSync', () => {
 		existsSync,
 		readFile,
 		readFileSync,
+		exists: vi.fn(),
 	}
 
 	it('should successfully compile a contract without errors', async () => {

--- a/bundler/compiler/src/resolveArtifacts.spec.ts
+++ b/bundler/compiler/src/resolveArtifacts.spec.ts
@@ -19,6 +19,7 @@ const fao: FileAccessObject = {
 	existsSync: vi.fn() as any,
 	readFile: vi.fn() as any,
 	readFileSync: vi.fn() as any,
+	exists: vi.fn() as any,
 }
 
 const solFile = 'test.sol'

--- a/bundler/compiler/src/resolveArtifactsSync.spec.ts
+++ b/bundler/compiler/src/resolveArtifactsSync.spec.ts
@@ -19,6 +19,7 @@ const fao: FileAccessObject = {
 	existsSync: vi.fn() as any,
 	readFileSync: vi.fn() as any,
 	readFile: vi.fn() as any,
+	exists: vi.fn() as any,
 }
 
 const mockModules: Record<string, ModuleInfo> = {

--- a/bundler/compiler/src/types.ts
+++ b/bundler/compiler/src/types.ts
@@ -41,6 +41,7 @@ export type FileAccessObject = {
 	readFile: (path: string, encoding: BufferEncoding) => Promise<string>
 	readFileSync: (path: string, encoding: BufferEncoding) => string
 	existsSync: (path: string) => boolean
+	exists: (path: string) => Promise<boolean>
 }
 
 export type Logger = {

--- a/bundler/compiler/src/utils/resolvePromise.js
+++ b/bundler/compiler/src/utils/resolvePromise.js
@@ -27,9 +27,9 @@ export const resolveEffect = (filePath, basedir, fao, logger) => {
 							cb(e)
 						})
 				},
-				isFile: (file, cb) => {
+				isFile: async (file, cb) => {
 					try {
-						cb(null, fao.existsSync(file))
+						cb(null, await fao.exists(file))
 					} catch (e) {
 						cb(/** @type Error */ (e))
 						logger.error(/** @type any */ (e))

--- a/bundler/compiler/src/utils/resolvePromise.spec.ts
+++ b/bundler/compiler/src/utils/resolvePromise.spec.ts
@@ -2,6 +2,7 @@ import type { FileAccessObject, Logger } from '../types.js'
 import { resolveEffect } from './resolvePromise.js'
 import { Effect } from 'effect'
 import fs from 'fs'
+import { access } from 'fs/promises'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const fao: FileAccessObject = {
@@ -11,6 +12,14 @@ const fao: FileAccessObject = {
 			fs.readFileSync(filePath, { encoding: encoding as 'utf8' }),
 		),
 	readFileSync: (filePath: string) => fs.readFileSync(filePath, 'utf8'),
+	exists: async (filePath: string) => {
+		try {
+			await access(filePath)
+			return true
+		} catch (e) {
+			return false
+		}
+	},
 }
 
 let logger: Logger = {
@@ -58,54 +67,12 @@ describe('resolvePromise', () => {
 			  [
 			    "There was an error resolving ./resolvePromise.spec.tst",
 			  ],
-			  [
-			    "readFile error",
-			  ],
-			  [
-			    "Error reading file",
-			  ],
-			  [
-			    "readFile error",
-			  ],
-			  [
-			    "There was an error resolving ./resolvePromise.spec.tst",
-			  ],
-			  [
-			    "readFile error",
-			  ],
-			  [
-			    "Error reading file",
-			  ],
-			  [
-			    "readFile error",
-			  ],
-			  [
-			    "There was an error resolving ./resolvePromise.spec.tst",
-			  ],
-			  [
-			    "readFile error",
-			  ],
-			  [
-			    "Error reading file",
-			  ],
-			  [
-			    "readFile error",
-			  ],
-			  [
-			    "There was an error resolving ./resolvePromise.spec.tst",
-			  ],
-			  [
-			    [Error: Cannot find module './resolvePromise.spec.tst' from './src/utils'],
-			  ],
-			  [
-			    "There was an error resolving ./resolvePromise.spec.tst",
-			  ],
 			]
 		`)
 	})
 
 	it('should throw an error for non-existent file', async () => {
-		fao.existsSync = () => false
+		fao.exists = () => Promise.resolve(false)
 		await expect(
 			Effect.runPromise(
 				resolveEffect('./resolvePromise.spec.tst', './src/utils', fao, logger),
@@ -125,20 +92,20 @@ describe('resolvePromise', () => {
 		`)
 	})
 
-	it('should throw an error if existsSync throws', () => {
-		fao.existsSync = () => {
-			throw new Error('existsSync error')
+	it('should throw an error if exists throws', () => {
+		fao.exists = () => {
+			throw new Error('exists error')
 		}
 		expect(
 			Effect.runPromise(
 				resolveEffect('./resolvePromise.spec.ts', './src/utils', fao, logger),
 			),
-		).rejects.toThrowErrorMatchingInlineSnapshot('"existsSync error"')
+		).rejects.toThrowErrorMatchingInlineSnapshot('"exists error"')
 		expect(
 			(logger.error as Mock).mock.calls[0].slice(0, 2),
 		).toMatchInlineSnapshot(`
       [
-        [Error: existsSync error],
+        [Error: exists error],
       ]
     `)
 	})

--- a/bundler/config/src/tsconfig/loadTsConfig.js
+++ b/bundler/config/src/tsconfig/loadTsConfig.js
@@ -79,7 +79,7 @@ const STsConfig = struct({
  */
 
 /**
- * Asyncronously loads an Tevm config from the given path
+ * Syncronously loads an Tevm config from the given path
  * @param {string} configFilePath
  * @returns {import("effect/Effect").Effect<never, LoadTsConfigError, TsConfig>} the contents of the tsconfig.json file
  * @internal

--- a/bundler/resolutions/src/moduleFactory.spec.ts
+++ b/bundler/resolutions/src/moduleFactory.spec.ts
@@ -2,7 +2,7 @@ import { moduleFactory } from './moduleFactory.js'
 import type { FileAccessObject } from './types.js'
 import { runPromise, runSync } from 'effect/Effect'
 import { existsSync, readFileSync } from 'fs'
-import { readFile } from 'fs/promises'
+import { access, readFile } from 'fs/promises'
 import { join } from 'path'
 import { describe, expect, it } from 'vitest'
 
@@ -10,6 +10,14 @@ const fao: FileAccessObject = {
 	existsSync: existsSync,
 	readFile: readFile,
 	readFileSync: readFileSync,
+	exists: async (file: string) => {
+		try {
+			await access(file)
+			return true
+		} catch (e) {
+			return false
+		}
+	},
 }
 
 class Fixture {

--- a/bundler/resolutions/src/types.ts
+++ b/bundler/resolutions/src/types.ts
@@ -2,6 +2,7 @@ export type FileAccessObject = {
 	readFile: (path: string, encoding: BufferEncoding) => Promise<string>
 	readFileSync: (path: string, encoding: BufferEncoding) => string
 	existsSync: (path: string) => boolean
+	exists: (path: string) => Promise<boolean>
 }
 
 export type Logger = {

--- a/bundler/resolutions/src/utils/resolveSafe.js
+++ b/bundler/resolutions/src/utils/resolveSafe.js
@@ -1,12 +1,6 @@
-import {
-	async as effectAsync,
-	fail,
-	runPromise,
-	runSync,
-	succeed,
-} from 'effect/Effect'
-import resolve from 'resolve'
 import { ExistsError, ReadFileError } from './safeFao.js'
+import { async as effectAsync, fail, runPromise, succeed } from 'effect/Effect'
+import resolve from 'resolve'
 
 /**
  * Error thrown when resolve fails
@@ -61,9 +55,9 @@ export const resolveSafe = (filePath, basedir, fao) => {
 							cb(e)
 						})
 				},
-				isFile: (file, cb) => {
+				isFile: async (file, cb) => {
 					try {
-						cb(null, runSync(fao.existsSync(file)))
+						cb(null, await runPromise(fao.exists(file)))
 					} catch (e) {
 						cb(/** @type {Error} */ (e))
 					}

--- a/bundler/resolutions/src/utils/resolveSafe.js
+++ b/bundler/resolutions/src/utils/resolveSafe.js
@@ -1,4 +1,3 @@
-import { ExistsSyncError, ReadFileError } from './safeFao.js'
 import {
 	async as effectAsync,
 	fail,
@@ -7,6 +6,7 @@ import {
 	succeed,
 } from 'effect/Effect'
 import resolve from 'resolve'
+import { ExistsError, ReadFileError } from './safeFao.js'
 
 /**
  * Error thrown when resolve fails
@@ -30,7 +30,7 @@ export class ResolveError extends Error {
 }
 
 /**
- * @typedef {ResolveError|import("./safeFao.js").ReadFileError | import("./safeFao.js").ExistsSyncError} ResolveSafeError
+ * @typedef {ResolveError|import("./safeFao.js").ReadFileError | import("./safeFao.js").ExistsError} ResolveSafeError
  */
 
 /**
@@ -72,11 +72,11 @@ export const resolveSafe = (filePath, basedir, fao) => {
 			(err, res) => {
 				if (err) {
 					const typedError =
-						/** @type {import("./safeFao.js").ReadFileError | import("./safeFao.js").ExistsSyncError} */ (
+						/** @type {import("./safeFao.js").ReadFileError | import("./safeFao.js").ExistsError} */ (
 							err
 						)
-					if (typedError.name === 'ExistsSyncError') {
-						resume(fail(new ExistsSyncError(typedError)))
+					if (typedError.name === 'ExistsError') {
+						resume(fail(new ExistsError(typedError)))
 					} else if (typedError.name === 'ReadFileError') {
 						resume(fail(new ReadFileError(typedError)))
 					} else {

--- a/bundler/resolutions/src/utils/safeFao.js
+++ b/bundler/resolutions/src/utils/safeFao.js
@@ -22,21 +22,21 @@ export class ReadFileError extends Error {
 	}
 }
 
-export class ExistsSyncError extends Error {
+export class ExistsError extends Error {
 	/**
-	 * @type {'ExistsSyncError'}
+	 * @type {'ExistsError'}
 	 */
-	_tag = 'ExistsSyncError'
+	_tag = 'ExistsError'
 	/**
-	 * @type {'ExistsSyncError'}
+	 * @type {'ExistsError'}
 	 * @override
 	 */
-	name = 'ExistsSyncError'
+	name = 'ExistsError'
 	/**
 	 * @param {Error} cause
 	 */
 	constructor(cause) {
-		super(`ExistsSync error: ${cause.message}`, { cause })
+		super(`Unable to determine existence: ${cause.message}`, { cause })
 	}
 }
 
@@ -89,13 +89,26 @@ export const safeFao = (fao) => {
 		/**
 		 * @param {string} path
 		 */
+		exists: (path) => {
+			return tryPromise({
+				try: () => {
+					return fao.exists(path)
+				},
+				catch: (e) => {
+					return new ExistsError(/** @type Error */ (e))
+				},
+			})
+		},
+		/**
+		 * @param {string} path
+		 */
 		existsSync: (path) => {
 			return trySync({
 				try: () => {
 					return fao.existsSync(path)
 				},
 				catch: (e) => {
-					return new ExistsSyncError(/** @type Error */ (e))
+					return new ExistsError(/** @type Error */ (e))
 				},
 			})
 		},


### PR DESCRIPTION
## Description

I previously lazily used existsSync because no promise based exists existed. Improve peformance by creating exists using fs.access

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

