### PR TITLE
:wheelchair: Feat: Make @tevm/contracts NodeNext

### DIFF
--- a/.changeset/chilled-comics-taste.md
+++ b/.changeset/chilled-comics-taste.md
@@ -1,0 +1,5 @@
+---
+"@tevm/contract": patch
+---
+
+Updated types to NodeNext for maximum compatibility with all build tool setups

--- a/.changeset/chilled-comics-taste.md
+++ b/.changeset/chilled-comics-taste.md
@@ -2,4 +2,4 @@
 "@tevm/contract": patch
 ---
 
-Updated types to NodeNext for maximum compatibility with all build tool setups
+Updated types to NodeNext for maximum compatibility with all build tool setups. NodeNext requires explicit file extensions like `./Foo/index.js` instead of `./Foo` which maximizes general compatibility with latest versions of node and all bundlers.

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -28,18 +28,12 @@
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs",
 			"default": "./dist/index.cjs",
-			"types": "./types/src/index.d.ts"
-		},
-		"./common": {
-			"import": "./dist/common.js",
-			"require": "./dist/common.cjs",
-			"default": "./dist/common.cjs",
-			"types": "./src/common/index.ts"
+			"types": "./src/index.ts"
 		}
 	},
 	"main": "dist/index.cjs",
 	"module": "dist/index.js",
-	"types": "types/src/index.d.ts",
+	"types": "src/index.ts",
 	"files": [
 		"dist",
 		"src",
@@ -68,7 +62,7 @@
 		"@openzeppelin/contracts": "^5.0.1",
 		"@tevm/tsconfig": "workspace:^",
 		"abitype": "^0.10.2",
-		"viem": "^1.18.1"
+		"viem": "^1.21.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/contract/src/TevmContract.ts
+++ b/packages/contract/src/TevmContract.ts
@@ -1,6 +1,6 @@
-import type { Events } from './event/Event'
-import type { Read } from './read/Read'
-import type { Write } from './write/Write'
+import type { Events } from './event/Event.js'
+import type { Read } from './read/Read.js'
+import type { Write } from './write/Write.js'
 import type { ParseAbi } from 'abitype'
 import type { Hex } from 'viem'
 

--- a/packages/contract/src/TevmContractFromAbi.ts
+++ b/packages/contract/src/TevmContractFromAbi.ts
@@ -1,4 +1,4 @@
-import type { TevmContract } from './TevmContract'
+import type { TevmContract } from './TevmContract.js'
 import type { Abi, FormatAbi } from 'abitype'
 import type { Hex } from 'viem'
 

--- a/packages/contract/src/createTevmContract.spec.ts
+++ b/packages/contract/src/createTevmContract.spec.ts
@@ -1,5 +1,5 @@
-import { createTevmContract } from './createTevmContract'
-import { dummyAbi } from './test/fixtures'
+import { createTevmContract } from './createTevmContract.js'
+import { dummyAbi } from './test/fixtures.js'
 import { formatAbi, parseAbi } from 'abitype'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/contract/src/createTevmContract.ts
+++ b/packages/contract/src/createTevmContract.ts
@@ -1,7 +1,7 @@
-import type { TevmContract } from './TevmContract'
-import { eventsFactory } from './event/eventFactory'
-import { readFactory } from './read/readFactory'
-import { writeFactory } from './write/writeFactory'
+import type { TevmContract } from './TevmContract.js'
+import { eventsFactory } from './event/eventFactory.js'
+import { readFactory } from './read/readFactory.js'
+import { writeFactory } from './write/writeFactory.js'
 import { parseAbi } from 'abitype'
 import type { Hex } from 'viem'
 

--- a/packages/contract/src/createTevmContractFromAbi.spec.ts
+++ b/packages/contract/src/createTevmContractFromAbi.spec.ts
@@ -1,5 +1,5 @@
-import { createTevmContractFromAbi } from './createTevmContractFromAbi'
-import { dummyAbi } from './test/fixtures'
+import { createTevmContractFromAbi } from './createTevmContractFromAbi.js'
+import { dummyAbi } from './test/fixtures.js'
 import { describe, expect, it } from 'vitest'
 
 describe(createTevmContractFromAbi.name, () => {

--- a/packages/contract/src/createTevmContractFromAbi.ts
+++ b/packages/contract/src/createTevmContractFromAbi.ts
@@ -1,7 +1,7 @@
-import type { TevmContract } from './TevmContract'
-import { eventsFactory } from './event/eventFactory'
-import { readFactory } from './read/readFactory'
-import { writeFactory } from './write/writeFactory'
+import type { TevmContract } from './TevmContract.js'
+import { eventsFactory } from './event/eventFactory.js'
+import { readFactory } from './read/readFactory.js'
+import { writeFactory } from './write/writeFactory.js'
 import { type Abi, type FormatAbi, formatAbi } from 'abitype'
 import type { Hex } from 'viem'
 

--- a/packages/contract/src/event/Event.ts
+++ b/packages/contract/src/event/Event.ts
@@ -1,4 +1,5 @@
 import type {
+	Abi,
 	ExtractAbiEvent,
 	ExtractAbiEventNames,
 	FormatAbi,
@@ -8,9 +9,18 @@ import type {
 	BlockNumber,
 	BlockTag,
 	CreateEventFilterParameters,
+	GetEventArgs,
 	Hex,
 } from 'viem'
-import type { MaybeExtractEventArgsFromAbi } from 'viem/_types/types/contract'
+
+export type MaybeExtractEventArgsFromAbi<
+	TAbi extends Abi | readonly unknown[] | undefined,
+	TEventName extends string | undefined,
+> = TAbi extends Abi | readonly unknown[]
+	? TEventName extends string
+	? GetEventArgs<TAbi, TEventName>
+	: undefined
+	: undefined
 
 export type ValueOf<T> = T[keyof T]
 
@@ -20,44 +30,44 @@ export type Events<
 	TBytecode extends Hex | undefined,
 	TDeployedBytecode extends Hex | undefined,
 > = {
-	[TEventName in ExtractAbiEventNames<ParseAbi<THumanReadableAbi>>]: (<
-		TStrict extends boolean = false,
-		TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
-		TToBlock extends BlockNumber | BlockTag | undefined = undefined,
-	>(
-		params: Pick<
-			CreateEventFilterParameters<
-				ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
-				ParseAbi<THumanReadableAbi>,
-				TStrict,
-				TFromBlock,
-				TToBlock,
-				TEventName,
-				MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
+		[TEventName in ExtractAbiEventNames<ParseAbi<THumanReadableAbi>>]: (<
+			TStrict extends boolean = false,
+			TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+			TToBlock extends BlockNumber | BlockTag | undefined = undefined,
+		>(
+			params: Pick<
+				CreateEventFilterParameters<
+					ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
+					ParseAbi<THumanReadableAbi>,
+					TStrict,
+					TFromBlock,
+					TToBlock,
+					TEventName,
+					MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
+				>,
+				'fromBlock' | 'toBlock' | 'args' | 'strict'
 			>,
-			'fromBlock' | 'toBlock' | 'args' | 'strict'
-		>,
-	) => CreateEventFilterParameters<
-		ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
-		ParseAbi<THumanReadableAbi>,
-		TStrict,
-		TFromBlock,
-		TToBlock,
-		TEventName,
-		MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
-	> & {
-		tevmContractName: TName
-		eventName: TEventName
-		abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
-		bytecode: TBytecode
-		deployedBytecode: TDeployedBytecode
-	}) & {
-		eventName: TEventName
-		humanReadableAbi: FormatAbi<
-			[ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
-		>
-		abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
-		bytecode: TBytecode
-		deployedBytecode: TDeployedBytecode
+		) => CreateEventFilterParameters<
+			ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
+			ParseAbi<THumanReadableAbi>,
+			TStrict,
+			TFromBlock,
+			TToBlock,
+			TEventName,
+			MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
+		> & {
+			tevmContractName: TName
+			eventName: TEventName
+			abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
+			bytecode: TBytecode
+			deployedBytecode: TDeployedBytecode
+		}) & {
+			eventName: TEventName
+			humanReadableAbi: FormatAbi<
+				[ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
+			>
+			abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
+			bytecode: TBytecode
+			deployedBytecode: TDeployedBytecode
+		}
 	}
-}

--- a/packages/contract/src/event/Event.ts
+++ b/packages/contract/src/event/Event.ts
@@ -18,8 +18,8 @@ export type MaybeExtractEventArgsFromAbi<
 	TEventName extends string | undefined,
 > = TAbi extends Abi | readonly unknown[]
 	? TEventName extends string
-	? GetEventArgs<TAbi, TEventName>
-	: undefined
+		? GetEventArgs<TAbi, TEventName>
+		: undefined
 	: undefined
 
 export type ValueOf<T> = T[keyof T]
@@ -30,44 +30,44 @@ export type Events<
 	TBytecode extends Hex | undefined,
 	TDeployedBytecode extends Hex | undefined,
 > = {
-		[TEventName in ExtractAbiEventNames<ParseAbi<THumanReadableAbi>>]: (<
-			TStrict extends boolean = false,
-			TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
-			TToBlock extends BlockNumber | BlockTag | undefined = undefined,
-		>(
-			params: Pick<
-				CreateEventFilterParameters<
-					ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
-					ParseAbi<THumanReadableAbi>,
-					TStrict,
-					TFromBlock,
-					TToBlock,
-					TEventName,
-					MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
-				>,
-				'fromBlock' | 'toBlock' | 'args' | 'strict'
+	[TEventName in ExtractAbiEventNames<ParseAbi<THumanReadableAbi>>]: (<
+		TStrict extends boolean = false,
+		TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+		TToBlock extends BlockNumber | BlockTag | undefined = undefined,
+	>(
+		params: Pick<
+			CreateEventFilterParameters<
+				ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
+				ParseAbi<THumanReadableAbi>,
+				TStrict,
+				TFromBlock,
+				TToBlock,
+				TEventName,
+				MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
 			>,
-		) => CreateEventFilterParameters<
-			ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
-			ParseAbi<THumanReadableAbi>,
-			TStrict,
-			TFromBlock,
-			TToBlock,
-			TEventName,
-			MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
-		> & {
-			tevmContractName: TName
-			eventName: TEventName
-			abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
-			bytecode: TBytecode
-			deployedBytecode: TDeployedBytecode
-		}) & {
-			eventName: TEventName
-			humanReadableAbi: FormatAbi<
-				[ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
-			>
-			abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
-			bytecode: TBytecode
-			deployedBytecode: TDeployedBytecode
-		}
+			'fromBlock' | 'toBlock' | 'args' | 'strict'
+		>,
+	) => CreateEventFilterParameters<
+		ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>,
+		ParseAbi<THumanReadableAbi>,
+		TStrict,
+		TFromBlock,
+		TToBlock,
+		TEventName,
+		MaybeExtractEventArgsFromAbi<ParseAbi<THumanReadableAbi>, TEventName>
+	> & {
+		tevmContractName: TName
+		eventName: TEventName
+		abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
+		bytecode: TBytecode
+		deployedBytecode: TDeployedBytecode
+	}) & {
+		eventName: TEventName
+		humanReadableAbi: FormatAbi<
+			[ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
+		>
+		abi: [ExtractAbiEvent<ParseAbi<THumanReadableAbi>, TEventName>]
+		bytecode: TBytecode
+		deployedBytecode: TDeployedBytecode
 	}
+}

--- a/packages/contract/src/event/eventFactory.spec.ts
+++ b/packages/contract/src/event/eventFactory.spec.ts
@@ -1,6 +1,6 @@
-import { createTevmContract } from '../createTevmContract'
-import { dummyAbi } from '../test/fixtures'
-import { eventsFactory } from './eventFactory'
+import { createTevmContract } from '../createTevmContract.js'
+import { dummyAbi } from '../test/fixtures.js'
+import { eventsFactory } from './eventFactory.js'
 import { formatAbi } from 'abitype'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -1,6 +1,6 @@
-export type { TevmContract } from './TevmContract'
-export { createTevmContract } from './createTevmContract'
-export { createTevmContractFromAbi } from './createTevmContractFromAbi'
+export type { TevmContract } from './TevmContract.js'
+export { createTevmContract } from './createTevmContract.js'
+export { createTevmContractFromAbi } from './createTevmContractFromAbi.js'
 // reexported because they are needed to be able to
 // instanciate an TevmContract with a json abi
 export { formatAbi, parseAbi } from 'abitype'

--- a/packages/contract/src/read/readFactory.spec.ts
+++ b/packages/contract/src/read/readFactory.spec.ts
@@ -1,6 +1,6 @@
-import { createTevmContract } from '../createTevmContract'
-import { dummyAbi } from '../test/fixtures'
-import { readFactory } from './readFactory'
+import { createTevmContract } from '../createTevmContract.js'
+import { dummyAbi } from '../test/fixtures.js'
+import { readFactory } from './readFactory.js'
 import { formatAbi } from 'abitype'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/contract/src/write/writeFactory.spec.ts
+++ b/packages/contract/src/write/writeFactory.spec.ts
@@ -1,6 +1,6 @@
-import { createTevmContract } from '../createTevmContract'
-import { dummyAbi } from '../test/fixtures'
-import { writeFactory } from './writeFactory'
+import { createTevmContract } from '../createTevmContract.js'
+import { dummyAbi } from '../test/fixtures.js'
+import { writeFactory } from './writeFactory.js'
 import { formatAbi } from 'abitype'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -10,8 +10,8 @@
     "outDir": "types",
     "skipLibCheck": true,
     // this should be "Bundler" but don't want to fight a broken type
-    "moduleResolution": "Node",
-    "module": "ESNext"
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
   },
   "include": [
     "src",

--- a/packages/schemas/docs/classes/common.InvalidBlockNumberError.md
+++ b/packages/schemas/docs/classes/common.InvalidBlockNumberError.md
@@ -149,6 +149,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -163,11 +165,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/common.InvalidUrlError.md
+++ b/packages/schemas/docs/classes/common.InvalidUrlError.md
@@ -148,6 +148,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -162,11 +164,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/ethereum.InvalidAddressError.md
+++ b/packages/schemas/docs/classes/ethereum.InvalidAddressError.md
@@ -155,6 +155,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -169,11 +171,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/ethereum.InvalidBytesError.md
+++ b/packages/schemas/docs/classes/ethereum.InvalidBytesError.md
@@ -148,6 +148,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -162,11 +164,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/ethereum.InvalidBytesFixedError.md
+++ b/packages/schemas/docs/classes/ethereum.InvalidBytesFixedError.md
@@ -150,6 +150,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -164,11 +166,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/ethereum.InvalidINTError.md
+++ b/packages/schemas/docs/classes/ethereum.InvalidINTError.md
@@ -150,6 +150,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -164,11 +166,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/ethereum.InvalidUINTError.md
+++ b/packages/schemas/docs/classes/ethereum.InvalidUINTError.md
@@ -150,6 +150,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -164,11 +166,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/packages/schemas/docs/classes/tevm.InvalidAddressBookError.md
+++ b/packages/schemas/docs/classes/tevm.InvalidAddressBookError.md
@@ -147,6 +147,8 @@ TypeError.prepareStackTrace
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
 
 ___
@@ -161,11 +163,36 @@ TypeError.stackTraceLimit
 
 #### Defined in
 
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
+
 node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TypeError.captureStackTrace
+
+#### Defined in
+
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,7 +948,7 @@ importers:
     devDependencies:
       '@evmts/core':
         specifier: next
-        version: 1.0.0-next.12(viem@1.19.4)
+        version: 1.0.0-next.12(viem@1.21.3)
       '@evmts/ts-plugin':
         specifier: next
         version: 1.0.0-next.18(fast-check@3.14.0)(typescript@5.3.3)
@@ -965,8 +965,8 @@ importers:
         specifier: ^0.10.2
         version: 0.10.2(typescript@5.3.3)(zod@3.22.4)
       viem:
-        specifier: ^1.18.1
-        version: 1.19.4(typescript@5.3.3)
+        specifier: ^1.21.3
+        version: 1.21.3(typescript@5.3.3)(zod@3.22.4)
 
   packages/effect:
     dependencies:
@@ -3958,7 +3958,7 @@ packages:
       effect: 2.0.0-next.54
       jsonc-parser: 3.2.0
       solc: 0.8.22
-      viem: 1.19.11(typescript@5.3.3)(zod@3.22.4)
+      viem: 1.21.3(typescript@5.3.3)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -3980,7 +3980,7 @@ packages:
       effect: 2.0.0-next.54
       jsonc-parser: 3.2.0
       solc: 0.8.23-fixed
-      viem: 1.19.11(typescript@5.3.3)(zod@3.22.4)
+      viem: 1.21.3(typescript@5.3.3)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -3990,12 +3990,12 @@ packages:
       - zod
     dev: true
 
-  /@evmts/core@1.0.0-next.12(viem@1.19.4):
+  /@evmts/core@1.0.0-next.12(viem@1.21.3):
     resolution: {integrity: sha512-1Hqxfl3C9K5b2eSjbXc0KpXU2kjSsh4O6mOcKILTujceJ4QwRVQNmSiVddYi1zvpGS7WYiXGyE1S2XACZMbdZw==}
     peerDependencies:
       viem: '>1.0.0'
     dependencies:
-      viem: 1.19.4(typescript@5.3.3)
+      viem: 1.21.3(typescript@5.3.3)(zod@3.22.4)
     dev: true
 
   /@evmts/effect@1.0.0-next.9(esbuild@0.19.11)(fast-check@3.14.0)(solc@0.8.22)(typescript@5.3.3):
@@ -4009,7 +4009,7 @@ packages:
       jsonc-parser: 3.2.0
       resolve: 1.22.8
       solc: 0.8.22
-      viem: 1.19.11(typescript@5.3.3)(zod@3.22.4)
+      viem: 1.21.3(typescript@5.3.3)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -4030,7 +4030,7 @@ packages:
       jsonc-parser: 3.2.0
       resolve: 1.22.8
       solc: 0.8.23-fixed
-      viem: 1.19.11(typescript@5.3.3)(zod@3.22.4)
+      viem: 1.21.3(typescript@5.3.3)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -17549,8 +17549,8 @@ packages:
       - zod
     dev: false
 
-  /viem@1.19.4(typescript@5.3.3):
-    resolution: {integrity: sha512-CvAVaOzxlu3Q/cpfrYvTRMBIPDMAkLu8aFmHLqU1Bg25DyUxp9xwoF1Ljp38q7/Rosm1OPFQ4y6K64v/VwoumQ==}
+  /viem@1.21.3(typescript@5.3.3)(zod@3.22.4):
+    resolution: {integrity: sha512-tBCRj+AtpGGcyrY7k2Xjv0k8JB6ShGQ+dxeCdtIxWJO6ATmicTp7Qbgn/0IsbyQ0nUF06LMyo8PR569cRflnIA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:

--- a/vm/jsonrpc/docs/classes/UnknownMethodError.md
+++ b/vm/jsonrpc/docs/classes/UnknownMethodError.md
@@ -151,9 +151,9 @@ Error.prepareStackTrace
 
 #### Defined in
 
-node_modules/.pnpm/bun-types@1.0.12/node_modules/bun-types/types.d.ts:13469
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:11
 
-node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:28
+node_modules/.pnpm/bun-types@1.0.15/node_modules/bun-types/types.d.ts:37226
 
 ___
 
@@ -167,9 +167,9 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/.pnpm/bun-types@1.0.12/node_modules/bun-types/types.d.ts:13473
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:13
 
-node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:30
+node_modules/.pnpm/bun-types@1.0.15/node_modules/bun-types/types.d.ts:37230
 
 ## Methods
 
@@ -196,7 +196,7 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/.pnpm/bun-types@1.0.12/node_modules/bun-types/types.d.ts:13462
+node_modules/.pnpm/@types+node@20.9.1/node_modules/@types/node/globals.d.ts:4
 
 ▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
@@ -219,4 +219,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/.pnpm/@types+node@20.10.4/node_modules/@types/node/globals.d.ts:21
+node_modules/.pnpm/bun-types@1.0.15/node_modules/bun-types/types.d.ts:37219

--- a/vm/predeploys/docs/classes/Predeploy.md
+++ b/vm/predeploys/docs/classes/Predeploy.md
@@ -54,7 +54,7 @@
 
 #### Defined in
 
-[definePredeploy.ts:23](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L23)
+[definePredeploy.ts:28](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L28)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[definePredeploy.ts:17](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L17)
+[definePredeploy.ts:22](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L22)
 
 ## Methods
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[definePredeploy.ts:24](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L24)
+[definePredeploy.ts:29](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L29)
 
 ___
 
@@ -96,4 +96,4 @@ ___
 
 #### Defined in
 
-[definePredeploy.ts:25](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L25)
+[definePredeploy.ts:30](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L30)

--- a/vm/predeploys/docs/modules.md
+++ b/vm/predeploys/docs/modules.md
@@ -20,14 +20,23 @@
 
 ### CustomPredeploy
 
-Ƭ **CustomPredeploy**: `Object`
+Ƭ **CustomPredeploy**\<`TName`, `THumanReadableAbi`, `TBytecode`, `TDeployedBytecode`\>: `Object`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `TName` | extends `string` |
+| `THumanReadableAbi` | extends `ReadonlyArray`\<`string`\> |
+| `TBytecode` | extends \`0x$\{string}\` \| `undefined` |
+| `TDeployedBytecode` | extends \`0x$\{string}\` \| `undefined` |
 
 #### Type declaration
 
 | Name | Type |
 | :------ | :------ |
 | `address` | `Address` |
-| `contract` | `TevmContract` |
+| `contract` | `TevmContract`\<`TName`, `THumanReadableAbi`, `TBytecode`, `TDeployedBytecode`\> |
 
 #### Defined in
 
@@ -45,14 +54,14 @@
 | :------ | :------ |
 | `TName` | extends `string` |
 | `THumanReadableAbi` | extends readonly `string`[] |
-| `TBytecode` | extends `undefined` \| \`0x$\{string}\` |
-| `TDeployedBytecode` | extends `undefined` \| \`0x$\{string}\` |
+| `TBytecode` | extends \`0x$\{string}\` |
+| `TDeployedBytecode` | extends \`0x$\{string}\` |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `«destructured»` | `Pick`\<[`Predeploy`](classes/Predeploy.md)\<`TName`, `THumanReadableAbi`, `TBytecode`, `TDeployedBytecode`\>, ``"contract"`` \| ``"address"``\> |
+| `«destructured»` | `Pick`\<[`Predeploy`](classes/Predeploy.md)\<`TName`, `THumanReadableAbi`, `TBytecode`, `TDeployedBytecode`\>, ``"address"`` \| ``"contract"``\> |
 
 #### Returns
 
@@ -60,4 +69,4 @@
 
 #### Defined in
 
-[definePredeploy.ts:30](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L30)
+[definePredeploy.ts:35](https://github.com/evmts/tevm-monorepo/blob/main/vm/predeploys/src/definePredeploy.ts#L35)

--- a/vm/predeploys/src/definePredeploy.ts
+++ b/vm/predeploys/src/definePredeploy.ts
@@ -3,9 +3,14 @@ import { type TevmContract } from '@tevm/contract'
 import { type Address } from 'abitype'
 import { getAddress } from 'viem'
 
-export type CustomPredeploy = {
+export type CustomPredeploy<
+	TName extends string,
+	THumanReadableAbi extends ReadonlyArray<string>,
+	TBytecode extends `0x${string}` | undefined,
+	TDeployedBytecode extends `0x${string}` | undefined,
+> = {
 	address: Address
-	contract: TevmContract
+	contract: TevmContract<TName, THumanReadableAbi, TBytecode, TDeployedBytecode>
 }
 
 export abstract class Predeploy<
@@ -30,8 +35,8 @@ export abstract class Predeploy<
 export const definePredeploy = <
 	TName extends string,
 	THumanReadableAbi extends readonly string[],
-	TBytecode extends `0x${string}` | undefined,
-	TDeployedBytecode extends `0x${string}` | undefined,
+	TBytecode extends `0x${string}`,
+	TDeployedBytecode extends `0x${string}`,
 >({
 	contract,
 	address,

--- a/vm/predeploys/src/predeploy.spec.ts
+++ b/vm/predeploys/src/predeploy.spec.ts
@@ -10,7 +10,7 @@ test('definePredeploy should define a predeploy', async () => {
 	const { abi, deployedBytecode } = DaiContract
 	const formatted = formatAbi(abi)
 	const contract = createTevmContract({
-		bytecode: undefined,
+		bytecode: '0x420',
 		humanReadableAbi: formatted,
 		name: 'ExamplePredeploy',
 		deployedBytecode: deployedBytecode,

--- a/vm/vm/src/CreateEVMOptions.ts
+++ b/vm/vm/src/CreateEVMOptions.ts
@@ -8,6 +8,6 @@ import type { CustomPredeploy } from '@tevm/predeploys'
 export type CreateEVMOptions = {
 	fork?: ForkOptions
 	customPrecompiles?: CustomPrecompile[]
-	customPredeploys?: CustomPredeploy[]
+	customPredeploys?: ReadonlyArray<CustomPredeploy<any, any, any, any>>
 	allowUnlimitedContractSize?: boolean
 }

--- a/vm/vm/src/test/predeploy.spec.ts
+++ b/vm/vm/src/test/predeploy.spec.ts
@@ -10,11 +10,11 @@ test('Call predeploy from TypeScript', async () => {
 	const { abi, deployedBytecode } = DaiContract
 	const formatted = formatAbi(abi)
 	const contract = createTevmContract({
-		bytecode: undefined,
+		bytecode: '0x420',
 		humanReadableAbi: formatted,
 		name: 'ExamplePredeploy',
 		deployedBytecode: deployedBytecode,
-	})
+	} as const)
 
 	const predeployAddress = '0x0420042004200420042004200420042004200420'
 	const predeploy = definePredeploy({


### PR DESCRIPTION
## Description

Contracts package not being NodeNext causes issues with interoping with other packages. It was not nodenext because a type for events from viem was a deep import and nodenext doesn't allow deep imports. Latest viem makes it so we can get rid of this deep import and then switch to node next

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated import paths across the application for improved module resolution and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->