### PR TITLE
:loud_sound: Fix: add try catch to revert data decoding

### DIFF
--- a/packages/actions/src/tevm/contractHandler.js
+++ b/packages/actions/src/tevm/contractHandler.js
@@ -116,15 +116,23 @@ export const contractHandler =
               err,
               'contractHandler: Contract revert error. Decoding the error',
             )
-            const decodedError = decodeErrorResult(
+            /**
+             * @type {undefined |ReturnType<typeof decodeErrorResult>}
+             */
+            let decodedError = undefined
+            try {
+              decodedError = decodeErrorResult(
 						/** @type {any} */({
-                abi: params.abi,
-                data: err.message,
-                functionName: params.functionName,
-              }),
-            )
-            const message = `Revert: ${decodedError.errorName} ${JSON.stringify(
-              decodedError,
+                  abi: params.abi,
+                  data: err.message,
+                  functionName: params.functionName,
+                }),
+              )
+            } catch (e) {
+              client.logger.debug(e, 'There was an error decoding error result')
+            }
+            const message = `Revert: ${decodedError?.errorName ?? `There was a revert with no revert message ${err.message}`} ${JSON.stringify(
+              decodedError ?? err,
             )}`
             client.logger.debug(message, 'Revert message decoded')
             return {

--- a/packages/memory-client/src/test/viemPublicActions.spec.ts
+++ b/packages/memory-client/src/test/viemPublicActions.spec.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { simpleContract } from '@tevm/test-utils'
+import { type PublicActions, encodeFunctionData } from 'viem'
+import type { MemoryClient } from '../MemoryClient.js'
+import { createMemoryClient } from '../createMemoryClient.js'
+
+describe('viemPublicActions', () => {
+	let mc: MemoryClient
+	let c = {
+		simpleContract: simpleContract.withAddress(`0x${'00'.repeat(20)}`),
+	}
+
+	beforeEach(async () => {
+		mc = createMemoryClient()
+		const deployResult = await mc.tevmDeploy({
+			bytecode: simpleContract.bytecode,
+			abi: simpleContract.abi,
+			args: [420n],
+		})
+		if (!deployResult.createdAddress) {
+			throw new Error('contract never deployed')
+		}
+		c = {
+			simpleContract: simpleContract.withAddress(deployResult.createdAddress),
+		}
+		await mc.tevmMine()
+	})
+
+	const tests: Record<keyof PublicActions, () => void> = {
+		call: () => {
+			it('should work', async () => {
+				expect(
+					await mc.call({
+						to: c.simpleContract.address,
+						data: encodeFunctionData(simpleContract.read.get()),
+					}),
+				).toEqual({
+					data: '0x00000000000000000000000000000000000000000000000000000000000001a4',
+				})
+			})
+		},
+		createBlockFilter: () => {
+			it.todo('not supported')
+		},
+		createContractEventFilter: () => {
+			it.todo('not supported')
+		},
+		createEventFilter: () => {
+			it.todo('not supported')
+		},
+		createPendingTransactionFilter: () => {
+			it.todo('not supported')
+		},
+		estimateContractGas: () => {
+			it('should work', async () => {
+				expect(await mc.estimateContractGas(c.simpleContract.write.set(69n))).toBe(16771823n)
+			})
+		},
+		estimateFeesPerGas: () => {},
+		estimateGas: () => {},
+		estimateMaxPriorityFeePerGas: () => {},
+		getBalance: () => {},
+		getBlobBaseFee: () => {},
+		getBlock: () => {},
+		getBlockNumber: () => {},
+		getBlockTransactionCount: () => {},
+		getBytecode: () => {},
+		getChainId: () => {},
+		getContractEvents: () => {},
+		getEnsAddress: () => {},
+		getEnsAvatar: () => {},
+		getEnsName: () => {},
+		getEnsResolver: () => {},
+		getEnsText: () => {},
+		getFeeHistory: () => {},
+		getFilterChanges: () => {},
+		getFilterLogs: () => {},
+		getGasPrice: () => {},
+		getLogs: () => {},
+		getProof: () => {},
+		getStorageAt: () => {},
+		getTransaction: () => {},
+		getTransactionConfirmations: () => {},
+		getTransactionCount: () => {},
+		getTransactionReceipt: () => {},
+		multicall: () => {},
+		prepareTransactionRequest: () => {},
+		readContract: () => {},
+		sendRawTransaction: () => {},
+		simulateContract: () => {},
+		uninstallFilter: () => {},
+		verifyMessage: () => {},
+		verifyTypedData: () => {},
+		watchContractEvent: () => {},
+		waitForTransactionReceipt: () => {},
+		watchBlockNumber: () => {},
+		watchBlocks: () => {},
+		watchEvent: () => {},
+		watchPendingTransactions: () => {},
+	}
+
+	Object.entries(tests).forEach(([actionName, actionTests]) => {
+		describe(actionName, actionTests)
+	})
+})


### PR DESCRIPTION
### TL;DR

Fixes a bug where reverts without messages throw

Add error transparency when decoding revert messages in TEVM contract handler, enriching the debugging process.

### What changed?

Improved error handling in contractHandler.js, added a try-catch block to safely handle decoding revert messages that can cause unforeseen exceptions. Now, if there is an issue during decoding, an appropriate message is logged.

### How to test?

1. Clone the PR branch
2. Install dependencies: `npm install`
3. Run the tests for contractHandler: `npm run test-contractHandler`

### Why make this change?

Better error transparency during decoding revert messages in TEVM contract handlers can help the debugging process, especially in complex TEVM applications where revert messages can be cryptic and can contain errors themselves.

---

## Description

_Concise description of proposed changes_

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

