### PR TITLE
:bug: Fix: Remove account from viem params

### DIFF
--- a/.changeset/ten-cherries-relax.md
+++ b/.changeset/ten-cherries-relax.md
@@ -1,0 +1,5 @@
+---
+"@tevm/actions-types": patch
+---
+
+Fixed bug with typescript type including Viem accounts

--- a/packages/actions-types/docs/type-aliases/EthCallParams.md
+++ b/packages/actions-types/docs/type-aliases/EthCallParams.md
@@ -6,9 +6,15 @@
 
 # Type alias: EthCallParams
 
-> **EthCallParams**: `CallParameters`
+> **EthCallParams**: `Omit`\<`CallParameters`, `"account"`\> & `object`
 
 JSON-RPC request for `eth_call` procedure
+
+## Type declaration
+
+### to
+
+> **to**: `Address`
 
 ## Source
 

--- a/packages/actions-types/docs/type-aliases/EthEstimateGasParams.md
+++ b/packages/actions-types/docs/type-aliases/EthEstimateGasParams.md
@@ -6,9 +6,15 @@
 
 # Type alias: EthEstimateGasParams
 
-> **EthEstimateGasParams**: `EstimateGasParameters`
+> **EthEstimateGasParams**: `Omit`\<`EstimateGasParameters`, `"account"`\> & `object`
 
 JSON-RPC request for `eth_estimateGas` procedure
+
+## Type declaration
+
+### to
+
+> **to**: `Address`
 
 ## Source
 

--- a/packages/actions-types/docs/type-aliases/EthGasPriceParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGasPriceParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_gasPrice` procedure
 
 ## Source
 
-[params/EthParams.ts:58](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L58)
+[params/EthParams.ts:60](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L60)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetBalanceParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetBalanceParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_getBalance` procedure
 
 ## Source
 
-[params/EthParams.ts:63](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L63)
+[params/EthParams.ts:65](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L65)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetBlockByHashParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetBlockByHashParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getBlockByHash` procedure
 
 ## Source
 
-[params/EthParams.ts:68](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L68)
+[params/EthParams.ts:70](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L70)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetBlockByNumberParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetBlockByNumberParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getBlockByNumber` procedure
 
 ## Source
 
-[params/EthParams.ts:76](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L76)
+[params/EthParams.ts:78](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L78)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetBlockTransactionCountByHashParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetBlockTransactionCountByHashParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getBlockTransactionCountByHash` procedure
 
 ## Source
 
-[params/EthParams.ts:84](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L84)
+[params/EthParams.ts:86](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L86)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetBlockTransactionCountByNumberParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetBlockTransactionCountByNumberParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getBlockTransactionCountByNumber` procedure
 
 ## Source
 
-[params/EthParams.ts:89](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L89)
+[params/EthParams.ts:91](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L91)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetCodeParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetCodeParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getCode` procedure
 
 ## Source
 
-[params/EthParams.ts:94](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L94)
+[params/EthParams.ts:96](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L96)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetFilterChangesParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetFilterChangesParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getFilterChanges` procedure
 
 ## Source
 
-[params/EthParams.ts:99](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L99)
+[params/EthParams.ts:101](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L101)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetFilterLogsParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetFilterLogsParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getFilterLogs` procedure
 
 ## Source
 
-[params/EthParams.ts:104](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L104)
+[params/EthParams.ts:106](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L106)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetLogsParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetLogsParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getLogs` procedure
 
 ## Source
 
-[params/EthParams.ts:109](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L109)
+[params/EthParams.ts:111](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L111)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetStorageAtParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetStorageAtParams.md
@@ -26,7 +26,7 @@ JSON-RPC request for `eth_getStorageAt` procedure
 
 ## Source
 
-[params/EthParams.ts:114](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L114)
+[params/EthParams.ts:116](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L116)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetTransactionByBlockHashAndIndexParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetTransactionByBlockHashAndIndexParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getTransactionByBlockHashAndIndex` procedure
 
 ## Source
 
-[params/EthParams.ts:146](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L146)
+[params/EthParams.ts:148](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L148)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetTransactionByBlockNumberAndIndexParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetTransactionByBlockNumberAndIndexParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getTransactionByBlockNumberAndIndex` procedure
 
 ## Source
 
-[params/EthParams.ts:154](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L154)
+[params/EthParams.ts:156](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L156)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetTransactionByHashParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetTransactionByHashParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getTransactionByHash` procedure
 
 ## Source
 
-[params/EthParams.ts:141](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L141)
+[params/EthParams.ts:143](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L143)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetTransactionCountParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetTransactionCountParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getTransactionCount` procedure
 
 ## Source
 
-[params/EthParams.ts:123](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L123)
+[params/EthParams.ts:125](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L125)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetTransactionReceiptParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetTransactionReceiptParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_getTransactionReceipt` procedure
 
 ## Source
 
-[params/EthParams.ts:162](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L162)
+[params/EthParams.ts:164](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L164)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetUncleByBlockHashAndIndexParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetUncleByBlockHashAndIndexParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getUncleByBlockHashAndIndex` procedure
 
 ## Source
 
-[params/EthParams.ts:167](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L167)
+[params/EthParams.ts:169](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L169)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetUncleByBlockNumberAndIndexParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetUncleByBlockNumberAndIndexParams.md
@@ -22,7 +22,7 @@ JSON-RPC request for `eth_getUncleByBlockNumberAndIndex` procedure
 
 ## Source
 
-[params/EthParams.ts:175](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L175)
+[params/EthParams.ts:177](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L177)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetUncleCountByBlockHashParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetUncleCountByBlockHashParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getUncleCountByBlockHash` procedure
 
 ## Source
 
-[params/EthParams.ts:131](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L131)
+[params/EthParams.ts:133](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L133)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthGetUncleCountByBlockNumberParams.md
+++ b/packages/actions-types/docs/type-aliases/EthGetUncleCountByBlockNumberParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_getUncleCountByBlockNumber` procedure
 
 ## Source
 
-[params/EthParams.ts:136](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L136)
+[params/EthParams.ts:138](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L138)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthHashrateParams.md
+++ b/packages/actions-types/docs/type-aliases/EthHashrateParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_hashrate` procedure
 
 ## Source
 
-[params/EthParams.ts:53](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L53)
+[params/EthParams.ts:55](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L55)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthMiningParams.md
+++ b/packages/actions-types/docs/type-aliases/EthMiningParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_mining` procedure
 
 ## Source
 
-[params/EthParams.ts:183](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L183)
+[params/EthParams.ts:185](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L185)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthNewBlockFilterParams.md
+++ b/packages/actions-types/docs/type-aliases/EthNewBlockFilterParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_newBlockFilter` procedure
 
 ## Source
 
-[params/EthParams.ts:223](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L223)
+[params/EthParams.ts:225](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L225)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthNewFilterParams.md
+++ b/packages/actions-types/docs/type-aliases/EthNewFilterParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_newFilter` procedure
 
 ## Source
 
-[params/EthParams.ts:218](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L218)
+[params/EthParams.ts:220](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L220)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthNewPendingTransactionFilterParams.md
+++ b/packages/actions-types/docs/type-aliases/EthNewPendingTransactionFilterParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_newPendingTransactionFilter` procedure
 
 ## Source
 
-[params/EthParams.ts:228](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L228)
+[params/EthParams.ts:230](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L230)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthParams.md
+++ b/packages/actions-types/docs/type-aliases/EthParams.md
@@ -10,7 +10,7 @@
 
 ## Source
 
-[params/EthParams.ts:235](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L235)
+[params/EthParams.ts:237](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L237)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthProtocolVersionParams.md
+++ b/packages/actions-types/docs/type-aliases/EthProtocolVersionParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_protocolVersion` procedure
 
 ## Source
 
-[params/EthParams.ts:188](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L188)
+[params/EthParams.ts:190](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L190)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthSendRawTransactionParams.md
+++ b/packages/actions-types/docs/type-aliases/EthSendRawTransactionParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_sendRawTransaction` procedure
 
 ## Source
 
-[params/EthParams.ts:193](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L193)
+[params/EthParams.ts:195](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L195)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthSendTransactionParams.md
+++ b/packages/actions-types/docs/type-aliases/EthSendTransactionParams.md
@@ -6,13 +6,19 @@
 
 # Type alias: EthSendTransactionParams
 
-> **EthSendTransactionParams**: `SendTransactionParameters`
+> **EthSendTransactionParams**: `Omit`\<`SendTransactionParameters`, `"account"`\> & `object`
 
 JSON-RPC request for `eth_sendTransaction` procedure
 
+## Type declaration
+
+### from
+
+> **from**: `Address`
+
 ## Source
 
-[params/EthParams.ts:198](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L198)
+[params/EthParams.ts:200](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L200)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthSignParams.md
+++ b/packages/actions-types/docs/type-aliases/EthSignParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_sign` procedure
 
 ## Source
 
-[params/EthParams.ts:203](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L203)
+[params/EthParams.ts:205](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L205)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthSignTransactionParams.md
+++ b/packages/actions-types/docs/type-aliases/EthSignTransactionParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_signTransaction` procedure
 
 ## Source
 
-[params/EthParams.ts:208](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L208)
+[params/EthParams.ts:210](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L210)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthSyncingParams.md
+++ b/packages/actions-types/docs/type-aliases/EthSyncingParams.md
@@ -12,7 +12,7 @@ JSON-RPC request for `eth_syncing` procedure
 
 ## Source
 
-[params/EthParams.ts:213](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L213)
+[params/EthParams.ts:215](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L215)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/docs/type-aliases/EthUninstallFilterParams.md
+++ b/packages/actions-types/docs/type-aliases/EthUninstallFilterParams.md
@@ -18,7 +18,7 @@ JSON-RPC request for `eth_uninstallFilter` procedure
 
 ## Source
 
-[params/EthParams.ts:233](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L233)
+[params/EthParams.ts:235](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions-types/src/params/EthParams.ts#L235)
 
 ***
 Generated using [typedoc-plugin-markdown](https://www.npmjs.com/package/typedoc-plugin-markdown) and [TypeDoc](https://typedoc.org/)

--- a/packages/actions-types/src/params/EthParams.ts
+++ b/packages/actions-types/src/params/EthParams.ts
@@ -1,12 +1,10 @@
 import type { EmptyParams } from '../common/EmptyParams.js'
-/***
- * TODO I didn't update any of these jsdocs
- */
 import type { FilterParams } from '../common/FilterParams.js'
 import type { Address } from 'abitype'
 import type {
 	BlockTag,
 	CallParameters,
+	Chain,
 	EstimateGasParameters,
 	GetBalanceParameters,
 	GetTransactionParameters,
@@ -18,19 +16,19 @@ import type {
 
 // eth_accounts
 /**
- * Params taken by `eth_accounts` handler
+ * Params taken by `eth_accounts` handler (no params)
  */
 export type EthAccountsParams = EmptyParams
 // eth_blockNumber
 /**
- * JSON-RPC request for `eth_blockNumber` procedure
+ * JSON-RPC request for `eth_blockNumber` procedure (no params)
  */
 export type EthBlockNumberParams = EmptyParams
 // eth_call
 /**
  * JSON-RPC request for `eth_call` procedure
  */
-export type EthCallParams = CallParameters
+export type EthCallParams<TChain extends Chain | undefined = Chain | undefined> = Omit<CallParameters<TChain>, 'account'> & { to: Address }
 // eth_chainId
 /**
  * JSON-RPC request for `eth_chainId` procedure
@@ -45,7 +43,9 @@ export type EthCoinbaseParams = EmptyParams
 /**
  * JSON-RPC request for `eth_estimateGas` procedure
  */
-export type EthEstimateGasParams = EstimateGasParameters
+export type EthEstimateGasParams<TChain extends Chain | undefined = Chain | undefined> = Omit<EstimateGasParameters<TChain>, 'account'> & {
+	to: Address
+}
 // eth_hashrate
 /**
  * JSON-RPC request for `eth_hashrate` procedure
@@ -195,7 +195,7 @@ export type EthSendRawTransactionParams = SendRawTransactionParameters
 /**
  * JSON-RPC request for `eth_sendTransaction` procedure
  */
-export type EthSendTransactionParams = SendTransactionParameters
+export type EthSendTransactionParams<TChain extends Chain | undefined = Chain | undefined> = Omit<SendTransactionParameters<TChain>, 'account'> & { from: Address }
 // eth_sign
 /**
  * JSON-RPC request for `eth_sign` procedure
@@ -208,7 +208,7 @@ export type EthSignParams = SignMessageParameters
 export type EthSignTransactionParams = SignMessageParameters
 // eth_syncing
 /**
- * JSON-RPC request for `eth_syncing` procedure
+ * JSON-RPC request for `eth_syncing` procedure (no params)
  */
 export type EthSyncingParams = EmptyParams
 // eth_newFilter
@@ -218,7 +218,7 @@ export type EthSyncingParams = EmptyParams
 export type EthNewFilterParams = FilterParams
 // eth_newBlockFilter
 /**
- * JSON-RPC request for `eth_newBlockFilter` procedure
+ * JSON-RPC request for `eth_newBlockFilter` procedure (no params)
  */
 export type EthNewBlockFilterParams = EmptyParams
 // eth_newPendingTransactionFilter


### PR DESCRIPTION
## Description

Because some types inherit from viem we accidentally included account in the api

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation source links for JSON-RPC procedures.
- **New Features**
	- Enhanced Ethereum transaction parameter types for clarity and consistency.
- **Bug Fixes**
	- Patched TypeScript type issue to correctly handle Ethereum account parameters.
- **Refactor**
	- Refined Ethereum JSON-RPC parameter types by removing redundant account fields and adding address specifications where necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->