### PR TITLE
:bug: Bug: Load tevm.config.json files

### DIFF
--- a/.changeset/few-trains-allow.md
+++ b/.changeset/few-trains-allow.md
@@ -1,0 +1,5 @@
+---
+"@tevm/config": minor
+---
+
+Added ability to read tevm.config.json as well as tevm.json files


### PR DESCRIPTION
## Description

Load tevm.config.json and tevm.json in that order of preference

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the capability to read configuration from `tevm.config.json` alongside `tevm.json`.
- **Refactor**
	- Improved error messaging in configuration loading to specify the config file being read.
	- Enhanced the configuration loading process to support multiple file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->