### PR TITLE
:clown_face: Chore: Disable opstack tests for now

### DIFF
--- a/extensions/opstack/package.json
+++ b/extensions/opstack/package.json
@@ -59,7 +59,7 @@
 		"lint:package": "bunx publint --strict && attw --pack",
 		"package:up": "pnpm up --latest",
 		"test": "bun test --watch",
-		"test:coverage": "bun test --coverage",
+		"//test:coverage": "bun test --coverage",
 		"test:run": "bun test",
 		"typecheck": "tsc --noEmit"
 	},


### PR DESCRIPTION
## Description

Bug in the nx cache has caused the opstack tests to be broken for a while now. The tests do not mine blocks and thus should have broken on the mine blocks pr

Disable for now

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

