### PR TITLE
docs(quick-start): add `"latest"` to all the `eth_getBalance` calls

### DIFF
--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -94,7 +94,7 @@ const request: EthGetBalanceJsonRpcRequest = {
   jsonrpc: '2.0',
   id: 1,
   method: 'eth_getBalance',
-  params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]
+  params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]
 }
 ```
 
@@ -149,7 +149,7 @@ const request: EthGetBalanceJsonRpcRequest = {
   jsonrpc: '2.0',
   id: 1,
   method: 'eth_getBalance',
-  params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]
+  params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]
 }
 
 const response = await tevm.request(request)
@@ -177,7 +177,7 @@ fetch("https://mainnet.optimism.io", {
     jsonrpc: '2.0',
     id: 1,
     method: 'eth_getBalance',
-    params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]
+    params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]
   })
 })
   .then(response => response.json())
@@ -206,7 +206,7 @@ const tevm = createMemoryClient({
 -   jsonrpc: '2.0',
 -   id: 1,
 -   method: 'eth_getBalance',
--   params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]
+-   params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]
 - }
 + const address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 


### PR DESCRIPTION
## Description

`EthGetBalanceJsonRpcRequest` calls require two values in `params`:

1. Address
2. Block tag (number or "latest", "earliest", etc.).

However, some of the calls in the quickstart don't have the block tag, which causes the code to fail.

## Testing

The original code produces this error:

```
747 |   method: req.method,
748 |   result: await gasPriceHandler({ getVm, forkUrl })({}).then(numberToHex)
749 | });
750 | var getBalanceProcedure = ({ getVm, forkUrl }) => async (req) => {
751 |   if (!req.params[1]) {
752 |     throw new Error(
                ^
error: getBalanceProcedure received invalid parameters: Block parameter (req.params[1]) is missing or invalid. Expected a hex string or block tag (e.g., "latest", "earliest").
      at /Users/qbzzt/src/tevm-app/node_modules/@tevm/procedures/dist/index.js:752:11
      at /Users/qbzzt/src/tevm-app/node_modules/@tevm/procedures/dist/index.js:750:58
      at /Users/qbzzt/src/tevm-app/node_modules/@tevm/procedures/dist/index.js:72:17
      at /Users/qbzzt/src/tevm-app/node_modules/@tevm/decorators/dist/index.js:105:30
      at /Users/qbzzt/src/tevm-app/node_modules/@tevm/decorators/dist/index.js:104:36
      at /Users/qbzzt/src/tevm-app/node_modules/viem/_esm/utils/promise/withRetry.js:12:36
      at attemptRetry (/Users/qbzzt/src/tevm-app/node_modules/viem/_esm/utils/promise/withRetry.js:4:39)
      at /Users/qbzzt/src/tevm-app/node_modules/viem/_esm/utils/promise/withRetry.js:9:17
```

When `"latest"` is added, you get this value in the response: `0x1b747735ea18e63` (a.k.a. 123646075610435171 wei).

## Additional Information

- [x] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: `qbzzt.eth`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Quick Start guide to include the "latest" parameter in `eth_getBalance` JSON-RPC requests examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->