### PR TITLE
:zap: Feat: Optimize state manager peformance and caching

### DIFF
--- a/.changeset/fair-weeks-glow.md
+++ b/.changeset/fair-weeks-glow.md
@@ -1,0 +1,19 @@
+---
+"@tevm/memory-client": patch
+"@tevm/base-client": patch
+"@tevm/state": patch
+---
+
+Made major improvements to tevm performance
+
+before: 2.38s
+after: 0.83s
+
+before: 6.69s
+after: 0.683s
+
+before: 8.42s
+after: 0.219s
+
+before: 4.07s
+after: 0.01s

--- a/docs/src/content/docs/reference/@tevm/state/classes/ContractCache.md
+++ b/docs/src/content/docs/reference/@tevm/state/classes/ContractCache.md
@@ -24,7 +24,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:10](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L10)
+[packages/state/src/ContractCache.js:11](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L11)
 
 ## Properties
 
@@ -34,7 +34,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:16](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L16)
+[packages/state/src/ContractCache.js:17](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L17)
 
 ## Accessors
 
@@ -48,7 +48,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:65](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L65)
+[packages/state/src/ContractCache.js:75](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L75)
 
 ## Methods
 
@@ -62,7 +62,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:61](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L61)
+[packages/state/src/ContractCache.js:62](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L62)
 
 ***
 
@@ -76,7 +76,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:29](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L29)
+[packages/state/src/ContractCache.js:30](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L30)
 
 ***
 
@@ -90,7 +90,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:22](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L22)
+[packages/state/src/ContractCache.js:23](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L23)
 
 ***
 
@@ -108,7 +108,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:54](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L54)
+[packages/state/src/ContractCache.js:55](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L55)
 
 ***
 
@@ -126,7 +126,27 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:37](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L37)
+[packages/state/src/ContractCache.js:38](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L38)
+
+***
+
+### has()
+
+> **has**(`address`): `boolean`
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+#### Returns
+
+`boolean`
+
+if the cache has the key
+
+#### Source
+
+[packages/state/src/ContractCache.js:70](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L70)
 
 ***
 
@@ -146,7 +166,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:46](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L46)
+[packages/state/src/ContractCache.js:47](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L47)
 
 ***
 
@@ -160,7 +180,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:76](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L76)
+[packages/state/src/ContractCache.js:86](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L86)
 
 ***
 
@@ -174,4 +194,4 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:69](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L69)
+[packages/state/src/ContractCache.js:79](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L79)

--- a/docs/src/content/docs/reference/@tevm/state/functions/checkpoint.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/checkpoint.md
@@ -5,7 +5,7 @@ prev: false
 title: "checkpoint"
 ---
 
-> **checkpoint**(`baseState`): () => `Promise`\<`void`\>
+> **checkpoint**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`void`\>
 
 Checkpoints the current change-set to the instance since the
 last call to checkpoint.
@@ -13,6 +13,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/clearCaches.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/clearCaches.md
@@ -5,13 +5,15 @@ prev: false
 title: "clearCaches"
 ---
 
-> **clearCaches**(`baseState`): () => `void`
+> **clearCaches**(`baseState`, `skipFetchingFromFork`?): () => `void`
 
 Resets all internal caches
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/clearContractStorage.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/clearContractStorage.md
@@ -5,13 +5,15 @@ prev: false
 title: "clearContractStorage"
 ---
 
-> **clearContractStorage**(`baseState`): (`address`) => `Promise`\<`void`\>
+> **clearContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`void`\>
 
 Clears all storage entries for the account corresponding to `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/commit.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/commit.md
@@ -5,7 +5,7 @@ prev: false
 title: "commit"
 ---
 
-> **commit**(`baseState`): (`createNewStateRoot`?) => `Promise`\<`void`\>
+> **commit**(`baseState`, `skipFetchingFromFork`?): (`createNewStateRoot`?) => `Promise`\<`void`\>
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -13,6 +13,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/deleteAccount.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/deleteAccount.md
@@ -5,13 +5,15 @@ prev: false
 title: "deleteAccount"
 ---
 
-> **deleteAccount**(`baseState`): (`address`) => `Promise`\<`void`\>
+> **deleteAccount**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`void`\>
 
 Deletes an account from state under the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/dumpCanonicalGenesis.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/dumpCanonicalGenesis.md
@@ -5,13 +5,15 @@ prev: false
 title: "dumpCanonicalGenesis"
 ---
 
-> **dumpCanonicalGenesis**(`baseState`): () => `Promise`\<[`TevmState`](/reference/tevm/state/type-aliases/tevmstate/)\>
+> **dumpCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<[`TevmState`](/reference/tevm/state/type-aliases/tevmstate/)\>
 
 Dumps the state of the state manager as a [TevmState](../../../../../../../reference/tevm/state/type-aliases/tevmstate)
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/dumpStorage.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/dumpStorage.md
@@ -5,7 +5,7 @@ prev: false
 title: "dumpStorage"
 ---
 
-> **dumpStorage**(`baseState`): (`address`) => `Promise`\<[`StorageDump`](/reference/tevm/common/interfaces/storagedump/)\>
+> **dumpStorage**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<[`StorageDump`](/reference/tevm/common/interfaces/storagedump/)\>
 
 Dumps the RLP-encoded storage values for an `account` specified by `address`.
 Keys are the storage keys, values are the storage values as strings.
@@ -14,6 +14,8 @@ Both are represented as `0x` prefixed hex strings.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/dumpStorageRange.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/dumpStorageRange.md
@@ -5,11 +5,13 @@ prev: false
 title: "dumpStorageRange"
 ---
 
-> **dumpStorageRange**(`baseState`): (`address`, `startKey`, `limit`) => `Promise`\<[`StorageRange`](/reference/tevm/common/interfaces/storagerange/)\>
+> **dumpStorageRange**(`baseState`, `skipFetchingFromFork`?): (`address`, `startKey`, `limit`) => `Promise`\<[`StorageRange`](/reference/tevm/common/interfaces/storagerange/)\>
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/generateCanonicalGenesis.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/generateCanonicalGenesis.md
@@ -5,13 +5,15 @@ prev: false
 title: "generateCanonicalGenesis"
 ---
 
-> **generateCanonicalGenesis**(`baseState`): (`initState`) => `Promise`\<`void`\>
+> **generateCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): (`initState`) => `Promise`\<`void`\>
 
 Loads a [TevmState](../../../../../../../reference/tevm/state/type-aliases/tevmstate) into the state manager
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/getAccount.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getAccount.md
@@ -5,13 +5,15 @@ prev: false
 title: "getAccount"
 ---
 
-> **getAccount**(`baseState`): (`address`) => `Promise`\<`undefined` \| [`EthjsAccount`](/reference/tevm/utils/classes/ethjsaccount/)\>
+> **getAccount**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`undefined` \| [`EthjsAccount`](/reference/tevm/utils/classes/ethjsaccount/)\>
 
 Gets the code corresponding to the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/getAccountAddresses.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getAccountAddresses.md
@@ -5,11 +5,13 @@ prev: false
 title: "getAccountAddresses"
 ---
 
-> **getAccountAddresses**(`baseState`): () => \`0x$\{string\}\`[]
+> **getAccountAddresses**(`baseState`, `skipFetchingFromFork`?): () => \`0x$\{string\}\`[]
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/getAppliedKey.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getAppliedKey.md
@@ -5,7 +5,7 @@ prev: false
 title: "getAppliedKey"
 ---
 
-> **getAppliedKey**(`baseState`): `undefined` \| (`address`) => `Uint8Array`
+> **getAppliedKey**(`baseState`, `skipFetchingFromFork`?): `undefined` \| (`address`) => `Uint8Array`
 
 :::caution[Deprecated]
 Returns the applied key for a given address
@@ -15,6 +15,8 @@ Used for saving preimages
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/getContractCode.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getContractCode.md
@@ -5,7 +5,7 @@ prev: false
 title: "getContractCode"
 ---
 
-> **getContractCode**(`baseState`): (`address`) => `Promise`\<`Uint8Array`\>
+> **getContractCode**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`Uint8Array`\>
 
 Gets the code corresponding to the provided `address`.
 Returns an empty `Uint8Array` if the account has no associated code.
@@ -13,6 +13,8 @@ Returns an empty `Uint8Array` if the account has no associated code.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -28,4 +30,4 @@ Returns an empty `Uint8Array` if the account has no associated code.
 
 ## Source
 
-[packages/state/src/actions/getContractCode.js:11](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractCode.js#L11)
+[packages/state/src/actions/getContractCode.js:13](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractCode.js#L13)

--- a/docs/src/content/docs/reference/@tevm/state/functions/getContractStorage.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getContractStorage.md
@@ -5,7 +5,7 @@ prev: false
 title: "getContractStorage"
 ---
 
-> **getContractStorage**(`baseState`): (`address`, `key`) => `Promise`\<`Uint8Array`\>
+> **getContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`, `key`) => `Promise`\<`Uint8Array`\>
 
 Gets the storage value associated with the provided `address` and `key`. This method returns
 the shortest representation of the stored value.
@@ -15,6 +15,8 @@ If this does not exist an empty `Uint8Array` is returned.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -32,4 +34,4 @@ If this does not exist an empty `Uint8Array` is returned.
 
 ## Source
 
-[packages/state/src/actions/getContractStorage.js:13](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractStorage.js#L13)
+[packages/state/src/actions/getContractStorage.js:14](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractStorage.js#L14)

--- a/docs/src/content/docs/reference/@tevm/state/functions/getProof.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getProof.md
@@ -5,13 +5,15 @@ prev: false
 title: "getProof"
 ---
 
-> **getProof**(`baseState`): (`address`, `storageSlots`?) => `Promise`\<`Proof`\>
+> **getProof**(`baseState`, `skipFetchingFromFork`?): (`address`, `storageSlots`?) => `Promise`\<`Proof`\>
 
 Get an EIP-1186 proof from the provider
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/getStateRoot.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getStateRoot.md
@@ -5,13 +5,15 @@ prev: false
 title: "getStateRoot"
 ---
 
-> **getStateRoot**(`baseState`): () => `Promise`\<`Uint8Array`\>
+> **getStateRoot**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`Uint8Array`\>
 
 Gets the current state root
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/hasStateRoot.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/hasStateRoot.md
@@ -5,13 +5,15 @@ prev: false
 title: "hasStateRoot"
 ---
 
-> **hasStateRoot**(`baseState`): (`root`) => `Promise`\<`boolean`\>
+> **hasStateRoot**(`baseState`, `skipFetchingFromFork`?): (`root`) => `Promise`\<`boolean`\>
 
 Returns true if state root exists
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/modifyAccountFields.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/modifyAccountFields.md
@@ -5,7 +5,7 @@ prev: false
 title: "modifyAccountFields"
 ---
 
-> **modifyAccountFields**(`baseState`): (`address`, `accountFields`) => `Promise`\<`void`\>
+> **modifyAccountFields**(`baseState`, `skipFetchingFromFork`?): (`address`, `accountFields`) => `Promise`\<`void`\>
 
 Gets the account associated with `address`, modifies the given account
 fields, then saves the account into state. Account fields can include
@@ -14,6 +14,8 @@ fields, then saves the account into state. Account fields can include
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/originalStorageCache.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/originalStorageCache.md
@@ -5,7 +5,7 @@ prev: false
 title: "originalStorageCache"
 ---
 
-> **originalStorageCache**(`baseState`): `object`
+> **originalStorageCache**(`baseState`, `skipFetchingFromFork`?): `object`
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -13,6 +13,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/putAccount.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/putAccount.md
@@ -5,13 +5,15 @@ prev: false
 title: "putAccount"
 ---
 
-> **putAccount**(`baseState`): (`address`, `account`?) => `Promise`\<`void`\>
+> **putAccount**(`baseState`, `skipFetchingFromFork`?): (`address`, `account`?) => `Promise`\<`void`\>
 
 Saves an account into state under the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/putContractCode.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/putContractCode.md
@@ -5,7 +5,7 @@ prev: false
 title: "putContractCode"
 ---
 
-> **putContractCode**(`baseState`): (`address`, `value`) => `Promise`\<`void`\>
+> **putContractCode**(`baseState`, `skipFetchingFromFork`?): (`address`, `value`) => `Promise`\<`void`\>
 
 Adds `value` to the state trie as code, and sets `codeHash` on the account
 corresponding to `address` to reference this.
@@ -13,6 +13,8 @@ corresponding to `address` to reference this.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/putContractStorage.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/putContractStorage.md
@@ -5,7 +5,7 @@ prev: false
 title: "putContractStorage"
 ---
 
-> **putContractStorage**(`baseState`): (`address`, `key`, `value`) => `Promise`\<`void`\>
+> **putContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`, `key`, `value`) => `Promise`\<`void`\>
 
 Adds value to the cache for the `account`
 corresponding to `address` at the provided `key`.
@@ -15,6 +15,8 @@ If it is empty or filled with zeros, deletes the value.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/revert.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/revert.md
@@ -5,7 +5,7 @@ prev: false
 title: "revert"
 ---
 
-> **revert**(`baseState`): () => `Promise`\<`void`\>
+> **revert**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`void`\>
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -13,6 +13,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/setStateRoot.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/setStateRoot.md
@@ -5,13 +5,15 @@ prev: false
 title: "setStateRoot"
 ---
 
-> **setStateRoot**(`baseState`): (`stateRoot`, `clearCache`?) => `Promise`\<`void`\>
+> **setStateRoot**(`baseState`, `skipFetchingFromFork`?): (`stateRoot`, `clearCache`?) => `Promise`\<`void`\>
 
 Changes the currently loaded state root
 
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/type-aliases/StateAction.md
+++ b/docs/src/content/docs/reference/@tevm/state/type-aliases/StateAction.md
@@ -5,7 +5,7 @@ prev: false
 title: "StateAction"
 ---
 
-> **StateAction**\<`T`\>: (`baseState`) => [`StateManager`](/reference/tevm/state/interfaces/statemanager/)\[`T`\]
+> **StateAction**\<`T`\>: (`baseState`, `skipFetchingFromFork`?) => [`StateManager`](/reference/tevm/state/interfaces/statemanager/)\[`T`\]
 
 ## Type parameters
 
@@ -14,6 +14,8 @@ title: "StateAction"
 ## Parameters
 
 • **baseState**: [`BaseState`](/reference/tevm/state/type-aliases/basestate/)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/actions/src/eth/ethGetLogsHandler.js
+++ b/packages/actions/src/eth/ethGetLogsHandler.js
@@ -25,7 +25,7 @@ const parseBlockParam = async (blockchain, blockParam) => {
 		}
 		throw new Error('safe not currently supported as block tag')
 	}
-	if (blockParam === 'latest') {
+	if (blockParam === 'latest' || blockParam === undefined) {
 		const safeBlock = blockchain.blocksByTag.get('latest')
 		// let's handle it here in case we forget to update it later
 		if (safeBlock) {
@@ -47,7 +47,7 @@ const parseBlockParam = async (blockchain, blockParam) => {
 		throw new Error('finalized noet yet supported for this feature')
 	}
 	blockchain.logger.error({ blockParam }, 'Unknown block param pased to blockNumberHandler')
-	throw new Error('Unknown block param pased to blockNumberHandler')
+	throw new Error(`Unknown block param ${blockParam} pased to blockNumberHandler`)
 }
 
 // TODO support EIP-234

--- a/packages/memory-client/src/test/__snapshots__/viemPublicActions.spec.ts.snap
+++ b/packages/memory-client/src/test/__snapshots__/viemPublicActions.spec.ts.snap
@@ -95,6 +95,10 @@ exports[`viemPublicActions getTransactionReceipt should work 1`] = `
   "effectiveGasPrice": null,
   "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "gasUsed": 159671n,
+  "l1Fee": null,
+  "l1FeeScalar": null,
+  "l1GasPrice": null,
+  "l1GasUsed": null,
   "logs": [],
   "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
   "status": null,
@@ -105,11 +109,75 @@ exports[`viemPublicActions getTransactionReceipt should work 1`] = `
 }
 `;
 
+exports[`viemPublicActions multicall should work 1`] = `
+[
+  {
+    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
+
+This could be due to any of the following:
+  - The contract does not have the function "aggregate3",
+  - The parameters passed to the contract function may be invalid, or
+  - The address is not a contract.
+ 
+Contract Call:
+  address:   0xcA11bde05977b3631167028862bE2a173976CA11
+  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
+  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
+
+Docs: https://viem.sh/docs/contract/readContract
+Version: viem@2.12.0],
+    "result": undefined,
+    "status": "failure",
+  },
+  {
+    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
+
+This could be due to any of the following:
+  - The contract does not have the function "aggregate3",
+  - The parameters passed to the contract function may be invalid, or
+  - The address is not a contract.
+ 
+Contract Call:
+  address:   0xcA11bde05977b3631167028862bE2a173976CA11
+  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
+  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
+
+Docs: https://viem.sh/docs/contract/readContract
+Version: viem@2.12.0],
+    "result": undefined,
+    "status": "failure",
+  },
+  {
+    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
+
+This could be due to any of the following:
+  - The contract does not have the function "aggregate3",
+  - The parameters passed to the contract function may be invalid, or
+  - The address is not a contract.
+ 
+Contract Call:
+  address:   0xcA11bde05977b3631167028862bE2a173976CA11
+  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
+  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
+
+Docs: https://viem.sh/docs/contract/readContract
+Version: viem@2.12.0],
+    "result": undefined,
+    "status": "failure",
+  },
+]
+`;
+
 exports[`viemPublicActions prepareTransactionRequest prepareTransactionRequest should work 1`] = `
 {
   "chain": {
     "blockExplorers": undefined,
-    "contracts": undefined,
+    "contracts": {
+      "multicall3": {
+        "address": "0xcA11bde05977b3631167028862bE2a173976CA11",
+        "blockCreated": 0,
+      },
+    },
     "copy": [Function],
     "custom": undefined,
     "ethjsCommon": Common {
@@ -1997,6 +2065,10 @@ exports[`viemPublicActions waitForTransactionReceipt waitForTransactionReceipt h
   "effectiveGasPrice": null,
   "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "gasUsed": 27784n,
+  "l1Fee": null,
+  "l1FeeScalar": null,
+  "l1GasPrice": null,
+  "l1GasUsed": null,
   "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000",
   "status": null,
   "to": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
@@ -2055,63 +2127,4 @@ exports[`viemPublicActions watchBlocks should work 1`] = `
   "withdrawals": [],
   "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
 }
-`;
-
-exports[`viemPublicActions multicall should work 1`] = `
-[
-  {
-    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
-
-This could be due to any of the following:
-  - The contract does not have the function "aggregate3",
-  - The parameters passed to the contract function may be invalid, or
-  - The address is not a contract.
- 
-Contract Call:
-  address:   0xcA11bde05977b3631167028862bE2a173976CA11
-  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
-  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
-
-Docs: https://viem.sh/docs/contract/readContract
-Version: viem@2.12.0],
-    "result": undefined,
-    "status": "failure",
-  },
-  {
-    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
-
-This could be due to any of the following:
-  - The contract does not have the function "aggregate3",
-  - The parameters passed to the contract function may be invalid, or
-  - The address is not a contract.
- 
-Contract Call:
-  address:   0xcA11bde05977b3631167028862bE2a173976CA11
-  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
-  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
-
-Docs: https://viem.sh/docs/contract/readContract
-Version: viem@2.12.0],
-    "result": undefined,
-    "status": "failure",
-  },
-  {
-    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
-
-This could be due to any of the following:
-  - The contract does not have the function "aggregate3",
-  - The parameters passed to the contract function may be invalid, or
-  - The address is not a contract.
- 
-Contract Call:
-  address:   0xcA11bde05977b3631167028862bE2a173976CA11
-  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
-  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
-
-Docs: https://viem.sh/docs/contract/readContract
-Version: viem@2.12.0],
-    "result": undefined,
-    "status": "failure",
-  },
-]
 `;

--- a/packages/memory-client/src/test/__snapshots__/viemPublicActions.spec.ts.snap
+++ b/packages/memory-client/src/test/__snapshots__/viemPublicActions.spec.ts.snap
@@ -2056,3 +2056,62 @@ exports[`viemPublicActions watchBlocks should work 1`] = `
   "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
 }
 `;
+
+exports[`viemPublicActions multicall should work 1`] = `
+[
+  {
+    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
+
+This could be due to any of the following:
+  - The contract does not have the function "aggregate3",
+  - The parameters passed to the contract function may be invalid, or
+  - The address is not a contract.
+ 
+Contract Call:
+  address:   0xcA11bde05977b3631167028862bE2a173976CA11
+  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
+  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
+
+Docs: https://viem.sh/docs/contract/readContract
+Version: viem@2.12.0],
+    "result": undefined,
+    "status": "failure",
+  },
+  {
+    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
+
+This could be due to any of the following:
+  - The contract does not have the function "aggregate3",
+  - The parameters passed to the contract function may be invalid, or
+  - The address is not a contract.
+ 
+Contract Call:
+  address:   0xcA11bde05977b3631167028862bE2a173976CA11
+  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
+  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
+
+Docs: https://viem.sh/docs/contract/readContract
+Version: viem@2.12.0],
+    "result": undefined,
+    "status": "failure",
+  },
+  {
+    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
+
+This could be due to any of the following:
+  - The contract does not have the function "aggregate3",
+  - The parameters passed to the contract function may be invalid, or
+  - The address is not a contract.
+ 
+Contract Call:
+  address:   0xcA11bde05977b3631167028862bE2a173976CA11
+  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
+  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
+
+Docs: https://viem.sh/docs/contract/readContract
+Version: viem@2.12.0],
+    "result": undefined,
+    "status": "failure",
+  },
+]
+`;

--- a/packages/memory-client/src/test/__snapshots__/viemPublicActions.spec.ts.snap
+++ b/packages/memory-client/src/test/__snapshots__/viemPublicActions.spec.ts.snap
@@ -95,10 +95,6 @@ exports[`viemPublicActions getTransactionReceipt should work 1`] = `
   "effectiveGasPrice": null,
   "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "gasUsed": 159671n,
-  "l1Fee": null,
-  "l1FeeScalar": null,
-  "l1GasPrice": null,
-  "l1GasUsed": null,
   "logs": [],
   "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
   "status": null,
@@ -109,75 +105,11 @@ exports[`viemPublicActions getTransactionReceipt should work 1`] = `
 }
 `;
 
-exports[`viemPublicActions multicall should work 1`] = `
-[
-  {
-    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
-
-This could be due to any of the following:
-  - The contract does not have the function "aggregate3",
-  - The parameters passed to the contract function may be invalid, or
-  - The address is not a contract.
- 
-Contract Call:
-  address:   0xcA11bde05977b3631167028862bE2a173976CA11
-  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
-  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
-
-Docs: https://viem.sh/docs/contract/readContract
-Version: viem@2.12.0],
-    "result": undefined,
-    "status": "failure",
-  },
-  {
-    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
-
-This could be due to any of the following:
-  - The contract does not have the function "aggregate3",
-  - The parameters passed to the contract function may be invalid, or
-  - The address is not a contract.
- 
-Contract Call:
-  address:   0xcA11bde05977b3631167028862bE2a173976CA11
-  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
-  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
-
-Docs: https://viem.sh/docs/contract/readContract
-Version: viem@2.12.0],
-    "result": undefined,
-    "status": "failure",
-  },
-  {
-    "error": [ContractFunctionExecutionError: The contract function "aggregate3" returned no data ("0x").
-
-This could be due to any of the following:
-  - The contract does not have the function "aggregate3",
-  - The parameters passed to the contract function may be invalid, or
-  - The address is not a contract.
- 
-Contract Call:
-  address:   0xcA11bde05977b3631167028862bE2a173976CA11
-  function:  aggregate3((address target, bool allowFailure, bytes callData)[])
-  args:                ([{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"},{"allowFailure":true,"callData":"0x6d4ce63c","target":"0x5FbDB2315678afecb367f032d93F642f64180aa3"}])
-
-Docs: https://viem.sh/docs/contract/readContract
-Version: viem@2.12.0],
-    "result": undefined,
-    "status": "failure",
-  },
-]
-`;
-
 exports[`viemPublicActions prepareTransactionRequest prepareTransactionRequest should work 1`] = `
 {
   "chain": {
     "blockExplorers": undefined,
-    "contracts": {
-      "multicall3": {
-        "address": "0xcA11bde05977b3631167028862bE2a173976CA11",
-        "blockCreated": 0,
-      },
-    },
+    "contracts": undefined,
     "copy": [Function],
     "custom": undefined,
     "ethjsCommon": Common {
@@ -2065,10 +1997,6 @@ exports[`viemPublicActions waitForTransactionReceipt waitForTransactionReceipt h
   "effectiveGasPrice": null,
   "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "gasUsed": 27784n,
-  "l1Fee": null,
-  "l1FeeScalar": null,
-  "l1GasPrice": null,
-  "l1GasUsed": null,
   "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000",
   "status": null,
   "to": "0x5fbdb2315678afecb367f032d93f642f64180aa3",

--- a/packages/memory-client/src/test/requests.spec.ts
+++ b/packages/memory-client/src/test/requests.spec.ts
@@ -84,7 +84,6 @@ describe('Tevm.request', async () => {
 							}),
 						),
 						to: contractAddress,
-						blockTag: '0xf5a353db0403849f5d9fe0bb78df4920556fc5729111540a13303cb538f0fc10',
 					},
 				],
 				jsonrpc: '2.0',
@@ -98,7 +97,7 @@ describe('Tevm.request', async () => {
 					abi: DaiContract.abi,
 					functionName: 'balanceOf',
 				}) satisfies bigint,
-			).toBe(0n)
+			).toBe(1n)
 			expect(hexToBigInt(res.executionGasUsed)).toBe(2447n)
 			expect(res.logs).toEqual([])
 		},

--- a/packages/receipt-manager/src/RecieptManager.ts
+++ b/packages/receipt-manager/src/RecieptManager.ts
@@ -226,6 +226,13 @@ export class ReceiptsManager {
 	): Promise<GetLogsReturn> {
 		const returnedLogs: GetLogsReturn = []
 		let returnedLogsSize = 0
+		// debugging wierd issue
+		try {
+			from.header.number
+		} catch (e) {
+			console.error(e)
+			console.log(from, to, addresses)
+		}
 		for (let i = from.header.number; i <= to.header.number; i++) {
 			const block = await getBlock(this.chain)(i)
 			const receipts = await this.getReceipts(block.hash())

--- a/packages/receipt-manager/src/RecieptManager.ts
+++ b/packages/receipt-manager/src/RecieptManager.ts
@@ -226,13 +226,6 @@ export class ReceiptsManager {
 	): Promise<GetLogsReturn> {
 		const returnedLogs: GetLogsReturn = []
 		let returnedLogsSize = 0
-		// debugging wierd issue
-		try {
-			from.header.number
-		} catch (e) {
-			console.error(e)
-			console.log(from, to, addresses)
-		}
 		for (let i = from.header.number; i <= to.header.number; i++) {
 			const block = await getBlock(this.chain)(i)
 			const receipts = await this.getReceipts(block.hash())

--- a/packages/state/docs/classes/ContractCache.md
+++ b/packages/state/docs/classes/ContractCache.md
@@ -25,7 +25,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:10](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L10)
+[packages/state/src/ContractCache.js:11](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L11)
 
 ## Properties
 
@@ -35,7 +35,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:16](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L16)
+[packages/state/src/ContractCache.js:17](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L17)
 
 ## Accessors
 
@@ -49,7 +49,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:65](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L65)
+[packages/state/src/ContractCache.js:75](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L75)
 
 ## Methods
 
@@ -63,7 +63,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:61](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L61)
+[packages/state/src/ContractCache.js:62](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L62)
 
 ***
 
@@ -77,7 +77,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:29](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L29)
+[packages/state/src/ContractCache.js:30](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L30)
 
 ***
 
@@ -91,7 +91,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:22](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L22)
+[packages/state/src/ContractCache.js:23](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L23)
 
 ***
 
@@ -109,7 +109,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:54](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L54)
+[packages/state/src/ContractCache.js:55](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L55)
 
 ***
 
@@ -127,7 +127,27 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:37](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L37)
+[packages/state/src/ContractCache.js:38](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L38)
+
+***
+
+### has()
+
+> **has**(`address`): `boolean`
+
+#### Parameters
+
+• **address**: `Address`
+
+#### Returns
+
+`boolean`
+
+if the cache has the key
+
+#### Source
+
+[packages/state/src/ContractCache.js:70](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L70)
 
 ***
 
@@ -147,7 +167,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:46](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L46)
+[packages/state/src/ContractCache.js:47](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L47)
 
 ***
 
@@ -161,7 +181,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:76](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L76)
+[packages/state/src/ContractCache.js:86](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L86)
 
 ***
 
@@ -175,4 +195,4 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Source
 
-[packages/state/src/ContractCache.js:69](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L69)
+[packages/state/src/ContractCache.js:79](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/ContractCache.js#L79)

--- a/packages/state/docs/functions/checkpoint.md
+++ b/packages/state/docs/functions/checkpoint.md
@@ -6,7 +6,7 @@
 
 # Function: checkpoint()
 
-> **checkpoint**(`baseState`): () => `Promise`\<`void`\>
+> **checkpoint**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`void`\>
 
 Checkpoints the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/clearCaches.md
+++ b/packages/state/docs/functions/clearCaches.md
@@ -6,13 +6,15 @@
 
 # Function: clearCaches()
 
-> **clearCaches**(`baseState`): () => `void`
+> **clearCaches**(`baseState`, `skipFetchingFromFork`?): () => `void`
 
 Resets all internal caches
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/clearContractStorage.md
+++ b/packages/state/docs/functions/clearContractStorage.md
@@ -6,13 +6,15 @@
 
 # Function: clearContractStorage()
 
-> **clearContractStorage**(`baseState`): (`address`) => `Promise`\<`void`\>
+> **clearContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`void`\>
 
 Clears all storage entries for the account corresponding to `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/commit.md
+++ b/packages/state/docs/functions/commit.md
@@ -6,7 +6,7 @@
 
 # Function: commit()
 
-> **commit**(`baseState`): (`createNewStateRoot`?) => `Promise`\<`void`\>
+> **commit**(`baseState`, `skipFetchingFromFork`?): (`createNewStateRoot`?) => `Promise`\<`void`\>
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/deleteAccount.md
+++ b/packages/state/docs/functions/deleteAccount.md
@@ -6,13 +6,15 @@
 
 # Function: deleteAccount()
 
-> **deleteAccount**(`baseState`): (`address`) => `Promise`\<`void`\>
+> **deleteAccount**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`void`\>
 
 Deletes an account from state under the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/dumpCanonicalGenesis.md
+++ b/packages/state/docs/functions/dumpCanonicalGenesis.md
@@ -6,13 +6,15 @@
 
 # Function: dumpCanonicalGenesis()
 
-> **dumpCanonicalGenesis**(`baseState`): () => `Promise`\<[`TevmState`](../type-aliases/TevmState.md)\>
+> **dumpCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<[`TevmState`](../type-aliases/TevmState.md)\>
 
 Dumps the state of the state manager as a [TevmState](../type-aliases/TevmState.md)
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/dumpStorage.md
+++ b/packages/state/docs/functions/dumpStorage.md
@@ -6,7 +6,7 @@
 
 # Function: dumpStorage()
 
-> **dumpStorage**(`baseState`): (`address`) => `Promise`\<`StorageDump`\>
+> **dumpStorage**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`StorageDump`\>
 
 Dumps the RLP-encoded storage values for an `account` specified by `address`.
 Keys are the storage keys, values are the storage values as strings.
@@ -15,6 +15,8 @@ Both are represented as `0x` prefixed hex strings.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/dumpStorageRange.md
+++ b/packages/state/docs/functions/dumpStorageRange.md
@@ -6,11 +6,13 @@
 
 # Function: dumpStorageRange()
 
-> **dumpStorageRange**(`baseState`): (`address`, `startKey`, `limit`) => `Promise`\<`StorageRange`\>
+> **dumpStorageRange**(`baseState`, `skipFetchingFromFork`?): (`address`, `startKey`, `limit`) => `Promise`\<`StorageRange`\>
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/generateCanonicalGenesis.md
+++ b/packages/state/docs/functions/generateCanonicalGenesis.md
@@ -6,13 +6,15 @@
 
 # Function: generateCanonicalGenesis()
 
-> **generateCanonicalGenesis**(`baseState`): (`initState`) => `Promise`\<`void`\>
+> **generateCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): (`initState`) => `Promise`\<`void`\>
 
 Loads a [TevmState](../type-aliases/TevmState.md) into the state manager
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/getAccount.md
+++ b/packages/state/docs/functions/getAccount.md
@@ -6,13 +6,15 @@
 
 # Function: getAccount()
 
-> **getAccount**(`baseState`): (`address`) => `Promise`\<`undefined` \| `Account`\>
+> **getAccount**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`undefined` \| `Account`\>
 
 Gets the code corresponding to the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/getAccountAddresses.md
+++ b/packages/state/docs/functions/getAccountAddresses.md
@@ -6,11 +6,13 @@
 
 # Function: getAccountAddresses()
 
-> **getAccountAddresses**(`baseState`): () => \`0x$\{string\}\`[]
+> **getAccountAddresses**(`baseState`, `skipFetchingFromFork`?): () => \`0x$\{string\}\`[]
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/getAppliedKey.md
+++ b/packages/state/docs/functions/getAppliedKey.md
@@ -6,11 +6,13 @@
 
 # Function: ~~getAppliedKey()~~
 
-> **getAppliedKey**(`baseState`): `undefined` \| (`address`) => `Uint8Array`
+> **getAppliedKey**(`baseState`, `skipFetchingFromFork`?): `undefined` \| (`address`) => `Uint8Array`
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/getContractCode.md
+++ b/packages/state/docs/functions/getContractCode.md
@@ -6,7 +6,7 @@
 
 # Function: getContractCode()
 
-> **getContractCode**(`baseState`): (`address`) => `Promise`\<`Uint8Array`\>
+> **getContractCode**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`Uint8Array`\>
 
 Gets the code corresponding to the provided `address`.
 Returns an empty `Uint8Array` if the account has no associated code.
@@ -14,6 +14,8 @@ Returns an empty `Uint8Array` if the account has no associated code.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -29,4 +31,4 @@ Returns an empty `Uint8Array` if the account has no associated code.
 
 ## Source
 
-[packages/state/src/actions/getContractCode.js:11](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractCode.js#L11)
+[packages/state/src/actions/getContractCode.js:13](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractCode.js#L13)

--- a/packages/state/docs/functions/getContractStorage.md
+++ b/packages/state/docs/functions/getContractStorage.md
@@ -6,7 +6,7 @@
 
 # Function: getContractStorage()
 
-> **getContractStorage**(`baseState`): (`address`, `key`) => `Promise`\<`Uint8Array`\>
+> **getContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`, `key`) => `Promise`\<`Uint8Array`\>
 
 Gets the storage value associated with the provided `address` and `key`. This method returns
 the shortest representation of the stored value.
@@ -16,6 +16,8 @@ If this does not exist an empty `Uint8Array` is returned.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -33,4 +35,4 @@ If this does not exist an empty `Uint8Array` is returned.
 
 ## Source
 
-[packages/state/src/actions/getContractStorage.js:13](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractStorage.js#L13)
+[packages/state/src/actions/getContractStorage.js:14](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/actions/getContractStorage.js#L14)

--- a/packages/state/docs/functions/getProof.md
+++ b/packages/state/docs/functions/getProof.md
@@ -6,13 +6,15 @@
 
 # Function: getProof()
 
-> **getProof**(`baseState`): (`address`, `storageSlots`?) => `Promise`\<`Proof`\>
+> **getProof**(`baseState`, `skipFetchingFromFork`?): (`address`, `storageSlots`?) => `Promise`\<`Proof`\>
 
 Get an EIP-1186 proof from the provider
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/getStateRoot.md
+++ b/packages/state/docs/functions/getStateRoot.md
@@ -6,13 +6,15 @@
 
 # Function: getStateRoot()
 
-> **getStateRoot**(`baseState`): () => `Promise`\<`Uint8Array`\>
+> **getStateRoot**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`Uint8Array`\>
 
 Gets the current state root
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/hasStateRoot.md
+++ b/packages/state/docs/functions/hasStateRoot.md
@@ -6,13 +6,15 @@
 
 # Function: hasStateRoot()
 
-> **hasStateRoot**(`baseState`): (`root`) => `Promise`\<`boolean`\>
+> **hasStateRoot**(`baseState`, `skipFetchingFromFork`?): (`root`) => `Promise`\<`boolean`\>
 
 Returns true if state root exists
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/modifyAccountFields.md
+++ b/packages/state/docs/functions/modifyAccountFields.md
@@ -6,7 +6,7 @@
 
 # Function: modifyAccountFields()
 
-> **modifyAccountFields**(`baseState`): (`address`, `accountFields`) => `Promise`\<`void`\>
+> **modifyAccountFields**(`baseState`, `skipFetchingFromFork`?): (`address`, `accountFields`) => `Promise`\<`void`\>
 
 Gets the account associated with `address`, modifies the given account
 fields, then saves the account into state. Account fields can include
@@ -15,6 +15,8 @@ fields, then saves the account into state. Account fields can include
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/originalStorageCache.md
+++ b/packages/state/docs/functions/originalStorageCache.md
@@ -6,7 +6,7 @@
 
 # Function: originalStorageCache()
 
-> **originalStorageCache**(`baseState`): `object`
+> **originalStorageCache**(`baseState`, `skipFetchingFromFork`?): `object`
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/putAccount.md
+++ b/packages/state/docs/functions/putAccount.md
@@ -6,13 +6,15 @@
 
 # Function: putAccount()
 
-> **putAccount**(`baseState`): (`address`, `account`?) => `Promise`\<`void`\>
+> **putAccount**(`baseState`, `skipFetchingFromFork`?): (`address`, `account`?) => `Promise`\<`void`\>
 
 Saves an account into state under the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/putContractCode.md
+++ b/packages/state/docs/functions/putContractCode.md
@@ -6,7 +6,7 @@
 
 # Function: putContractCode()
 
-> **putContractCode**(`baseState`): (`address`, `value`) => `Promise`\<`void`\>
+> **putContractCode**(`baseState`, `skipFetchingFromFork`?): (`address`, `value`) => `Promise`\<`void`\>
 
 Adds `value` to the state trie as code, and sets `codeHash` on the account
 corresponding to `address` to reference this.
@@ -14,6 +14,8 @@ corresponding to `address` to reference this.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/putContractStorage.md
+++ b/packages/state/docs/functions/putContractStorage.md
@@ -6,7 +6,7 @@
 
 # Function: putContractStorage()
 
-> **putContractStorage**(`baseState`): (`address`, `key`, `value`) => `Promise`\<`void`\>
+> **putContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`, `key`, `value`) => `Promise`\<`void`\>
 
 Adds value to the cache for the `account`
 corresponding to `address` at the provided `key`.
@@ -16,6 +16,8 @@ If it is empty or filled with zeros, deletes the value.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/revert.md
+++ b/packages/state/docs/functions/revert.md
@@ -6,7 +6,7 @@
 
 # Function: revert()
 
-> **revert**(`baseState`): () => `Promise`\<`void`\>
+> **revert**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`void`\>
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/functions/setStateRoot.md
+++ b/packages/state/docs/functions/setStateRoot.md
@@ -6,13 +6,15 @@
 
 # Function: setStateRoot()
 
-> **setStateRoot**(`baseState`): (`stateRoot`, `clearCache`?) => `Promise`\<`void`\>
+> **setStateRoot**(`baseState`, `skipFetchingFromFork`?): (`stateRoot`, `clearCache`?) => `Promise`\<`void`\>
 
 Changes the currently loaded state root
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/docs/type-aliases/StateAction.md
+++ b/packages/state/docs/type-aliases/StateAction.md
@@ -6,7 +6,7 @@
 
 # Type alias: StateAction()\<T\>
 
-> **StateAction**\<`T`\>: (`baseState`) => [`StateManager`](../interfaces/StateManager.md)\[`T`\]
+> **StateAction**\<`T`\>: (`baseState`, `skipFetchingFromFork`?) => [`StateManager`](../interfaces/StateManager.md)\[`T`\]
 
 ## Type parameters
 
@@ -15,6 +15,8 @@
 ## Parameters
 
 • **baseState**: [`BaseState`](BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 

--- a/packages/state/src/ContractCache.js
+++ b/packages/state/src/ContractCache.js
@@ -1,4 +1,5 @@
 import { CacheType, StorageCache } from '@ethereumjs/statemanager'
+import { bytesToUnprefixedHex } from '@tevm/utils'
 
 const oneBytes = Uint8Array.from([1])
 
@@ -60,6 +61,15 @@ export class ContractCache {
 	 */
 	checkpoint() {
 		this.storageCache.checkpoint()
+	}
+
+	/**
+	 * @param {import('@tevm/utils').EthjsAddress} address
+	 * @returns {boolean} if the cache has the key
+	 */
+	has(address) {
+		const storageMap = this.storageCache._orderedMapCache?.getElementByKey(bytesToUnprefixedHex(address.bytes))
+		return storageMap?.has(bytesToUnprefixedHex(oneBytes)) ?? false
 	}
 
 	get _checkpoints() {

--- a/packages/state/src/actions/dumpCannonicalGenesis.js
+++ b/packages/state/src/actions/dumpCannonicalGenesis.js
@@ -29,15 +29,16 @@ export const dumpCanonicalGenesis = (baseState) => async () => {
 
 	for (const address of accountAddresses) {
 		const hexAddress = getAddress(`0x${address}`)
-		const account = await getAccount(baseState, true)(EthjsAddress.fromString(hexAddress))
+		const ethAddress = EthjsAddress.fromString(hexAddress)
+		const account = await getAccount(baseState, true)(ethAddress)
 
 		if (account === undefined) {
 			baseState.logger.debug({ address: hexAddress }, 'Warning: Account in accountAddresses not found')
 		}
 		if (account !== undefined) {
-			const storage = await dumpStorage(baseState, true)(EthjsAddress.fromString(hexAddress))
+			const storage = await dumpStorage(baseState, true)(ethAddress)
 
-			const deployedBytecode = await getContractCode(baseState, true)(EthjsAddress.fromString(hexAddress))
+			const deployedBytecode = await getContractCode(baseState, true)(ethAddress)
 
 			const dump = {
 				nonce: account.nonce,
@@ -45,7 +46,7 @@ export const dumpCanonicalGenesis = (baseState) => async () => {
 				storageRoot: bytesToHex(account.storageRoot),
 				codeHash: bytesToHex(account.codeHash),
 				storage,
-				deployedBytecode: toHex(deployedBytecode),
+				...(baseState.caches.contracts.has(ethAddress) ? { deployedBytecode: toHex(deployedBytecode) } : {}),
 			}
 
 			baseState.logger.debug({ address: hexAddress, ...dump }, 'dumping address')

--- a/packages/state/src/actions/dumpCannonicalGenesis.js
+++ b/packages/state/src/actions/dumpCannonicalGenesis.js
@@ -29,15 +29,15 @@ export const dumpCanonicalGenesis = (baseState) => async () => {
 
 	for (const address of accountAddresses) {
 		const hexAddress = getAddress(`0x${address}`)
-		const account = await getAccount(baseState)(EthjsAddress.fromString(hexAddress))
+		const account = await getAccount(baseState, true)(EthjsAddress.fromString(hexAddress))
 
 		if (account === undefined) {
 			baseState.logger.debug({ address: hexAddress }, 'Warning: Account in accountAddresses not found')
 		}
 		if (account !== undefined) {
-			const storage = await dumpStorage(baseState)(EthjsAddress.fromString(hexAddress))
+			const storage = await dumpStorage(baseState, true)(EthjsAddress.fromString(hexAddress))
 
-			const deployedBytecode = await getContractCode(baseState)(EthjsAddress.fromString(hexAddress))
+			const deployedBytecode = await getContractCode(baseState, true)(EthjsAddress.fromString(hexAddress))
 
 			const dump = {
 				nonce: account.nonce,
@@ -45,11 +45,7 @@ export const dumpCanonicalGenesis = (baseState) => async () => {
 				storageRoot: bytesToHex(account.storageRoot),
 				codeHash: bytesToHex(account.codeHash),
 				storage,
-				...(deployedBytecode.length > 0
-					? {
-							deployedBytecode: toHex(deployedBytecode),
-						}
-					: {}),
+				deployedBytecode: toHex(deployedBytecode),
 			}
 
 			baseState.logger.debug({ address: hexAddress, ...dump }, 'dumping address')

--- a/packages/state/src/actions/getAccount.js
+++ b/packages/state/src/actions/getAccount.js
@@ -5,30 +5,36 @@ import { getAccountFromProvider } from './getAccountFromProvider.js'
  * Gets the code corresponding to the provided `address`.
  * @type {import("../state-types/index.js").StateAction<'getAccount'>}
  */
-export const getAccount = (baseState) => async (address) => {
-	const {
-		caches: { accounts },
-	} = baseState
-	const elem = accounts.get(address)
-	if (elem !== undefined) {
-		return elem.accountRLP !== undefined ? EthjsAccount.fromRlpSerializedAccount(elem.accountRLP) : undefined
+export const getAccount =
+	(baseState, skipFetchingFromFork = false) =>
+	async (address) => {
+		const {
+			caches: { accounts },
+		} = baseState
+		const elem = accounts.get(address)
+		if (elem !== undefined) {
+			return elem.accountRLP !== undefined ? EthjsAccount.fromRlpSerializedAccount(elem.accountRLP) : undefined
+		}
+		if (!baseState.options.fork?.transport && elem === undefined) {
+			return undefined
+		}
+		if (skipFetchingFromFork) {
+			return undefined
+		}
+		baseState.logger.debug({ address }, 'fetching account from remote RPC')
+		const account = await getAccountFromProvider(baseState)(
+			/** @type {import('@tevm/utils').Address}*/ (address.toString()),
+		)
+		if (
+			account.nonce === 0n &&
+			account.balance === 0n &&
+			account.codeHash.every((d) => d === 0) &&
+			account.storageRoot.every((d) => d === 0)
+		) {
+			accounts.put(address, undefined)
+			return undefined
+		}
+		accounts.put(address, account)
+		baseState.logger.debug({ address, account }, 'Cached forked account in state manager')
+		return account
 	}
-	if (!baseState.options.fork?.transport && elem === undefined) {
-		return undefined
-	}
-	baseState.logger.debug({ address }, 'fetching account from remote RPC')
-	const account = await getAccountFromProvider(baseState)(
-		/** @type {import('@tevm/utils').Address}*/ (address.toString()),
-	)
-	if (
-		account.nonce === 0n &&
-		account.balance === 0n &&
-		account.codeHash.every((d) => d === 0) &&
-		account.storageRoot.every((d) => d === 0)
-	) {
-		return undefined
-	}
-	accounts.put(address, account)
-	baseState.logger.debug({ address, account }, 'Cached forked account in state manager')
-	return account
-}

--- a/packages/state/src/actions/getContractCode.js
+++ b/packages/state/src/actions/getContractCode.js
@@ -3,50 +3,64 @@ import { hexToBytes } from 'viem'
 import { getForkBlockTag } from './getForkBlockTag.js'
 import { getForkClient } from './getForkClient.js'
 
+const EMPTY_CODE = Object.freeze(new Uint8Array())
+
 /**
  * Gets the code corresponding to the provided `address`.
  * Returns an empty `Uint8Array` if the account has no associated code.
  * @type {import("../state-types/index.js").StateAction<'getContractCode'>}
  */
-export const getContractCode = (baseState) => async (address) => {
-	const {
-		options,
-		caches: { contracts },
-	} = baseState
+export const getContractCode =
+	(baseState, skipFetchingFromFork = false) =>
+	async (address) => {
+		const {
+			options,
+			caches: { contracts },
+		} = baseState
 
-	const codeBytes = contracts.get(address)
+		const codeBytes = contracts.get(address)
 
-	if (codeBytes !== undefined) {
-		return codeBytes
+		if (codeBytes !== undefined) {
+			return codeBytes
+		}
+
+		if (!options.fork?.transport) {
+			return EMPTY_CODE
+		}
+
+		if (skipFetchingFromFork) {
+			return EMPTY_CODE
+		}
+
+		baseState.logger.debug({ address }, 'Fetching contract code from remote RPC...')
+
+		const client = getForkClient(baseState)
+		const blockTag = getForkBlockTag(baseState)
+
+		// don't fetch if we cached empty code already
+		if (contracts.has(address)) {
+			return EMPTY_CODE
+		}
+
+		const remoteCode = await client.getBytecode({
+			address: /** @type {import('@tevm/utils').Address}*/ (address.toString()),
+			...blockTag,
+		})
+
+		if (!remoteCode) {
+			baseState.logger.debug({ address }, 'No remote code found')
+			contracts.put(address, EMPTY_CODE)
+			return EMPTY_CODE
+		}
+
+		const remoteCodeBytes = hexToBytes(remoteCode)
+
+		contracts.put(address, remoteCodeBytes)
+
+		baseState.logger.debug(
+			{ address, deployedBytecode: bytesToHex(remoteCodeBytes) },
+			'Cached forked contract bytecode to state',
+		)
+
+		return remoteCodeBytes
 	}
-
-	if (!options.fork?.transport) {
-		return new Uint8Array()
-	}
-
-	baseState.logger.debug({ address }, 'Fetching contract code from remote RPC...')
-
-	const client = getForkClient(baseState)
-	const blockTag = getForkBlockTag(baseState)
-
-	const remoteCode = await client.getBytecode({
-		address: /** @type {import('@tevm/utils').Address}*/ (address.toString()),
-		...blockTag,
-	})
-
-	if (!remoteCode) {
-		baseState.logger.debug({ address }, 'No remote code found')
-		return new Uint8Array()
-	}
-
-	const remoteCodeBytes = hexToBytes(remoteCode)
-
-	contracts.put(address, remoteCodeBytes)
-
-	baseState.logger.debug(
-		{ address, deployedBytecode: bytesToHex(remoteCodeBytes) },
-		'Cached forked contract bytecode to state',
-	)
-
-	return remoteCodeBytes
-}

--- a/packages/state/src/actions/getContractStorage.js
+++ b/packages/state/src/actions/getContractStorage.js
@@ -1,4 +1,5 @@
 import { bytesToHex, hexToBytes } from 'viem'
+import { getAccount } from './getAccount.js'
 import { getForkBlockTag } from './getForkBlockTag.js'
 import { getForkClient } from './getForkClient.js'
 import { putContractStorage } from './putContractStorage.js'
@@ -24,6 +25,12 @@ export const getContractStorage = (baseState) => async (address, key) => {
 	const cachedValue = storageCache.get(address, key)
 	if (cachedValue !== undefined) {
 		return cachedValue
+	}
+
+	const isContractAtAddress = (await getAccount(baseState)(address))?.isContract()
+	if (!isContractAtAddress) {
+		baseState.logger.debug(`No contract found at address ${address}. Cannot getContractStorage if there is no contract`)
+		return hexToBytes('0x0')
 	}
 
 	if (!baseState.options.fork?.transport) {

--- a/packages/state/src/state-types/StateAction.ts
+++ b/packages/state/src/state-types/StateAction.ts
@@ -1,4 +1,7 @@
 import type { BaseState } from '../BaseState.js'
 import type { StateManager } from '../StateManager.js'
 
-export type StateAction<T extends keyof StateManager> = (baseState: BaseState) => StateManager[T]
+export type StateAction<T extends keyof StateManager> = (
+	baseState: BaseState,
+	skipFetchingFromFork?: boolean,
+) => StateManager[T]

--- a/tevm/docs/index/type-aliases/StateOptions.md
+++ b/tevm/docs/index/type-aliases/StateOptions.md
@@ -48,4 +48,4 @@ Called when state manager commits state
 
 ## Source
 
-packages/state/dist/index.d.ts:169
+packages/state/dist/index.d.ts:174

--- a/tevm/docs/index/type-aliases/TevmState.md
+++ b/tevm/docs/index/type-aliases/TevmState.md
@@ -14,4 +14,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:160
+packages/state/dist/index.d.ts:165

--- a/tevm/docs/state/classes/ContractCache.md
+++ b/tevm/docs/state/classes/ContractCache.md
@@ -49,7 +49,7 @@ packages/state/dist/index.d.ts:53
 
 #### Source
 
-packages/state/dist/index.d.ts:82
+packages/state/dist/index.d.ts:87
 
 ## Methods
 
@@ -131,6 +131,26 @@ packages/state/dist/index.d.ts:66
 
 ***
 
+### has()
+
+> **has**(`address`): `boolean`
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+#### Returns
+
+`boolean`
+
+if the cache has the key
+
+#### Source
+
+packages/state/dist/index.d.ts:86
+
+***
+
 ### put()
 
 > **put**(`address`, `bytecode`): `void`
@@ -161,7 +181,7 @@ packages/state/dist/index.d.ts:72
 
 #### Source
 
-packages/state/dist/index.d.ts:87
+packages/state/dist/index.d.ts:92
 
 ***
 
@@ -175,4 +195,4 @@ packages/state/dist/index.d.ts:87
 
 #### Source
 
-packages/state/dist/index.d.ts:83
+packages/state/dist/index.d.ts:88

--- a/tevm/docs/state/functions/checkpoint.md
+++ b/tevm/docs/state/functions/checkpoint.md
@@ -6,7 +6,7 @@
 
 # Function: checkpoint()
 
-> **checkpoint**(`baseState`): () => `Promise`\<`void`\>
+> **checkpoint**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`void`\>
 
 Checkpoints the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -25,4 +27,4 @@ last call to checkpoint.
 
 ## Source
 
-packages/state/dist/index.d.ts:193
+packages/state/dist/index.d.ts:198

--- a/tevm/docs/state/functions/clearCaches.md
+++ b/tevm/docs/state/functions/clearCaches.md
@@ -6,13 +6,15 @@
 
 # Function: clearCaches()
 
-> **clearCaches**(`baseState`): () => `void`
+> **clearCaches**(`baseState`, `skipFetchingFromFork`?): () => `void`
 
 Resets all internal caches
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -26,4 +28,4 @@ Resets all internal caches
 
 ## Source
 
-packages/state/dist/index.d.ts:199
+packages/state/dist/index.d.ts:204

--- a/tevm/docs/state/functions/clearContractStorage.md
+++ b/tevm/docs/state/functions/clearContractStorage.md
@@ -6,13 +6,15 @@
 
 # Function: clearContractStorage()
 
-> **clearContractStorage**(`baseState`): (`address`) => `Promise`\<`void`\>
+> **clearContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`void`\>
 
 Clears all storage entries for the account corresponding to `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -28,4 +30,4 @@ Clears all storage entries for the account corresponding to `address`.
 
 ## Source
 
-packages/state/dist/index.d.ts:205
+packages/state/dist/index.d.ts:210

--- a/tevm/docs/state/functions/commit.md
+++ b/tevm/docs/state/functions/commit.md
@@ -6,7 +6,7 @@
 
 # Function: commit()
 
-> **commit**(`baseState`): (`createNewStateRoot`?) => `Promise`\<`void`\>
+> **commit**(`baseState`, `skipFetchingFromFork`?): (`createNewStateRoot`?) => `Promise`\<`void`\>
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -35,4 +37,4 @@ This api is not stable
 
 ## Source
 
-packages/state/dist/index.d.ts:212
+packages/state/dist/index.d.ts:217

--- a/tevm/docs/state/functions/createBaseState.md
+++ b/tevm/docs/state/functions/createBaseState.md
@@ -18,4 +18,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:186
+packages/state/dist/index.d.ts:191

--- a/tevm/docs/state/functions/createStateManager.md
+++ b/tevm/docs/state/functions/createStateManager.md
@@ -18,4 +18,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:184
+packages/state/dist/index.d.ts:189

--- a/tevm/docs/state/functions/deepCopy.md
+++ b/tevm/docs/state/functions/deepCopy.md
@@ -22,4 +22,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:214
+packages/state/dist/index.d.ts:219

--- a/tevm/docs/state/functions/deleteAccount.md
+++ b/tevm/docs/state/functions/deleteAccount.md
@@ -6,13 +6,15 @@
 
 # Function: deleteAccount()
 
-> **deleteAccount**(`baseState`): (`address`) => `Promise`\<`void`\>
+> **deleteAccount**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`void`\>
 
 Deletes an account from state under the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -28,4 +30,4 @@ Deletes an account from state under the provided `address`.
 
 ## Source
 
-packages/state/dist/index.d.ts:220
+packages/state/dist/index.d.ts:225

--- a/tevm/docs/state/functions/dumpCanonicalGenesis.md
+++ b/tevm/docs/state/functions/dumpCanonicalGenesis.md
@@ -6,13 +6,15 @@
 
 # Function: dumpCanonicalGenesis()
 
-> **dumpCanonicalGenesis**(`baseState`): () => `Promise`\<[`TevmState`](../../index/type-aliases/TevmState.md)\>
+> **dumpCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<[`TevmState`](../../index/type-aliases/TevmState.md)\>
 
 Dumps the state of the state manager as a [TevmState](../../index/type-aliases/TevmState.md)
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -26,4 +28,4 @@ Dumps the state of the state manager as a [TevmState](../../index/type-aliases/T
 
 ## Source
 
-packages/state/dist/index.d.ts:226
+packages/state/dist/index.d.ts:231

--- a/tevm/docs/state/functions/dumpStorage.md
+++ b/tevm/docs/state/functions/dumpStorage.md
@@ -6,7 +6,7 @@
 
 # Function: dumpStorage()
 
-> **dumpStorage**(`baseState`): (`address`) => `Promise`\<[`StorageDump`](../../common/interfaces/StorageDump.md)\>
+> **dumpStorage**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<[`StorageDump`](../../common/interfaces/StorageDump.md)\>
 
 Dumps the RLP-encoded storage values for an `account` specified by `address`.
 Keys are the storage keys, values are the storage values as strings.
@@ -15,6 +15,8 @@ Both are represented as `0x` prefixed hex strings.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -30,4 +32,4 @@ Both are represented as `0x` prefixed hex strings.
 
 ## Source
 
-packages/state/dist/index.d.ts:234
+packages/state/dist/index.d.ts:239

--- a/tevm/docs/state/functions/dumpStorageRange.md
+++ b/tevm/docs/state/functions/dumpStorageRange.md
@@ -6,11 +6,13 @@
 
 # Function: dumpStorageRange()
 
-> **dumpStorageRange**(`baseState`): (`address`, `startKey`, `limit`) => `Promise`\<[`StorageRange`](../../common/interfaces/StorageRange.md)\>
+> **dumpStorageRange**(`baseState`, `skipFetchingFromFork`?): (`address`, `startKey`, `limit`) => `Promise`\<[`StorageRange`](../../common/interfaces/StorageRange.md)\>
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -30,4 +32,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:239
+packages/state/dist/index.d.ts:244

--- a/tevm/docs/state/functions/generateCanonicalGenesis.md
+++ b/tevm/docs/state/functions/generateCanonicalGenesis.md
@@ -6,13 +6,15 @@
 
 # Function: generateCanonicalGenesis()
 
-> **generateCanonicalGenesis**(`baseState`): (`initState`) => `Promise`\<`void`\>
+> **generateCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): (`initState`) => `Promise`\<`void`\>
 
 Loads a [TevmState](../../index/type-aliases/TevmState.md) into the state manager
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -28,4 +30,4 @@ Loads a [TevmState](../../index/type-aliases/TevmState.md) into the state manage
 
 ## Source
 
-packages/state/dist/index.d.ts:245
+packages/state/dist/index.d.ts:250

--- a/tevm/docs/state/functions/getAccount.md
+++ b/tevm/docs/state/functions/getAccount.md
@@ -6,13 +6,15 @@
 
 # Function: getAccount()
 
-> **getAccount**(`baseState`): (`address`) => `Promise`\<`undefined` \| [`EthjsAccount`](../../utils/classes/EthjsAccount.md)\>
+> **getAccount**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`undefined` \| [`EthjsAccount`](../../utils/classes/EthjsAccount.md)\>
 
 Gets the code corresponding to the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -28,4 +30,4 @@ Gets the code corresponding to the provided `address`.
 
 ## Source
 
-packages/state/dist/index.d.ts:251
+packages/state/dist/index.d.ts:256

--- a/tevm/docs/state/functions/getAccountAddresses.md
+++ b/tevm/docs/state/functions/getAccountAddresses.md
@@ -6,11 +6,13 @@
 
 # Function: getAccountAddresses()
 
-> **getAccountAddresses**(`baseState`): () => \`0x$\{string\}\`[]
+> **getAccountAddresses**(`baseState`, `skipFetchingFromFork`?): () => \`0x$\{string\}\`[]
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -22,4 +24,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:256
+packages/state/dist/index.d.ts:261

--- a/tevm/docs/state/functions/getAccountFromProvider.md
+++ b/tevm/docs/state/functions/getAccountFromProvider.md
@@ -26,4 +26,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:258
+packages/state/dist/index.d.ts:263

--- a/tevm/docs/state/functions/getAppliedKey.md
+++ b/tevm/docs/state/functions/getAppliedKey.md
@@ -6,11 +6,13 @@
 
 # Function: ~~getAppliedKey()~~
 
-> **getAppliedKey**(`baseState`): `undefined` \| (`address`) => `Uint8Array`
+> **getAppliedKey**(`baseState`, `skipFetchingFromFork`?): `undefined` \| (`address`) => `Uint8Array`
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -23,4 +25,4 @@ Used for saving preimages
 
 ## Source
 
-packages/state/dist/index.d.ts:266
+packages/state/dist/index.d.ts:271

--- a/tevm/docs/state/functions/getContractCode.md
+++ b/tevm/docs/state/functions/getContractCode.md
@@ -6,7 +6,7 @@
 
 # Function: getContractCode()
 
-> **getContractCode**(`baseState`): (`address`) => `Promise`\<`Uint8Array`\>
+> **getContractCode**(`baseState`, `skipFetchingFromFork`?): (`address`) => `Promise`\<`Uint8Array`\>
 
 Gets the code corresponding to the provided `address`.
 Returns an empty `Uint8Array` if the account has no associated code.
@@ -14,6 +14,8 @@ Returns an empty `Uint8Array` if the account has no associated code.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -29,4 +31,4 @@ Returns an empty `Uint8Array` if the account has no associated code.
 
 ## Source
 
-packages/state/dist/index.d.ts:273
+packages/state/dist/index.d.ts:278

--- a/tevm/docs/state/functions/getContractStorage.md
+++ b/tevm/docs/state/functions/getContractStorage.md
@@ -6,7 +6,7 @@
 
 # Function: getContractStorage()
 
-> **getContractStorage**(`baseState`): (`address`, `key`) => `Promise`\<`Uint8Array`\>
+> **getContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`, `key`) => `Promise`\<`Uint8Array`\>
 
 Gets the storage value associated with the provided `address` and `key`. This method returns
 the shortest representation of the stored value.
@@ -16,6 +16,8 @@ If this does not exist an empty `Uint8Array` is returned.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -33,4 +35,4 @@ If this does not exist an empty `Uint8Array` is returned.
 
 ## Source
 
-packages/state/dist/index.d.ts:282
+packages/state/dist/index.d.ts:287

--- a/tevm/docs/state/functions/getForkBlockTag.md
+++ b/tevm/docs/state/functions/getForkBlockTag.md
@@ -18,4 +18,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:284
+packages/state/dist/index.d.ts:289

--- a/tevm/docs/state/functions/getForkClient.md
+++ b/tevm/docs/state/functions/getForkClient.md
@@ -18,4 +18,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:290
+packages/state/dist/index.d.ts:295

--- a/tevm/docs/state/functions/getProof.md
+++ b/tevm/docs/state/functions/getProof.md
@@ -6,13 +6,15 @@
 
 # Function: getProof()
 
-> **getProof**(`baseState`): (`address`, `storageSlots`?) => `Promise`\<`Proof`\>
+> **getProof**(`baseState`, `skipFetchingFromFork`?): (`address`, `storageSlots`?) => `Promise`\<`Proof`\>
 
 Get an EIP-1186 proof from the provider
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -30,4 +32,4 @@ Get an EIP-1186 proof from the provider
 
 ## Source
 
-packages/state/dist/index.d.ts:296
+packages/state/dist/index.d.ts:301

--- a/tevm/docs/state/functions/getStateRoot.md
+++ b/tevm/docs/state/functions/getStateRoot.md
@@ -6,13 +6,15 @@
 
 # Function: getStateRoot()
 
-> **getStateRoot**(`baseState`): () => `Promise`\<`Uint8Array`\>
+> **getStateRoot**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`Uint8Array`\>
 
 Gets the current state root
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -24,4 +26,4 @@ Gets the current state root
 
 ## Source
 
-packages/state/dist/index.d.ts:302
+packages/state/dist/index.d.ts:307

--- a/tevm/docs/state/functions/hasStateRoot.md
+++ b/tevm/docs/state/functions/hasStateRoot.md
@@ -6,13 +6,15 @@
 
 # Function: hasStateRoot()
 
-> **hasStateRoot**(`baseState`): (`root`) => `Promise`\<`boolean`\>
+> **hasStateRoot**(`baseState`, `skipFetchingFromFork`?): (`root`) => `Promise`\<`boolean`\>
 
 Returns true if state root exists
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -28,4 +30,4 @@ Returns true if state root exists
 
 ## Source
 
-packages/state/dist/index.d.ts:308
+packages/state/dist/index.d.ts:313

--- a/tevm/docs/state/functions/modifyAccountFields.md
+++ b/tevm/docs/state/functions/modifyAccountFields.md
@@ -6,7 +6,7 @@
 
 # Function: modifyAccountFields()
 
-> **modifyAccountFields**(`baseState`): (`address`, `accountFields`) => `Promise`\<`void`\>
+> **modifyAccountFields**(`baseState`, `skipFetchingFromFork`?): (`address`, `accountFields`) => `Promise`\<`void`\>
 
 Gets the account associated with `address`, modifies the given account
 fields, then saves the account into state. Account fields can include
@@ -15,6 +15,8 @@ fields, then saves the account into state. Account fields can include
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -32,4 +34,4 @@ fields, then saves the account into state. Account fields can include
 
 ## Source
 
-packages/state/dist/index.d.ts:316
+packages/state/dist/index.d.ts:321

--- a/tevm/docs/state/functions/originalStorageCache.md
+++ b/tevm/docs/state/functions/originalStorageCache.md
@@ -6,7 +6,7 @@
 
 # Function: originalStorageCache()
 
-> **originalStorageCache**(`baseState`): `object`
+> **originalStorageCache**(`baseState`, `skipFetchingFromFork`?): `object`
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -39,4 +41,4 @@ last call to checkpoint.
 
 ## Source
 
-packages/state/dist/index.d.ts:360
+packages/state/dist/index.d.ts:365

--- a/tevm/docs/state/functions/putAccount.md
+++ b/tevm/docs/state/functions/putAccount.md
@@ -6,13 +6,15 @@
 
 # Function: putAccount()
 
-> **putAccount**(`baseState`): (`address`, `account`?) => `Promise`\<`void`\>
+> **putAccount**(`baseState`, `skipFetchingFromFork`?): (`address`, `account`?) => `Promise`\<`void`\>
 
 Saves an account into state under the provided `address`.
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -30,4 +32,4 @@ Saves an account into state under the provided `address`.
 
 ## Source
 
-packages/state/dist/index.d.ts:322
+packages/state/dist/index.d.ts:327

--- a/tevm/docs/state/functions/putContractCode.md
+++ b/tevm/docs/state/functions/putContractCode.md
@@ -6,7 +6,7 @@
 
 # Function: putContractCode()
 
-> **putContractCode**(`baseState`): (`address`, `value`) => `Promise`\<`void`\>
+> **putContractCode**(`baseState`, `skipFetchingFromFork`?): (`address`, `value`) => `Promise`\<`void`\>
 
 Adds `value` to the state trie as code, and sets `codeHash` on the account
 corresponding to `address` to reference this.
@@ -14,6 +14,8 @@ corresponding to `address` to reference this.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -31,4 +33,4 @@ corresponding to `address` to reference this.
 
 ## Source
 
-packages/state/dist/index.d.ts:329
+packages/state/dist/index.d.ts:334

--- a/tevm/docs/state/functions/putContractStorage.md
+++ b/tevm/docs/state/functions/putContractStorage.md
@@ -6,7 +6,7 @@
 
 # Function: putContractStorage()
 
-> **putContractStorage**(`baseState`): (`address`, `key`, `value`) => `Promise`\<`void`\>
+> **putContractStorage**(`baseState`, `skipFetchingFromFork`?): (`address`, `key`, `value`) => `Promise`\<`void`\>
 
 Adds value to the cache for the `account`
 corresponding to `address` at the provided `key`.
@@ -16,6 +16,8 @@ If it is empty or filled with zeros, deletes the value.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -35,4 +37,4 @@ If it is empty or filled with zeros, deletes the value.
 
 ## Source
 
-packages/state/dist/index.d.ts:338
+packages/state/dist/index.d.ts:343

--- a/tevm/docs/state/functions/revert.md
+++ b/tevm/docs/state/functions/revert.md
@@ -6,7 +6,7 @@
 
 # Function: revert()
 
-> **revert**(`baseState`): () => `Promise`\<`void`\>
+> **revert**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<`void`\>
 
 Commits the current change-set to the instance since the
 last call to checkpoint.
@@ -14,6 +14,8 @@ last call to checkpoint.
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -25,4 +27,4 @@ last call to checkpoint.
 
 ## Source
 
-packages/state/dist/index.d.ts:345
+packages/state/dist/index.d.ts:350

--- a/tevm/docs/state/functions/setStateRoot.md
+++ b/tevm/docs/state/functions/setStateRoot.md
@@ -6,13 +6,15 @@
 
 # Function: setStateRoot()
 
-> **setStateRoot**(`baseState`): (`stateRoot`, `clearCache`?) => `Promise`\<`void`\>
+> **setStateRoot**(`baseState`, `skipFetchingFromFork`?): (`stateRoot`, `clearCache`?) => `Promise`\<`void`\>
 
 Changes the currently loaded state root
 
 ## Parameters
 
 • **baseState**: [`BaseState`](../type-aliases/BaseState.md)
+
+• **skipFetchingFromFork?**: `boolean`
 
 ## Returns
 
@@ -30,4 +32,4 @@ Changes the currently loaded state root
 
 ## Source
 
-packages/state/dist/index.d.ts:351
+packages/state/dist/index.d.ts:356

--- a/tevm/docs/state/functions/shallowCopy.md
+++ b/tevm/docs/state/functions/shallowCopy.md
@@ -22,4 +22,4 @@
 
 ## Source
 
-packages/state/dist/index.d.ts:353
+packages/state/dist/index.d.ts:358

--- a/tevm/docs/state/interfaces/StateManager.md
+++ b/tevm/docs/state/interfaces/StateManager.md
@@ -20,7 +20,7 @@ The internal state representation
 
 #### Source
 
-packages/state/dist/index.d.ts:121
+packages/state/dist/index.d.ts:126
 
 ***
 
@@ -36,7 +36,7 @@ Returns contract addresses
 
 #### Source
 
-packages/state/dist/index.d.ts:126
+packages/state/dist/index.d.ts:131
 
 ***
 
@@ -82,7 +82,7 @@ node\_modules/.pnpm/@ethereumjs+common@4.3.0/node\_modules/@ethereumjs/common/di
 
 #### Source
 
-packages/state/dist/index.d.ts:122
+packages/state/dist/index.d.ts:127
 
 ## Methods
 
@@ -116,7 +116,7 @@ Resets all internal caches
 
 #### Source
 
-packages/state/dist/index.d.ts:138
+packages/state/dist/index.d.ts:143
 
 ***
 
@@ -166,7 +166,7 @@ This api is not stable
 
 #### Source
 
-packages/state/dist/index.d.ts:148
+packages/state/dist/index.d.ts:153
 
 ***
 
@@ -182,7 +182,7 @@ Returns a new instance of the ForkStateManager with the same opts and all storag
 
 #### Source
 
-packages/state/dist/index.d.ts:130
+packages/state/dist/index.d.ts:135
 
 ***
 
@@ -220,7 +220,7 @@ Dumps the state of the state manager as a [TevmState](../../index/type-aliases/T
 
 #### Source
 
-packages/state/dist/index.d.ts:134
+packages/state/dist/index.d.ts:139
 
 ***
 
@@ -585,7 +585,7 @@ THis API is considered unstable
 
 #### Source
 
-packages/state/dist/index.d.ts:144
+packages/state/dist/index.d.ts:149
 
 ***
 

--- a/tevm/docs/state/type-aliases/BaseState.md
+++ b/tevm/docs/state/type-aliases/BaseState.md
@@ -62,4 +62,4 @@ Mapping of hashes to State roots
 
 ## Source
 
-packages/state/dist/index.d.ts:104
+packages/state/dist/index.d.ts:109

--- a/tevm/docs/state/type-aliases/StateAction.md
+++ b/tevm/docs/state/type-aliases/StateAction.md
@@ -6,7 +6,7 @@
 
 # Type alias: StateAction()\<T\>
 
-> **StateAction**\<`T`\>: (`baseState`) => [`StateManager`](../interfaces/StateManager.md)\[`T`\]
+> **StateAction**\<`T`\>: (`baseState`, `skipFetchingFromFork`?) => [`StateManager`](../interfaces/StateManager.md)\[`T`\]
 
 ## Type parameters
 
@@ -16,10 +16,12 @@
 
 • **baseState**: [`BaseState`](BaseState.md)
 
+• **skipFetchingFromFork?**: `boolean`
+
 ## Returns
 
 [`StateManager`](../interfaces/StateManager.md)\[`T`\]
 
 ## Source
 
-packages/state/dist/index.d.ts:158
+packages/state/dist/index.d.ts:163

--- a/tevm/docs/state/type-aliases/StateCache.md
+++ b/tevm/docs/state/type-aliases/StateCache.md
@@ -28,4 +28,4 @@ The shape of the internal cache
 
 ## Source
 
-packages/state/dist/index.d.ts:94
+packages/state/dist/index.d.ts:99

--- a/tevm/docs/state/type-aliases/StateRoots.md
+++ b/tevm/docs/state/type-aliases/StateRoots.md
@@ -12,4 +12,4 @@ Mapping of state roots as hex string to the state
 
 ## Source
 
-packages/state/dist/index.d.ts:167
+packages/state/dist/index.d.ts:172


### PR DESCRIPTION
### TL;DR
Fixes a bug where eth_getCode would get triggered on every account in forked mode everytime we committed state. Now  eth_getCode runs at most one time along with any other empty cache situation.

### What changed?
Initialization of a MemoryClient in forked mode (ready)

before: 2.38s
after: 0.83s

Deploying a contract as a call (deploy-call)

before: 6.69s
after: 0.683s

Mining a tx with this deploy (mine)

before: 8.42s
after: 0.219s

Executing a call against our deployed contract (call)

before: 4.07s
after: 0.01s

---

## Description

_Concise description of proposed changes_

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Major performance enhancements to reduce execution times for various components.

- **New Features**
  - Added detailed timing logs for asynchronous operations to improve performance monitoring.
  - Introduced new methods and parameters to enhance functionality and control flow.

- **Bug Fixes**
  - Added checks to ensure valid contracts before retrieving storage, preventing errors.

- **Refactor**
  - Improved handling of asynchronous operations and readiness checks.
  - Introduced structured approaches for handling and caching data.

- **Tests**
  - Added new test cases and updated existing ones to cover new functionalities and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->