### PR TITLE
:bug: Fix: Broken openzepplen version in svelte build

### DIFF
--- a/bundler/base/src/resolveModuleAsync.js
+++ b/bundler/base/src/resolveModuleAsync.js
@@ -75,15 +75,17 @@ export const resolveModuleAsync = async (
 			// But still write dts and mjs files since they always
 			// fall back to generating an empty file with error messages
 			artifactsExist,
-		).catch(e => {
+		).catch((e) => {
 			logger.error(e)
-			logger.error('there was an error writing to the cache. This may cause peformance issues')
+			logger.error(
+				'there was an error writing to the cache. This may cause peformance issues',
+			)
 		})
 
 		return { solcInput, solcOutput, asts, modules, code }
 	} catch (e) {
 		logger.error(`there was an error in tevm plugin resolving .${moduleType}`)
-		logger.error(/** @type any */(e))
+		logger.error(/** @type any */ (e))
 		throw e
 	}
 }

--- a/examples/svelte-ethers/package.json
+++ b/examples/svelte-ethers/package.json
@@ -17,7 +17,7 @@
 		"ethers": "^6.8.0"
 	},
 	"devDependencies": {
-		"@openzeppelin/contracts": "^5.0.0",
+		"@openzeppelin/contracts": "^4.9.x",
 		"@sveltejs/adapter-auto": "^2.1.0",
 		"@sveltejs/kit": "^1.27.2",
 		"@tevm/ts-plugin": "workspace:^",

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -7,9 +7,9 @@
 	],
 	"scripts": {
 		"anvil": "source .env && anvil --fork-url https://eth-mainnet.g.alchemy.com/v2/$VITE_ALCHEMY_API_KEY",
-		"build": "bun build:contracts && bun build:dist",
+		"build": "bun build:contracts && bun build:app",
+		"build:app": "vite build",
 		"build:contracts": "forge build",
-		"build:dist": "vite build",
 		"clean": "rm -rf node_modules && rm -rf artifacts && rm -rf dist && rm -rf cache",
 		"deploy-contracts": "source .env && forge script script/Deploy.s.sol:Deploy --broadcast --verify -vvvv",
 		"deploy-contracts:anvil": "bun deploy-contracts --fork-url http://localhost:8545",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,8 +527,8 @@ importers:
         version: 6.8.1
     devDependencies:
       '@openzeppelin/contracts':
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^4.9.x
+        version: 4.9.3
       '@sveltejs/adapter-auto':
         specifier: ^2.1.0
         version: 2.1.1(@sveltejs/kit@1.27.6)


### PR DESCRIPTION
## Description

Svelte build had a bad version of open zepplen that didn't run in ci because the package was missing build:dist

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

