### PR TITLE
:bug: Fix: Broken links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,7 +1,9 @@
 import starlight from '@astrojs/starlight'
 import { defineConfig } from 'astro/config'
-// import starlightLinksValidatorPlugin from 'starlight-links-validator'
+import starlightLinksValidatorPlugin from 'starlight-links-validator'
 import starlightTypeDoc, { typeDocSidebarGroup } from 'starlight-typedoc'
+
+const ENABLE_LINK_CHECKER = false
 
 // https://astro.build/config
 export default defineConfig({
@@ -14,9 +16,13 @@ export default defineConfig({
 			},
 			tableOfContents: true,
 			plugins: [
-				// starlightLinksValidatorPlugin({
-				// 	errorOnRelativeLinks: false,
-				// }),
+				...(ENABLE_LINK_CHECKER
+					? [
+							starlightLinksValidatorPlugin({
+								errorOnRelativeLinks: true,
+							}),
+					  ]
+					: []),
 				starlightTypeDoc({
 					entryPoints: [
 						'../packages/actions',

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -19,10 +19,10 @@ npm create tevm my-app
 
 This guide will get you familiar with the most essential features of Tevm and start interacting with the Ethereum Virtual Machine (EVM) in Node.js or browser environments with `Tevm`. By the end of this guide you will understand:
 
-1. How to create a forked EVM in JavaScript using [`createMemoryClient`](../reference/@tevm/memory-client/functions/createMemoryClient.md)
-2. How to write, build, and execute solidity scripts with a [`TevmClient`](../reference/@tevm/client-types/type-aliases/TevmClient.md)
-3. How to streamline your workflow using [`tevm contract imports`](../reference/@tevm/bun-plugin/functions/bunPluginTevm.md) with the tevm bundler
-4. How to write solidity scripts with the [`tevm script action`](../reference/@tevm/client-types/type-aliases/TevmClient.md#script)
+1. How to create a forked EVM in JavaScript using [`createMemoryClient`](/reference/tevm/memory-client/functions/creatememoryclient)
+2. How to write, build, and execute solidity scripts with a [`TevmClient`](/reference/tevm/client-types/type-aliases/tevmclient)
+3. How to streamline your workflow using [`tevm contract imports`](/reference/tevm/bun-plugin/functions/bunplugintevm) with the tevm bundler
+4. How to write solidity scripts with the [`tevm script action`](/reference/tevm/client-types/type-aliases/tevmclient#script)
 
 ## Prerequisites
 
@@ -62,7 +62,7 @@ Now let's create a Tevm VM to execute Ethereum bytecode in our JavaScript
 
 1. Open the index.ts file
 
-2. Now initialize a [MemoryClient](../reference/@tevm/memory-client/type-aliases/MemoryClient.md) with [createMemoryClient](../reference/@tevm/memory-client/functions/createMemoryClient.md)
+2. Now initialize a [MemoryClient](/reference/tevm/memory-client/type-aliases/memoryclient) with [createMemoryClient](/reference/tevm/memory-client/functions/creatememoryclient)
 
 ```typescript
 import { createMemoryClient } from 'tevm';
@@ -74,15 +74,15 @@ This initializes an an ethereum VM instance akin to starting anvil but in memory
 
 ## Using ethereum JSON-RPC
 
-The entrypoint to using Tevm is [`TevmClient.request`](../reference/@tevm/procedures-types/type-aliases/TevmJsonRpcRequestHandler.md). It implements the
+The entrypoint to using Tevm is [`TevmClient.request`](/reference/tevm/procedures-types/type-aliases/tevmjsonrpcrequesthandler). It implements the
 
 - much of the [ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc)
-- custom [tevm_*](../reference/@tevm/procedures-types/type-aliases/TevmJsonRpcRequest.md) requests
+- custom [tevm_*](/reference/tevm/procedures-types/type-aliases/tevmjsonrpcrequest) requests
 - will support anvil_* and ganache_* in future versions
 
 Let's use [eth_getBalance](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getbalance)
 
-1. Create a [eth_getBalance](../reference/@tevm/procedures-types/type-aliases/EthGetBalanceRequest.md)
+1. Create a [eth_getBalance](/reference/tevm/procedures-types/type-aliases/ethgetbalancejsonrpcrequest)
 
 ```typescript
 import { createMemoryClient } from 'tevm';
@@ -98,7 +98,7 @@ const request: EthGetBalanceRequest = {
 }
 ```
 
-2. Now pass our request into [`@tevm/request`](../reference/@tevm/client-types/type-aliases/TevmClient.md#request)
+2. Now pass our request into [`@tevm/request`](/reference/tevm/client-types/type-aliases/tevmclient#request)
 
 ```typescript
 import { createMemoryClient } from 'tevm';
@@ -130,9 +130,9 @@ This address has 0 eth because we have a brand new vm. Let's make our VM fork et
 
 Similar to anvil or ganache `Tevm` has the ability to fork a live network.
 
-1. Update [createMemoryClient](../reference/@tevm/memory-client/functions/createMemoryClient.md) to fork ethereum using [forkUrl](../reference/@tevm/memory-client/type-aliases/CreateEVMOptions.md)
+1. Update [createMemoryClient](/reference/tevm/memory-client/functions/creatememoryclient) to fork ethereum using [forkUrl](/reference/tevm/memory-client/type-aliases/createevmoptions)
 
-Add any ethereum RPC url to the [`options.fork.url`](../reference/@tevm/memory-client/type-aliases/CreateEVMOptions.md)
+Add any ethereum RPC url to the [`options.fork.url`](/reference/tevm/memory-client/type-aliases/createevmoptions)
 
 ```typescript
 import { createMemoryClient } from 'tevm';
@@ -183,13 +183,13 @@ fetch("https://mainnet.optimism.io", {
   .then(console.log);
 ```
 
-But with [`MemoryClient`](../reference/@tevm/memory-client/type-aliases/MemoryClient.md) all requests will be issued to the same block number we forked and cached in memory once made.
+But with [`MemoryClient`](/reference/tevm/memory-client/type-aliases/memoryclient) all requests will be issued to the same block number we forked and cached in memory once made.
 
 ## Using `Actions` API to execute a contract
 
 Tevm exposes a [viem-like](https://viem.sh) `actions api` to provide a higher level of abstraction than the JSON-RPC interface.
 
-1. Replace [`tevm_getAccount` JSON-RPC procedure](../reference/@tevm/api/type-aliases/GetAccountJsonRpcProcedure.md) with the [getAccount action](../reference/@tevm/api/type-aliases/GetAccountHandler.md)
+1. Replace [`tevm_getAccount` JSON-RPC procedure](/reference/tevm/procedures-types/type-aliases/getaccountjsonrpcprocedure) with the [getAccount action](/reference/tevm/actions-types/type-aliases/getaccounthandler)
 
 ```typescript
 import { createMemoryClient } from 'tevm';
@@ -218,7 +218,7 @@ const tevm = await createMemoryClient({
 
 2. Run a transaction
 
-Now send a transaction using [TevmClient.call](../reference/@tevm/client-types/type-aliases/TevmClient.md#call). This is equivelent to using [`eth_call`](../reference/@tevm/procedures-types/type-aliases/EthCallJsonRpcProcedure.md).
+Now send a transaction using [TevmClient.call](/reference/tevm/client-types/type-aliases/tevmclient#call). This is equivelent to using [`eth_call`](/reference/tevm/procedures-types/type-aliases/ethcalljsonrpcprocedure).
 
 `Tevm.call` wraps `tevm_call` which is similar to `eth_call` or `Tevm.eth.call` but has extra parameters for modifying the VM.
 
@@ -252,13 +252,13 @@ console.log(balance)
 bun run vm.js
 ```
 
-To see more options check out [CallParams](../reference/@tevm/actions-types/type-aliases/CallParams.md) docs
+To see more options check out [CallParams](/reference/tevm/actions-types/type-aliases/callparams) docs
 
 ## Executing contract calls
 
-We can execute a contract call by sending encoded contract data just like [`eth_call`](../reference/@tevm/procedures-types/type-aliases/EthCallJsonRpcProcedure.md)
+We can execute a contract call by sending encoded contract data just like [`eth_call`](/reference/tevm/procedures-types/type-aliases/ethcalljsonrpcprocedure)
 
-1. Use [`encodeFunctionData`](../reference/@tevm/contract/functions/encodeFunctionData.md) to pass in a contract call to [`tevm.call`](../reference/@tevm/api/type-aliases/TevmClient.md#call)
+1. Use [`encodeFunctionData`](/reference/tevm/contract/functions/encodefunctiondata) to pass in a contract call to [`tevm.call`](/reference/tevm/client-types/type-aliases/tevmclient#call)
 
 ```typescript
 import { createMemoryClient, encodeFunctionData, decodeFunctionData, parseAbi } from 'tevm';
@@ -293,7 +293,7 @@ console.log(balance)
 
 2. Use `TevmClient.contract`
 
-Rather than encoding and decoding data with `TevmClient.call` we can instead use the [`TevmClient.contract`](../reference/@tevm/client-types/type-aliases/TevmClient.md#contract) method. It wraps the `eth_call` JSON-rpc method and matches much of [viems readContract](https://viem.sh/docs/contract/readContract.html) API but with some extra VM control. 
+Rather than encoding and decoding data with `TevmClient.call` we can instead use the [`TevmClient.contract`](/reference/tevm/client-types/type-aliases/tevmclient#contract) method. It wraps the `eth_call` JSON-rpc method and matches much of [viems readContract](https://viem.sh/docs/contract/readContract.html) API but with some extra VM control. 
 
 Refactor our call to use `Tevm.contract`
 
@@ -331,7 +331,7 @@ await tevm.setAccount({address: `0x${'42'.repeat(20)}`, deployedBytecode: '0x000
 
 And then use `tevm.contract` as we did in last section.
 
-But Tevm provides a convenient [`tevm_script`](../reference/@tevm/procedures-types/type-aliases/ScriptJsonRpcProcedure.md) JSON-RPC request and matching [TevmClient.script action](../reference/@tevm/client-types/type-aliases/TevmClient.md#script)
+But Tevm provides a convenient [`tevm_script`](/reference/tevm/procedures-types/type-aliases/scriptjsonrpcprocedure) JSON-RPC request and matching [TevmClient.script action](/reference/tevm/client-types/type-aliases/tevmclient#script)
 
 1. First let's make a new solidity file
 
@@ -362,7 +362,7 @@ bunx tevm compile HelloWorld.s.sol
 
 You should see a `.js` file get generated with the JavaScript version of your contract. Inspect the file. We will talk more about this later.
 
-4. Import contract and use it in a [`Tevm.script`](../reference/@tevm/api/type-aliases/TevmClient.md#script) action.
+4. Import contract and use it in a [`Tevm.script`](/reference/tevm/client-types/type-aliases/tevmclient#script) action.
 
 ```typescript
 import { HelloWorld } from './HelloWorld.s.sol.js';
@@ -435,7 +435,7 @@ bun install @tevm/bundler
 
 This package installs two tools we need:
 
-- Bundler support to bundle our solidity contracts. Plugins exist for webpack, vite, rollup, esbuild and more. We will use the [bun plugin](../reference/@tevm/bun-plugin/functions/bunPluginTevm.md).
+- Bundler support to bundle our solidity contracts. Plugins exist for webpack, vite, rollup, esbuild and more. We will use the [bun plugin](/reference/tevm/bun-plugin/functions/bunplugintevm).
 - [LSP](https://microsoft.github.io/language-server-protocol/) support for TypeScript via a [typescript language service plugin](https://github.com/microsoft/TypeScript/wiki/Writing-a-Language-Service-Plugin)
 
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -23,13 +23,13 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
 	<Card title="Tevm memory devnet" icon="pencil">
-		[EVM execution and forking](./learn/clients.md) akin to [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
+		[EVM execution and forking](/learn/clients) akin to [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
 	</Card>
 	<Card title="Solidity scripting" icon="add-document">
-		A powerful [solidity scripting](./learn/scripting.md) support akin to [foundry scripts](https://book.getfoundry.sh/tutorials/solidity-scripting)
+		A powerful [solidity scripting](/learn/scripting) support akin to [foundry scripts](https://book.getfoundry.sh/tutorials/solidity-scripting)
 	</Card>
 	<Card title="Solidity imports" icon="setting">
-		[Importing solidity files](./learn/solidity-imports.md) directly into TypeScript. Never juggle an ABI again!
+		[Importing solidity files](/learn/solidity-imports) directly into TypeScript. Never juggle an ABI again!
 	</Card>
 	<Card title="Runs in all environments" icon="open-book">
 		Tevm runs in the browser, node.js, and bun

--- a/docs/src/content/docs/learn/actions/index.md
+++ b/docs/src/content/docs/learn/actions/index.md
@@ -5,82 +5,82 @@ description: Tevm actions api
 
 ## Overview
 
-Tevm has an [actions based api](../../reference/tevm/actions-types/api) similar to [viem's actions api](https://viem.sh/docs/actions/public/getbalance) and following similar patterns. This is a higher level of abstraction than the lower level [JSON-RPC api](./json-rpc)
+Tevm has an [actions based api](/reference/tevm/actions-types/api) similar to [viem's actions api](https://viem.sh/docs/actions/public/getbalance) and following similar patterns. This is a higher level of abstraction than the lower level [JSON-RPC api](/learn/json-rpc)
 
 ## Tevm actions
 
 Tevm methods are the main recomended way to interact with Tevm. 🚧 means the procedure is still under construction
 
-- [`Tevm.call`](../../reference/tevm/actions-types/type-aliases/callhandler) - Similar to eth call but with additional properties to control the VM execution
-- [`Tevm.getAccount`](../../reference/tevm/actions-types/type-aliases/getaccounthandler) - gets account information such as balances contract information nonces and state roots.
-- [`Tevm.setAccount`](../../reference/tevm/actions-types/type-aliases/setaccounthandler) - directly modifies the state of an account
-- [`Tevm.contract`](../../reference/tevm/actions-types/type-aliases/callhandler) - Similar to eth call but with additional properties to control the VM execution
-- [`Tevm.script`](../../reference/tevm/actions-types/type-aliases/scripthandler) - Runs the provided bytecode against the EVM state
-- 🚧 [`Tevm.traceContractCall`](../../reference/tevm/actions-types/type-aliases/tracecontractcallhandler) 
-- 🚧 [`Tevm.traceScript`](../../reference/tevm/actions-types/type-aliases/tracescripthandler) 
-- [`Tevm.dumpState`](../../reference/tevm/actions-types/type-aliases/dumpstatehandler) - Returns the state of the VM
-- [`Tevm.loadState`](../../reference/tevm/actions-types/type-aliases/loadstatehandler) - Initializes the state of the VM
+- [`Tevm.call`](/reference/tevm/actions-types/type-aliases/callhandler) - Similar to eth call but with additional properties to control the VM execution
+- [`Tevm.getAccount`](/reference/tevm/actions-types/type-aliases/getaccounthandler) - gets account information such as balances contract information nonces and state roots.
+- [`Tevm.setAccount`](/reference/tevm/actions-types/type-aliases/setaccounthandler) - directly modifies the state of an account
+- [`Tevm.contract`](/reference/tevm/actions-types/type-aliases/callhandler) - Similar to eth call but with additional properties to control the VM execution
+- [`Tevm.script`](/reference/tevm/actions-types/type-aliases/scripthandler) - Runs the provided bytecode against the EVM state
+- 🚧 `Tevm.traceContractCall`
+- 🚧 `Tevm.traceScript`
+- [`Tevm.dumpState`](/reference/tevm/actions-types/type-aliases/dumpstatehandler) - Returns the state of the VM
+- [`Tevm.loadState`](/reference/tevm/actions-types/type-aliases/loadstatehandler) - Initializes the state of the VM
 
 ## Eth methods
 
 Tevm plans on implementing most of the [ethereum JSON-RPC](https://ethereum.org/developers/docs/apis/json-rpc) spec
 
-- [`Tevm.eth.chainId'](../../reference/tevm/actions-types/type-aliases/ethchainidhandler)
-- [`Tevm.eth.call'](../../reference/tevm/actions-types/type-aliases/ethcallhandler)
-- [`Tevm.eth.getCode'](../../reference/tevm/actions-types/type-aliases/ethgetcodehandler)
-- [`Tevm.eth.getStorageAt'](../../reference/tevm/actions-types/type-aliases/ethgetcodehandler)
-- [`Tevm.eth.gasPrice'](../../reference/tevm/actions-types/type-aliases/ethgaspricehandler)
-- [`Tevm.eth.getBalance'](../../reference/tevm/actions-types/type-aliases/ethgetbalancehandler)
-- [`Tevm.eth.estimateGas'](../../reference/tevm/actions-types/type-aliases/ethestimategashandler)
-- 🚧 [`Tevm.eth.sign'](../../reference/tevm/actions-types/type-aliases/ethsignprocedure)
-- 🚧 [`Tevm.eth.getLogs'](../../reference/tevm/actions-types/type-aliases/ethgetlogshandler)
-- 🚧 [`Tevm.eth.accounts'](../../reference/tevm/actions-types/type-aliases/ethaccountshandler)
-- 🚧 [`Tevm.eth.coinbase'](../../reference/tevm/actions-types/type-aliases/ethcoinbasehandler)
-- 🚧 [`Tevm.eth.hashrate'](../../reference/tevm/actions-types/type-aliases/ethhashratehandler)
-- 🚧 [`Tevm.eth.newFilter'](../../reference/tevm/actions-types/type-aliases/ethnewfilterhandler)
-- 🚧 [`Tevm.eth.getFilterLogs'](../../reference/tevm/actions-types/type-aliases/ethgetfilterlogshandler)
-- 🚧 [`Tevm.eth.getBlockByHash'](../../reference/tevm/actions-types/type-aliases/ethgetblockbyhashhandler)
-- 🚧 [`Tevm.eth.newBlockFilter'](../../reference/tevm/actions-types/type-aliases/ethnewblockfilterhandler)
-- 🚧 [`Tevm.eth.protocolVersion'](../../reference/tevm/actions-types/type-aliases/ethprotocolversionhandler)
-- 🚧 [`Tevm.eth.sendTransaction'](../../reference/tevm/actions-types/type-aliases/ethsendtransactionhandler)
-- 🚧 [`Tevm.eth.signTransaction'](../../reference/tevm/actions-types/type-aliases/ethsigntransactionhandler)
-- 🚧 [`Tevm.eth.uninstallFilter'](../../reference/tevm/actions-types/type-aliases/ethuninstallfilterhandler)
-- 🚧 [`Tevm.eth.getBlockByNumber'](../../reference/tevm/actions-types/type-aliases/ethgetblockbynumberhandler)
-- 🚧 [`Tevm.eth.getFilterChanges'](../../reference/tevm/actions-types/type-aliases/ethgetfilterchangeshandler)
-- 🚧 [`Tevm.eth.sendRawTransaction'](../../reference/tevm/actions-types/type-aliases/ethsendrawtransactionhandler)
-- 🚧 [`Tevm.eth.getTransactionCount'](../../reference/tevm/actions-types/type-aliases/ethgettransactioncounthandler)
-- 🚧 [`Tevm.eth.getTransactionByHash'](../../reference/tevm/actions-types/type-aliases/ethgettransactionbyhashhandler)
-- 🚧 [`Tevm.eth.getTransactionReceipt'](../../reference/tevm/actions-types/type-aliases/ethgettransactionreceipthandler)
-- 🚧 [`Tevm.eth.newPendingTransactionFilter'](../../reference/tevm/actions-types/type-aliases/ethnewpendingtransactionfilterjsonrpcresponse)
-- 🚧 [`Tevm.eth.getBlockTransactionCountByHash'](../../reference/tevm/actions-types/type-aliases/ethgetblocktransactioncountbyhashhandler)
-- 🚧 [`Tevm.eth.getBlockTransactionCountByNumber'](../../reference/tevm/actions-types/type-aliases/tevm.eth.getblocktransactioncountbynumber)
-- 🚧 [`Tevm.eth.getTransactionByBlockHashAndIndex'](../../reference/tevm/actions-types/type-aliases/ethgettransactionbyblockhashandindexhandler)
-- 🚧 [`Tevm.eth.getTransactionByBlockNumberAndIndex'](../../reference/tevm/actions-types/type-aliases/ethtransactionbyblocknumberandindexhandler)
+- [`Tevm.eth.chainId'](/reference/tevm/actions-types/type-aliases/ethchainidhandler)
+- [`Tevm.eth.call'](/reference/tevm/actions-types/type-aliases/ethcallhandler)
+- [`Tevm.eth.getCode'](/reference/tevm/actions-types/type-aliases/ethgetcodehandler)
+- [`Tevm.eth.getStorageAt'](/reference/tevm/actions-types/type-aliases/ethgetcodehandler)
+- [`Tevm.eth.gasPrice'](/reference/tevm/actions-types/type-aliases/ethgaspricehandler)
+- [`Tevm.eth.getBalance'](/reference/tevm/actions-types/type-aliases/ethgetbalancehandler)
+- [`Tevm.eth.estimateGas'](/reference/tevm/actions-types/type-aliases/ethestimategashandler)
+- 🚧 `Tevm.eth.sign'
+- 🚧 [`Tevm.eth.getLogs'](/reference/tevm/actions-types/type-aliases/ethgetlogshandler)
+- 🚧 [`Tevm.eth.accounts'](/reference/tevm/actions-types/type-aliases/ethaccountshandler)
+- 🚧 [`Tevm.eth.coinbase'](/reference/tevm/actions-types/type-aliases/ethcoinbasehandler)
+- 🚧 [`Tevm.eth.hashrate'](/reference/tevm/actions-types/type-aliases/ethhashratehandler)
+- 🚧 [`Tevm.eth.newFilter'](/reference/tevm/actions-types/type-aliases/ethnewfilterhandler)
+- 🚧 [`Tevm.eth.getFilterLogs'](/reference/tevm/actions-types/type-aliases/ethgetfilterlogshandler)
+- 🚧 [`Tevm.eth.getBlockByHash'](/reference/tevm/actions-types/type-aliases/ethgetblockbyhashhandler)
+- 🚧 [`Tevm.eth.newBlockFilter'](/reference/tevm/actions-types/type-aliases/ethnewblockfilterhandler)
+- 🚧 [`Tevm.eth.protocolVersion'](/reference/tevm/actions-types/type-aliases/ethprotocolversionhandler)
+- 🚧 [`Tevm.eth.sendTransaction'](/reference/tevm/actions-types/type-aliases/ethsendtransactionhandler)
+- 🚧 [`Tevm.eth.signTransaction'](/reference/tevm/actions-types/type-aliases/ethsigntransactionhandler)
+- 🚧 [`Tevm.eth.uninstallFilter'](/reference/tevm/actions-types/type-aliases/ethuninstallfilterhandler)
+- 🚧 [`Tevm.eth.getBlockByNumber'](/reference/tevm/actions-types/type-aliases/ethgetblockbynumberhandler)
+- 🚧 [`Tevm.eth.getFilterChanges'](/reference/tevm/actions-types/type-aliases/ethgetfilterchangeshandler)
+- 🚧 [`Tevm.eth.sendRawTransaction'](/reference/tevm/actions-types/type-aliases/ethsendrawtransactionhandler)
+- 🚧 [`Tevm.eth.getTransactionCount'](/reference/tevm/actions-types/type-aliases/ethgettransactioncounthandler)
+- 🚧 [`Tevm.eth.getTransactionByHash'](/reference/tevm/actions-types/type-aliases/ethgettransactionbyhashhandler)
+- 🚧 [`Tevm.eth.getTransactionReceipt'](/reference/tevm/actions-types/type-aliases/ethgettransactionreceipthandler)
+- 🚧 `Tevm.eth.newPendingTransactionFilter'
+- 🚧 [`Tevm.eth.getBlockTransactionCountByHash'](/reference/tevm/actions-types/type-aliases/ethgetblocktransactioncountbyhashhandler)
+- 🚧 `Tevm.eth.getBlockTransactionCountByNumber'
+- 🚧 [`Tevm.eth.getTransactionByBlockHashAndIndex'](/reference/tevm/actions-types/type-aliases/ethgettransactionbyblockhashandindexhandler)
+- 🚧 `Tevm.eth.getTransactionByBlockNumberAndIndex'
 
 ## Debug methods
 
-- 🚧 [`Tevm.debug.traceTransaction`](../../reference/tevm/actions-types/type-aliases/debugtracetransactionhandler)
-- 🚧 [`Tevm.debug.traceCall`](../../reference/tevm/actions-types/type-aliases/debugtracecallhandler)
+- 🚧 [`Tevm.debug.traceTransaction`](/reference/tevm/actions-types/type-aliases/debugtracetransactionhandler)
+- 🚧 [`Tevm.debug.traceCall`](/reference/tevm/actions-types/type-aliases/debugtracecallhandler)
 
 ## Anvil/Hardhat methods
 
 Anvil/hardhat methods are provided for compatability
 
-- 🚧 [`Tevm.anvil.mine'](../../reference/tevm/actions-types/type-aliases/anvilminehandler)
-- 🚧 [`Tevm.anvil.reset'](../../reference/tevm/actions-types/type-aliases/anvilresethandler)
-- 🚧 [`Tevm.anvil.setCode'](../../reference/tevm/actions-types/type-aliases/anvilsetcodehandler)
-- 🚧 [`Tevm.anvil.setNonce'](../../reference/tevm/actions-types/type-aliases/anvilsetnoncehandler)
-- 🚧 [`Tevm.anvil.dumpState'](../../reference/tevm/actions-types/type-aliases/anvildumpstatehandler)
-- 🚧 [`Tevm.anvil.loadState'](../../reference/tevm/actions-types/type-aliases/anvilloadstatehandler)
-- 🚧 [`Tevm.anvil.setBalance'](../../reference/tevm/actions-types/type-aliases/anvilsetbalancehandler)
-- 🚧 [`Tevm.anvil.setChainId'](../../reference/tevm/actions-types/type-aliases/anvilsetchainidhandler)
-- 🚧 [`Tevm.anvil.getAutomine'](../../reference/tevm/actions-types/type-aliases/anvilgetautominehandler)
-- 🚧 [`Tevm.anvil.setStorageAt'](../../reference/tevm/actions-types/type-aliases/anvilsetstorageathandler)
-- 🚧 [`Tevm.anvil.dropTransaction'](../../reference/tevm/actions-types/type-aliases/anvildroptransactionhandler)
-- 🚧 [`Tevm.anvil.impersonateAccount'](../../reference/tevm/actions-types/type-aliases/anvilimpersonateaccounthandler)
-- 🚧 [`Tevm.anvil.stopImpersonatingAccount'](../../reference/tevm/actions-types/type-aliases/anvilstopimpersonatingaccounthandler)
+- 🚧 [`Tevm.anvil.mine'](/reference/tevm/actions-types/type-aliases/anvilminehandler)
+- 🚧 [`Tevm.anvil.reset'](/reference/tevm/actions-types/type-aliases/anvilresethandler)
+- 🚧 [`Tevm.anvil.setCode'](/reference/tevm/actions-types/type-aliases/anvilsetcodehandler)
+- 🚧 [`Tevm.anvil.setNonce'](/reference/tevm/actions-types/type-aliases/anvilsetnoncehandler)
+- 🚧 [`Tevm.anvil.dumpState'](/reference/tevm/actions-types/type-aliases/anvildumpstatehandler)
+- 🚧 [`Tevm.anvil.loadState'](/reference/tevm/actions-types/type-aliases/anvilloadstatehandler)
+- 🚧 [`Tevm.anvil.setBalance'](/reference/tevm/actions-types/type-aliases/anvilsetbalancehandler)
+- 🚧 [`Tevm.anvil.setChainId'](/reference/tevm/actions-types/type-aliases/anvilsetchainidhandler)
+- 🚧 [`Tevm.anvil.getAutomine'](/reference/tevm/actions-types/type-aliases/anvilgetautominehandler)
+- 🚧 [`Tevm.anvil.setStorageAt'](/reference/tevm/actions-types/type-aliases/anvilsetstorageathandler)
+- 🚧 [`Tevm.anvil.dropTransaction'](/reference/tevm/actions-types/type-aliases/anvildroptransactionhandler)
+- 🚧 [`Tevm.anvil.impersonateAccount'](/reference/tevm/actions-types/type-aliases/anvilimpersonateaccounthandler)
+- 🚧 [`Tevm.anvil.stopImpersonatingAccount'](/reference/tevm/actions-types/type-aliases/anvilstopimpersonatingaccounthandler)
 
 ## Tree shakeable actions
 
-Like viem, Tevm provides tree shakable versions of the actions in the [tevm/procedures](../../reference/tevm/procedures/) package. But for Tevm it is recomended you use the higher level [client apis](./clients). If bundle size is a concern a more effective way of reducing bundle size is using a [remote http client](../../reference/tevm/http-client/api) and running the EVM on a [backend server](../../reference/tevm/server/api)
+Like viem, Tevm provides tree shakable versions of the actions in the [tevm/procedures](/reference/tevm/procedures/api) package. But for Tevm it is recomended you use the higher level [client apis](/learn/clients). If bundle size is a concern a more effective way of reducing bundle size is using a [remote http client](/reference/tevm/http-client/api) and running the EVM on a [backend server](/reference/tevm/server/api)
 

--- a/docs/src/content/docs/learn/clients/index.md
+++ b/docs/src/content/docs/learn/clients/index.md
@@ -5,20 +5,20 @@ description: Introduction to clients and actions
 
 ## Tevm Clients
 
-The interface to Tevm api is called [TevmClient](../../reference/@tevm/client-types/type-aliases/tevmclient.md). This api provides a uniform API for interacting with Tevm whether interacting with a [MemoryClient](./memory-client.md) directly or remotely interacting via an [HttpCLient](../../reference/@tevm/http-client/type-aliases/httpclient.md). Tevm clients share the same [actions](./actions.md) based interface along with a [`request`](../reference/@tevm/memory-client/type-aliases/memoryclient.md#request) method for handling JSON-RPC requests.
+The interface to Tevm api is called [TevmClient](/reference/tevm/client-types/type-aliases/tevmclient). This api provides a uniform API for interacting with Tevm whether interacting with a [MemoryClient](/reference/tevm/memory-client/type-aliases/memoryclient) directly or remotely interacting via an [HttpCLient](/reference/tevm/http-client/type-aliases/httpclient). Tevm clients share the same [actions](/learn/actions) based interface along with a [`request`](/reference/tevm/client-types/type-aliases/tevmclient#request) method for handling JSON-RPC requests.
 
 The following clients are available
 
-- [MemoryClient](./memory-client.md) - An in memory instance of the EVM that can run in Node.js, bun or the browser
-- [HttpClient](./http-client.md) - A client that talks to a remote `MemoryClient` running in an [http server](../reference/@tevm/server/api.md) 
-- [Viem extensions](../reference/@tevm/viem/api.md) - Provides a viem based client instance and some experimental optimistic updating apis.
-- 🚧 Under construction [Ethers extensions](../reference/@tevm/ethers/api.md) - An ethers based memory client and http client
+- [MemoryClient](/reference/tevm/memory-client/type-aliases/memoryclient) - An in memory instance of the EVM that can run in Node.js, bun or the browser
+- [HttpClient](/reference/tevm/http-client/type-aliases/httpclient) - A client that talks to a remote `MemoryClient` running in an [http server](/reference/tevm/server/api) 
+- [Viem extensions](/reference/tevm/viem/api) - Provides a viem based client instance and some experimental optimistic updating apis.
+- 🚧 Under construction [Ethers extensions](/reference/tevm/ethers/api) - An ethers based memory client and http client
 - 🚧 Under construction `WebsocketClient` - A web socket based TevmClient similar to the `HttpClient`
 
 ## Actions
 
-The main interface for interacting with any Tevm client is it's `actions api`. See [actions api](./actions.md) guide or the [TevmClient reference](../reference/@tevm/client-types/type-aliases/tevmclient.md) for more information.
+The main interface for interacting with any Tevm client is it's `actions api`. See [actions api](/learn/actions) guide or the [TevmClient reference](/reference/tevm/client-types/type-aliases/tevmclient) for more information.
 
 ## Procedures
 
-Tevm also has an `client.request` method for doing JSON procedure calls.  For `MemoryClient` this procedure call happens in memory and for `HttpClient` this procedure call is resolved remotely using JSON-RPC (json remote procedure call). For more information see the [JSON-RPC](./json-rpc.md) docs and the [`client.request`](../reference/@tevm/procedures-types/type-aliases/tevmjsonrpcrequesthandler.md) generated reference docs.
+Tevm also has an `client.request` method for doing JSON procedure calls.  For `MemoryClient` this procedure call happens in memory and for `HttpClient` this procedure call is resolved remotely using JSON-RPC (json remote procedure call). For more information see the [JSON-RPC](/learn/json-rpc) docs and the [`client.request`](/reference/tevm/procedures-types/type-aliases/tevmjsonrpcrequesthandler) generated reference docs.

--- a/docs/src/content/docs/learn/contracts/index.md
+++ b/docs/src/content/docs/learn/contracts/index.md
@@ -5,9 +5,9 @@ description: Guide on using contract action creators
 
 ## Contract action creators
 
-The [`@tevm/contracts`](../reference/@tevm/contract/API.md) package is an optional module in `tevm` for cleaning up your contract code. It represents a contract or script and provides a typesafe api for creating [actions](./actions.md)
+The [`@tevm/contracts`](/reference/tevm/contract/api) package is an optional module in `tevm` for cleaning up your contract code. It represents a contract or script and provides a typesafe api for creating [actions](/learn/actions)
 
-In the following diff the added code shows how to dispatch a [`script`](../reference/@tevm/actions-types/type-aliases/ScriptHandler.md) action with a contract action creator. The removed code is both how you would do it without an action creator and also the returned value of the action creator.
+In the following diff the added code shows how to dispatch a [`script`](/reference/tevm/actions-types/type-aliases/scripthandler) action with a contract action creator. The removed code is both how you would do it without an action creator and also the returned value of the action creator.
 
 ```typescript
 - const scriptResult = await tevm.script({
@@ -25,8 +25,8 @@ In the following diff the added code shows how to dispatch a [`script`](../refer
 
 There are two ways to create a contract.
 
-1. Using the [`createScript`](../reference/@tevm/contract/functions/createScript.md) or [createContract](../reference/@tevm/contract/functions/createContract.md) utils.
-2. Automatically [generating scripts with the tevm bundler](./solidity-imports.md)
+1. Using the [`createScript`](/reference/tevm/contract/functions/createscript) or [createContract](/reference/tevm/contract/functions/createcontract) utils.
+2. Automatically [generating scripts with the tevm bundler](/learn/solidity-imports)
 
 To create a contract instance pass in it's human readable ABI and name into `createContract`. If creating a script you will also need to pass `bytecode` and `deployedBytecode`
 
@@ -41,7 +41,7 @@ const script = createScript({
 })
 ```
 
-Contracts and scripts are created with humanReadableAbi but you can also use a JSON abi via the [`formatAbi` utility](../reference/@tevm/contract/functions/formatAbi.md).
+Contracts and scripts are created with humanReadableAbi but you can also use a JSON abi via the [`formatAbi` utility](/reference/tevm/contract/functions/formatabi).
 
 ```typescript
 import { createScript, formatAbi } from 'tevm/contract'
@@ -62,14 +62,14 @@ const script = createScript({
 Because of how TypeScript processes JSON files you will lose typesafety if you import your ABI from a json file or don't use `as const`. A solution to the JSON import problem will exist in a future version.
 :::
 
-See the [contract reference docs](../reference/@tevm/contract/API.md) for more information on creating contracts.
+See the [contract reference docs](/reference/tevm/contract/api) for more information on creating contracts.
 
 ## Contracts vs scripts
 
 There are two types of contracts.  
 
-1. [Contracts](../reference/@tevm/contract/type-aliases/Contract.md) which are created with [createContract](../reference/@tevm/contract/functions/createContract.md)
-2. [Scripts](../reference/@tevm/contract/type-aliases/Script.md) which are created with [createScript](../reference/@tevm/contract/functions/createScript.md)
+1. [Contracts](/reference/tevm/contract/type-aliases/contract) which are created with [createContract](/reference/tevm/contract/functions/createcontract)
+2. [Scripts](/reference/tevm/contract/type-aliases/script) which are created with [createScript](/reference/tevm/contract/functions/createscript)
 
 The only difference between the two is `Scripts` have bytecode and can run without being deployed first. Contracts can only run with the bytecode already deployed to the chain. Contract actions require a `to` address that is used by the EVM to fetch the bytecode from storage.
 

--- a/docs/src/content/docs/learn/json-rpc/index.md
+++ b/docs/src/content/docs/learn/json-rpc/index.md
@@ -5,7 +5,7 @@ description: JSON Remote Procedure Calls
 
 ## JSON-RPC Requests
 
-All [clients](./clients.md) implement a [`tevm.request()`](../reference/@tevm/procedures-types/type-aliases/tevmjsonrpcrequesthandler.md) method for handling JSON-RPC requests.
+All [clients](/learn/clients) implement a [`tevm.request()`](/reference/tevm/procedures-types/type-aliases/tevmjsonrpcrequesthandler) method for handling JSON-RPC requests.
 
 ```typescript
 const {result, errors, id, method, jsonrpc} = await client.request({
@@ -22,70 +22,70 @@ Below are all procedures implemented or planned to be implemented. 🚧 means th
 
 Tevm methods are feature-rich methods that provide a high level of control over the VM.
 
-- [`tevm_call`](../reference/@tevm/procedures-types/type-aliases/calljsonrpcprocedure.md) - Similar to eth call but with additional properties to control the VM execution
-- [`tevm_getAccount`](../reference/@tevm/procedures-types/type-aliases/getaccountjsonrpcprocedure.md) - gets account information such as balances contract information nonces and state roots.
-- [`tevm_setAccount`](../reference/@tevm/procedures-types/type-aliases/setaccountjsonrpcprocedure.md) - directly modifies the state of an account
-- [`tevm_script`](../reference/@tevm/procedures-types/type-aliases/scriptjsonrpcprocedure.md) - Runs the provided bytecode against the EVM state
-- 🚧 [`tevm_traceContractCall`](../reference/@tevm/procedures-types/type-aliases/tracecontractcalljsonrpcprocedure.md) 
-- 🚧 [`tevm_traceScript`](../reference/@tevm/procedures-types/type-aliases/tracescriptjsonrpcprocedure.md) 
-- [`tevm_dumpState`](../reference/@tevm/procedures-types/type-aliases/dumpstatejsonrpcprocedure.md) - Returns the state of the VM
-- [`tevm_loadState`](../reference/@tevm/procedures-types/type-aliases/loadstatejsonrpcprocedure.md) - Initializes the state of the VM
+- [`tevm_call`](/reference/tevm/procedures-types/type-aliases/calljsonrpcprocedure) - Similar to eth call but with additional properties to control the VM execution
+- [`tevm_getAccount`](/reference/tevm/procedures-types/type-aliases/getaccountjsonrpcprocedure) - gets account information such as balances contract information nonces and state roots.
+- [`tevm_setAccount`](/reference/tevm/procedures-types/type-aliases/setaccountjsonrpcprocedure) - directly modifies the state of an account
+- [`tevm_script`](/reference/tevm/procedures-types/type-aliases/scriptjsonrpcprocedure) - Runs the provided bytecode against the EVM state
+- [`tevm_dumpState`](/reference/tevm/procedures-types/type-aliases/dumpstatejsonrpcprocedure) - Returns the state of the VM
+- [`tevm_loadState`](/reference/tevm/procedures-types/type-aliases/loadstatejsonrpcprocedure) - Initializes the state of the VM
+- 🚧 `tevm_traceContractCall`
+- 🚧 `tevm_traceScript`
 
 ## Eth methods
 
 Tevm plans on implementing most of the [ethereum JSON-RPC](https://ethereum.org/developers/docs/apis/json-rpc) spec
 
-- [`eth_chainId'](../reference/@tevm/procedures-types/type-aliases/ethchainidjsonrpcprocedure.md)
-- [`eth_call'](../reference/@tevm/procedures-types/type-aliases/ethcalljsonrpcprocedure.md)
-- [`eth_getCode'](../reference/@tevm/procedures-types/type-aliases/ethgetcodejsonrpcprocedure.md)
-- [`eth_getStorageAt'](../reference/@tevm/procedures-types/type-aliases/ethgetcodejsonrpcprocedure.md)
-- [`eth_gasPrice'](../reference/@tevm/procedures-types/type-aliases/ethgaspricejsonrpcprocedure.md)
-- [`eth_getBalance'](../reference/@tevm/procedures-types/type-aliases/ethgetbalancejsonrpcprocedure.md)
-- [`eth_estimateGas'](../reference/@tevm/procedures-types/type-aliases/ethestimategasjsonrpcprocedure.md)
-- 🚧 [`eth_sign'](../reference/@tevm/procedures-types/type-aliases/ethsignprocedure.md)
-- 🚧 [`eth_getLogs'](../reference/@tevm/procedures-types/type-aliases/ethgetlogsjsonrpcprocedure.md)
-- 🚧 [`eth_accounts'](../reference/@tevm/procedures-types/type-aliases/ethaccountsjsonrpcprocedure.md)
-- 🚧 [`eth_coinbase'](../reference/@tevm/procedures-types/type-aliases/ethcoinbasejsonrpcprocedure.md)
-- 🚧 [`eth_hashrate'](../reference/@tevm/procedures-types/type-aliases/ethhashratejsonrpcprocedure.md)
-- 🚧 [`eth_newFilter'](../reference/@tevm/procedures-types/type-aliases/ethnewfilterjsonrpcprocedure.md)
-- 🚧 [`eth_getFilterLogs'](../reference/@tevm/procedures-types/type-aliases/ethgetfilterlogsjsonrpcprocedure.md)
-- 🚧 [`eth_getBlockByHash'](../reference/@tevm/procedures-types/type-aliases/ethgetblockbyhashjsonrpcprocedure.md)
-- 🚧 [`eth_newBlockFilter'](../reference/@tevm/procedures-types/type-aliases/ethnewblockfilterjsonrpcprocedure.md)
-- 🚧 [`eth_protocolVersion'](../reference/@tevm/procedures-types/type-aliases/ethprotocolversionjsonrpcprocedure.md)
-- 🚧 [`eth_sendTransaction'](../reference/@tevm/procedures-types/type-aliases/ethsendtransactionjsonrpcprocedure.md)
-- 🚧 [`eth_signTransaction'](../reference/@tevm/procedures-types/type-aliases/ethsigntransactionjsonrpcprocedure.md)
-- 🚧 [`eth_uninstallFilter'](../reference/@tevm/procedures-types/type-aliases/ethuninstallfilterjsonrpcprocedure.md)
-- 🚧 [`eth_getBlockByNumber'](../reference/@tevm/procedures-types/type-aliases/ethgetblockbynumberjsonrpcprocedure.md)
-- 🚧 [`eth_getFilterChanges'](../reference/@tevm/procedures-types/type-aliases/ethgetfilterchangesjsonrpcprocedure.md)
-- 🚧 [`eth_sendRawTransaction'](../reference/@tevm/procedures-types/type-aliases/ethsendrawtransactionjsonrpcprocedure.md)
-- 🚧 [`eth_getTransactionCount'](../reference/@tevm/procedures-types/type-aliases/ethgettransactioncountjsonrpcprocedure.md)
-- 🚧 [`eth_getTransactionByHash'](../reference/@tevm/procedures-types/type-aliases/ethgettransactionbyhashjsonrpcprocedure.md)
-- 🚧 [`eth_getTransactionReceipt'](../reference/@tevm/procedures-types/type-aliases/ethgettransactionreceiptjsonrpcprocedure.md)
-- 🚧 [`eth_newPendingTransactionFilter'](../reference/@tevm/procedures-types/type-aliases/ethnewpendingtransactionfilterjsonrpcresponse.md)
-- 🚧 [`eth_getBlockTransactionCountByHash'](../reference/@tevm/procedures-types/type-aliases/ethgetblocktransactioncountbyhashjsonrpcprocedure.md)
-- 🚧 [`eth_getBlockTransactionCountByNumber'](../reference/@tevm/procedures-types/type-aliases/eth_getblocktransactioncountbynumber.md)
-- 🚧 [`eth_getTransactionByBlockHashAndIndex'](../reference/@tevm/procedures-types/type-aliases/ethgettransactionbyblockhashandindexjsonrpcprocedure.md)
-- 🚧 [`eth_getTransactionByBlockNumberAndIndex'](../reference/@tevm/procedures-types/type-aliases/ethtransactionbyblocknumberandindexjsonrpcprocedure.md)
+- [`eth_chainId'](/reference/tevm/procedures-types/type-aliases/ethchainidjsonrpcprocedure)
+- [`eth_call'](/reference/tevm/procedures-types/type-aliases/ethcalljsonrpcprocedure)
+- [`eth_getCode'](/reference/tevm/procedures-types/type-aliases/ethgetcodejsonrpcprocedure)
+- [`eth_getStorageAt'](/reference/tevm/procedures-types/type-aliases/ethgetcodejsonrpcprocedure)
+- [`eth_gasPrice'](/reference/tevm/procedures-types/type-aliases/ethgaspricejsonrpcprocedure)
+- [`eth_getBalance'](/reference/tevm/procedures-types/type-aliases/ethgetbalancejsonrpcprocedure)
+- [`eth_estimateGas'](/reference/tevm/procedures-types/type-aliases/ethestimategasjsonrpcprocedure)
+- 🚧 `eth_sign'
+- 🚧 [`eth_getLogs'](/reference/tevm/procedures-types/type-aliases/ethgetlogsjsonrpcprocedure)
+- 🚧 [`eth_accounts'](/reference/tevm/procedures-types/type-aliases/ethaccountsjsonrpcprocedure)
+- 🚧 [`eth_coinbase'](/reference/tevm/procedures-types/type-aliases/ethcoinbasejsonrpcprocedure)
+- 🚧 [`eth_hashrate'](/reference/tevm/procedures-types/type-aliases/ethhashratejsonrpcprocedure)
+- 🚧 [`eth_newFilter'](/reference/tevm/procedures-types/type-aliases/ethnewfilterjsonrpcprocedure)
+- 🚧 [`eth_getFilterLogs'](/reference/tevm/procedures-types/type-aliases/ethgetfilterlogsjsonrpcprocedure)
+- 🚧 [`eth_getBlockByHash'](/reference/tevm/procedures-types/type-aliases/ethgetblockbyhashjsonrpcprocedure)
+- 🚧 [`eth_newBlockFilter'](/reference/tevm/procedures-types/type-aliases/ethnewblockfilterjsonrpcprocedure)
+- 🚧 [`eth_protocolVersion'](/reference/tevm/procedures-types/type-aliases/ethprotocolversionjsonrpcprocedure)
+- 🚧 [`eth_sendTransaction'](/reference/tevm/procedures-types/type-aliases/ethsendtransactionjsonrpcprocedure)
+- 🚧 [`eth_signTransaction'](/reference/tevm/procedures-types/type-aliases/ethsigntransactionjsonrpcprocedure)
+- 🚧 [`eth_uninstallFilter'](/reference/tevm/procedures-types/type-aliases/ethuninstallfilterjsonrpcprocedure)
+- 🚧 [`eth_getBlockByNumber'](/reference/tevm/procedures-types/type-aliases/ethgetblockbynumberjsonrpcprocedure)
+- 🚧 [`eth_getFilterChanges'](/reference/tevm/procedures-types/type-aliases/ethgetfilterchangesjsonrpcprocedure)
+- 🚧 [`eth_sendRawTransaction'](/reference/tevm/procedures-types/type-aliases/ethsendrawtransactionjsonrpcprocedure)
+- 🚧 [`eth_getTransactionCount'](/reference/tevm/procedures-types/type-aliases/ethgettransactioncountjsonrpcprocedure)
+- 🚧 [`eth_getTransactionByHash'](/reference/tevm/procedures-types/type-aliases/ethgettransactionbyhashjsonrpcprocedure)
+- 🚧 [`eth_getTransactionReceipt'](/reference/tevm/procedures-types/type-aliases/ethgettransactionreceiptjsonrpcprocedure)
+- 🚧 [`eth_newPendingTransactionFilter'](/reference/tevm/procedures-types/type-aliases/ethnewpendingtransactionfilterjsonrpcresponse)
+- 🚧 [`eth_getBlockTransactionCountByHash'](/reference/tevm/procedures-types/type-aliases/ethgetblocktransactioncountbyhashjsonrpcprocedure)
+- 🚧 `eth_getBlockTransactionCountByNumber'
+- 🚧 [`eth_getTransactionByBlockHashAndIndex'](/reference/tevm/procedures-types/type-aliases/ethgettransactionbyblockhashandindexjsonrpcprocedure)
+- 🚧 `eth_getTransactionByBlockNumberAndIndex'
 
 ## Debug methods
 
-- 🚧 [`debug_traceTransaction`](../reference/@tevm/procedures-types/type-aliases/debugtracetransactionprocedure.md)
-- 🚧 [`debug_traceCall`](../reference/@tevm/procedures-types/type-aliases/debugtracecallprocedure.md)
+- 🚧 [`debug_traceTransaction`](/reference/tevm/procedures-types/type-aliases/debugtracetransactionprocedure)
+- 🚧 [`debug_traceCall`](/reference/tevm/procedures-types/type-aliases/debugtracecallprocedure)
 
 ## Anvil/Hardhat methods
 
 Anvil/hardhat methods are provided for compatability
 
-- 🚧 [`anvil_mine'](../reference/@tevm/procedures-types/type-aliases/anvilmineprocedure.md)
-- 🚧 [`anvil_reset'](../reference/@tevm/procedures-types/type-aliases/anvilresetprocedure.md)
-- 🚧 [`anvil_setCode'](../reference/@tevm/procedures-types/type-aliases/anvilsetcodeprocedure.md)
-- 🚧 [`anvil_setNonce'](../reference/@tevm/procedures-types/type-aliases/anvilsetnonceprocedure.md)
-- 🚧 [`anvil_dumpState'](../reference/@tevm/procedures-types/type-aliases/anvildumpstateprocedure.md)
-- 🚧 [`anvil_loadState'](../reference/@tevm/procedures-types/type-aliases/anvilloadstateprocedure.md)
-- 🚧 [`anvil_setBalance'](../reference/@tevm/procedures-types/type-aliases/anvilsetbalanceprocedure.md)
-- 🚧 [`anvil_setChainId'](../reference/@tevm/procedures-types/type-aliases/anvilsetchainidprocedure.md)
-- 🚧 [`anvil_getAutomine'](../reference/@tevm/procedures-types/type-aliases/anvilgetautomineprocedure.md)
-- 🚧 [`anvil_setStorageAt'](../reference/@tevm/procedures-types/type-aliases/anvilsetstorageatprocedure.md)
-- 🚧 [`anvil_dropTransaction'](../reference/@tevm/procedures-types/type-aliases/anvildroptransactionprocedure.md)
-- 🚧 [`anvil_impersonateAccount'](../reference/@tevm/procedures-types/type-aliases/anvilimpersonateaccountprocedure.md)
-- 🚧 [`anvil_stopImpersonatingAccount'](../reference/@tevm/procedures-types/type-aliases/anvilstopimpersonatingaccountprocedure.md)
+- 🚧 [`anvil_mine'](/reference/tevm/procedures-types/type-aliases/anvilmineprocedure)
+- 🚧 [`anvil_reset'](/reference/tevm/procedures-types/type-aliases/anvilresetprocedure)
+- 🚧 [`anvil_setCode'](/reference/tevm/procedures-types/type-aliases/anvilsetcodeprocedure)
+- 🚧 [`anvil_setNonce'](/reference/tevm/procedures-types/type-aliases/anvilsetnonceprocedure)
+- 🚧 [`anvil_dumpState'](/reference/tevm/procedures-types/type-aliases/anvildumpstateprocedure)
+- 🚧 [`anvil_loadState'](/reference/tevm/procedures-types/type-aliases/anvilloadstateprocedure)
+- 🚧 [`anvil_setBalance'](/reference/tevm/procedures-types/type-aliases/anvilsetbalanceprocedure)
+- 🚧 [`anvil_setChainId'](/reference/tevm/procedures-types/type-aliases/anvilsetchainidprocedure)
+- 🚧 [`anvil_getAutomine'](/reference/tevm/procedures-types/type-aliases/anvilgetautomineprocedure)
+- 🚧 [`anvil_setStorageAt'](/reference/tevm/procedures-types/type-aliases/anvilsetstorageatprocedure)
+- 🚧 [`anvil_dropTransaction'](/reference/tevm/procedures-types/type-aliases/anvildroptransactionprocedure)
+- 🚧 [`anvil_impersonateAccount'](/reference/tevm/procedures-types/type-aliases/anvilimpersonateaccountprocedure)
+- 🚧 [`anvil_stopImpersonatingAccount'](/reference/tevm/procedures-types/type-aliases/anvilstopimpersonatingaccountprocedure)

--- a/docs/src/content/docs/learn/reference/index.md
+++ b/docs/src/content/docs/learn/reference/index.md
@@ -14,9 +14,9 @@ All buildtime packages like the typescript or webpack plugin are similarly avail
 
 All clients share the `TevmClient` api which is how you interact with the EVM. The following reference docs contain it's api.
 
-- [@tevm/client-types](/reference/tevm/client-types/api/) - Contains the [TevmClient](../../reference/@tevm/client-types/type-aliases/tevmclient) all `Clients` share. This is usually the best place to start.
-- [@tevm/actions-types](/reference/tevm/actions-types/api/) - Contains the [actions api](../actions) definitions
-- [@tevm/procedures-types](/reference/tevm/procedures-types/api/) - Contains the [JSON-RPC](../json-rpc/) definitions
+- [@tevm/client-types](/reference/tevm/client-types/api/) - Contains the [TevmClient](/reference/tevm/client-types/type-aliases/tevmclient) all `Clients` share. This is usually the best place to start.
+- [@tevm/actions-types](/reference/tevm/actions-types/api/) - Contains the [actions api](/learn/actions) definitions
+- [@tevm/procedures-types](/reference/tevm/procedures-types/api/) - Contains the [JSON-RPC](/learn/json-rpc/) definitions
 
 ## Clients
 
@@ -32,7 +32,7 @@ There are also extension clients for [viem](https://viem.sh) and [ethers](https:
 
 ## Contracts
 
-A common way of using `contract action` with tevm is Tevm [`Contracts` and `Scripts`](../contracts/). They are defined in the `@tevm/contracts` package
+A common way of using `contract action` with tevm is Tevm [`Contracts` and `Scripts`](/learn/contracts/). They are defined in the `@tevm/contracts` package
 
 - [@tevm/contract](/reference/tevm/contract/api/)
 
@@ -49,7 +49,7 @@ The following internal packages contain the majority of the implementation code.
 
 ## @tevm/bundler
 
-To configure your bundler setup navigate to your bundler's plugins docs [`@tevm/*-plugin`](../../reference/@tevm/vite-plugin/api)
+To configure your bundler setup navigate to your bundler's plugins docs [`@tevm/*-plugin`](/reference/tevm/vite-plugin/api)
 
 - [@tevm/bun-plugin](/reference/tevm/bun-plugin/api/)
 - [@tevm/esbuild-plugin](/reference/tevm/esbuild-plugin/api/)
@@ -58,7 +58,7 @@ To configure your bundler setup navigate to your bundler's plugins docs [`@tevm/
 - [@tevm/vite-plugin](/reference/tevm/vite-plugin/api/)
 - [@tevm/webpack-plugin](/reference/tevm/webpack-plugin/api/)
 
-There is also config documentation below but you are most likely only interested in the [CompilerConfig](../../reference/@tevm/config/types/type-aliases/CompilerConfig.md) docs.
+There is also config documentation below but you are most likely only interested in the [CompilerConfig](/reference/tevm/config/types/type-aliases/compilerconfig) docs.
 
 - [@tevm/config](/reference/tevm/config/api/)
 

--- a/docs/src/content/docs/learn/solidity-imports/index.md
+++ b/docs/src/content/docs/learn/solidity-imports/index.md
@@ -9,7 +9,7 @@ Solidity imports simplify your tevm code via compiling contracts to ABI and byte
 
 To support solidity imports the following steps must be taken:
 
-1. Configure a [bundler](https://dev.to/sayanide/the-what-why-and-how-of-javascript-bundlers-4po9) to turn your solidity imports into [tevm scripts](../reference/@tevm/contract/type-aliases/script.md).
+1. Configure a [bundler](https://dev.to/sayanide/the-what-why-and-how-of-javascript-bundlers-4po9) to turn your solidity imports into [tevm scripts](/reference/tevm/contract/type-aliases/script).
 2. Configure your [TypeScript LSP](https://microsoft.github.io/language-server-protocol/) to recognize solidity imports correctly as well
 3. Optionally Configure your `tevm.config.json`
 4. Some may need to configure their editor
@@ -38,7 +38,7 @@ npm install @tevm/rollup-plugin
 
 #### Core bundler
 
-A JavaScript bundler is code that runs at buildtime to turn an import graph into a single file or multiple files. [@tevm/base-bundler](https://github.com/evmts/tevm-monorepo/tree/main/bundler-packages/base-bundler) turns Solidity imports into [tevm script instances](../reference/@tevm/contract/type-aliases/script.md). The core Tevm bundler code is reused to build every bundler integration.
+A JavaScript bundler is code that runs at buildtime to turn an import graph into a single file or multiple files. [@tevm/base-bundler](https://github.com/evmts/tevm-monorepo/tree/main/bundler-packages/base-bundler) turns Solidity imports into [tevm script instances](/reference/tevm/contract/type-aliases/script). The core Tevm bundler code is reused to build every bundler integration.
 
 1. On initialization tevm bundler and LSP will load your tsconfig (to read basedir and paths), foundry remappings (if configured), and `tevm.config.json` if present
 
@@ -54,7 +54,7 @@ import {ERC20} from '@openzeppelin/contracts/tokens/ERC20/ERC20.sol'
 
 5. If content has changed it will then pass in all the relavent contract code into [solc](https://github.com/evmts/tevm-monorepo/tree/main/bundler-packages/solc)
 
-6. Once it gets the artifacts it will then use the [@tevm/contracts](./contracts.md) to turn the artifacts into a `TevmContract` or `TevmScript` via the [@tevm/runtime] package. The runtime code will look like the following:
+6. Once it gets the artifacts it will then use the [@tevm/contracts](/learn/contracts) to turn the artifacts into a `TevmContract` or `TevmScript` via the [@tevm/runtime] package. The runtime code will look like the following:
 
 ```javascript
 import { createContract } from '@tevm/contract'
@@ -96,12 +96,12 @@ The TypeScript plugin generates a similar dts file.
 
 The [@tevm/base-bundler](https://github.com/evmts/tevm-monorepo/tree/main/bundler-packages/base-bundler) is used to create the following bundler integrations. Click on your bundler of choice to see the reference docs for your bundler.
 
-- [bun](../reference/@tevm/bun-plugin/functions/bunplugintevm.md) 
-- [esbuild](../reference/@tevm/esbuild-plugin/functions/bunplugintevm.md) 
-- [rollup](../reference/@tevm/rollup-plugin/functions/bunplugintevm.md) 
-- [vite](../reference/@tevm/vite-plugin/functions/bunplugintevm.md) 
-- [rspack](../reference/@tevm/rspack-plugin/functions/bunplugintevm.md) 
-- [webpack](../reference/@tevm/esbuild-plugin/functions/bunplugintevm.md) 
+- [bun](/reference/tevm/bun-plugin/functions/bunplugintevm) 
+- [esbuild](/reference/tevm/esbuild-plugin/functions/esbuildplugintevm) 
+- [rollup](/reference/tevm/rollup-plugin/functions/rollupplugintevm) 
+- [vite](/reference/tevm/vite-plugin/functions/viteplugintevm) 
+- [rspack](/reference/tevm/rspack-plugin/functions/rspackplugintevm) 
+- [webpack](/reference/tevm/webpack-plugin/variables/webpackplugintevm) 
 
 If your bundler is not supported consider [opening an issue](https://github.com/evmts/tevm-monorepo/issues/new) as it is likely a small lift to add support.
 
@@ -146,7 +146,7 @@ Tevm is currently unable to resolve nested foundry projects such as installing a
 
 ## tevm.config.json
 
-Tevm compiler offers some advanced configuration via the `tevm.config.json` file. This single configuration will be read by both your bundler and the typescript plugin. For configuration options see the [CompilerConfig reference docs](../reference/@tevm/config/types/type-aliases/CompilerConfig.md).
+Tevm compiler offers some advanced configuration via the `tevm.config.json` file. This single configuration will be read by both your bundler and the typescript plugin. For configuration options see the [CompilerConfig reference docs](/reference/tevm/config/types/type-aliases/compilerconfig).
 
 ## 🚧 Typechecking
 


### PR DESCRIPTION
## Description

Fix all broken links in reference docs

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a link checker that can be enabled or disabled via configuration to validate internal documentation links.

- **Documentation**
  - Updated links in the Getting Started guide to use absolute paths for Tevm references.
  - Revised links within the main documentation index to absolute URLs.
  - Corrected URLs in the Actions documentation and marked certain methods as under construction.
  - Updated hyperlinks in the Clients section to point to the correct documentation resources.
  - Refreshed Contracts section links to point to the updated `@tevm/contracts` package resources.
  - Standardized JSON-RPC section links to use absolute paths.
  - Updated various reference links within the Reference section to point to new documentation locations.
  - Modified URLs in the Solidity Imports documentation for improved resource referencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->