### PR TITLE
:memo: Docs: Document the default gas limit

### DIFF
--- a/docs/src/content/docs/reference/@tevm/actions-types/type-aliases/BaseCallParams.md
+++ b/docs/src/content/docs/reference/@tevm/actions-types/type-aliases/BaseCallParams.md
@@ -47,6 +47,7 @@ those options. Otherwise both are set to the `from` address
 > **gas**?: `bigint`
 
 The gas limit for the call.
+Defaults to 0xffffff (16_777_215n)
 
 ### gasPrice
 

--- a/packages/actions-types/docs/type-aliases/BaseCallParams.md
+++ b/packages/actions-types/docs/type-aliases/BaseCallParams.md
@@ -48,6 +48,7 @@ those options. Otherwise both are set to the `from` address
 > **gas**?: `bigint`
 
 The gas limit for the call.
+Defaults to 0xffffff (16_777_215n)
 
 ### gasPrice
 

--- a/packages/actions-types/src/params/BaseCallParams.ts
+++ b/packages/actions-types/src/params/BaseCallParams.ts
@@ -13,6 +13,7 @@ export type BaseCallParams = {
 	skipBalance?: boolean
 	/**
 	 * The gas limit for the call.
+	 * Defaults to 0xffffff (16_777_215n)
 	 */
 	gas?: bigint
 	/**

--- a/packages/memory-client/src/createMemoryClient.js
+++ b/packages/memory-client/src/createMemoryClient.js
@@ -101,9 +101,9 @@ export const createMemoryClient = async (options = {}) => {
 			header: common.genesis(),
 			...(common.isActivatedEIP(4895)
 				? {
-					withdrawals:
+						withdrawals:
 							/** @type {Array<import('@ethereumjs/util').WithdrawalData>}*/ ([]),
-				}
+				  }
 				: {}),
 		},
 		{ common, setHardfork: false, skipConsensusFormatValidation: true },
@@ -217,12 +217,12 @@ export const createMemoryClient = async (options = {}) => {
 
 	// add test accounts
 	await Promise.all(
-		testAccounts.map(account => {
+		testAccounts.map((account) => {
 			return tevm.setAccount({
 				balance: parseEther('1000'),
 				address: account.address,
 			})
-		})
+		}),
 	)
 
 	return tevm

--- a/tevm/docs/actions-types/type-aliases/BaseCallParams.md
+++ b/tevm/docs/actions-types/type-aliases/BaseCallParams.md
@@ -48,6 +48,7 @@ those options. Otherwise both are set to the `from` address
 > **gas**?: `bigint`
 
 The gas limit for the call.
+Defaults to 0xffffff (16_777_215n)
 
 ### gasPrice
 


### PR DESCRIPTION
## Description

Default gas limit was implicit. We don't set this default ethereumjs sets it. We should consider defaulting to 30mm (the block limit for mainnet and op stack)

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

