### PR TITLE
:sparkles: Feat: Expose ability to control how state is pruned

### DIFF
--- a/.changeset/large-trees-explain.md
+++ b/.changeset/large-trees-explain.md
@@ -1,0 +1,5 @@
+---
+"@tevm/state": minor
+---
+
+Added options to configure and pass in custom caches. For example caches that prune old state sooner

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,29 +12,15 @@ runs:
       with:
         bun-version: 1.0.36
 
-    - uses: pnpm/action-setup@v2
-      name: Install pnpm
-      with:
-        version: 9.2.0
-        run_install: false
+    - name: Install pnpm
+      run: |
+        npm i pnpm@9.4.0 --global && pnpm --version
+      shell: bash
 
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
         version: nightly
-
-    - name: Get pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-    - uses: actions/cache@v3
-      name: Setup pnpm cache
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,15 +12,29 @@ runs:
       with:
         bun-version: 1.0.36
 
-    - name: Install pnpm
-      run: |
-        npm i pnpm@9.4.0 --global && pnpm --version
-      shell: bash
+    - uses: pnpm/action-setup@v2
+      name: Install pnpm
+      with:
+        version: 9.2.0
+        run_install: false
 
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
         version: nightly
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v3
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/docs/src/content/docs/reference/@tevm/state/classes/AccountCache.md
+++ b/docs/src/content/docs/reference/@tevm/state/classes/AccountCache.md
@@ -1,0 +1,358 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "AccountCache"
+---
+
+## Extends
+
+- `Cache`
+
+## Constructors
+
+### new AccountCache()
+
+> **new AccountCache**(`opts`): [`AccountCache`](/reference/tevm/state/classes/accountcache/)
+
+#### Parameters
+
+• **opts**: `CacheOpts`
+
+#### Returns
+
+[`AccountCache`](/reference/tevm/state/classes/accountcache/)
+
+#### Overrides
+
+`Cache.constructor`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:27
+
+## Properties
+
+### \_checkpoints
+
+> **\_checkpoints**: `number`
+
+#### Inherited from
+
+`Cache._checkpoints`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:4
+
+***
+
+### \_debug
+
+> **\_debug**: `Debugger`
+
+#### Inherited from
+
+`Cache._debug`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:3
+
+***
+
+### \_diffCache
+
+> **\_diffCache**: `Map`\<`string`, `undefined` \| `AccountCacheElement`\>[]
+
+Diff cache collecting the state of the cache
+at the beginning of checkpoint height
+(respectively: before a first modification)
+
+If the whole cache element is undefined (in contrast
+to the account), the element didn't exist in the cache
+before.
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:26
+
+***
+
+### \_lruCache
+
+> **\_lruCache**: `undefined` \| `LRUCache`\<`string`, `AccountCacheElement`, `unknown`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:15
+
+***
+
+### \_orderedMapCache
+
+> **\_orderedMapCache**: `undefined` \| `OrderedMap`\<`string`, `AccountCacheElement`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:16
+
+***
+
+### \_stats
+
+> **\_stats**: `object`
+
+#### dels
+
+> **dels**: `number`
+
+#### hits
+
+> **hits**: `number`
+
+#### reads
+
+> **reads**: `number`
+
+#### size
+
+> **size**: `number`
+
+#### writes
+
+> **writes**: `number`
+
+#### Inherited from
+
+`Cache._stats`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:5
+
+## Methods
+
+### \_saveCachePreState()
+
+> **\_saveCachePreState**(`cacheKeyHex`): `void`
+
+#### Parameters
+
+• **cacheKeyHex**: `string`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:28
+
+***
+
+### checkpoint()
+
+> **checkpoint**(): `void`
+
+Marks current state of cache as checkpoint, which can
+later on be reverted or committed.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:62
+
+***
+
+### clear()
+
+> **clear**(): `void`
+
+Clears cache.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:82
+
+***
+
+### commit()
+
+> **commit**(): `void`
+
+Commits to current state of cache (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:57
+
+***
+
+### del()
+
+> **del**(`address`): `void`
+
+Marks address as deleted in cache.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+Address
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:44
+
+***
+
+### flush()
+
+> **flush**(): [`string`, `AccountCacheElement`][]
+
+Flushes cache by returning accounts that have been modified
+or deleted and resetting the diff cache (at checkpoint height).
+
+#### Returns
+
+[`string`, `AccountCacheElement`][]
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:49
+
+***
+
+### get()
+
+> **get**(`address`): `undefined` \| `AccountCacheElement`
+
+Returns the queried account or undefined if account doesn't exist
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+Address of account
+
+#### Returns
+
+`undefined` \| `AccountCacheElement`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:39
+
+***
+
+### put()
+
+> **put**(`address`, `account`): `void`
+
+Puts account to cache under its address.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+Address of account
+
+• **account**: `undefined` \| [`EthjsAccount`](/reference/tevm/utils/classes/ethjsaccount/)
+
+Account or undefined if account doesn't exist in the trie
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:34
+
+***
+
+### revert()
+
+> **revert**(): `void`
+
+Revert changes to cache last checkpoint (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:53
+
+***
+
+### size()
+
+> **size**(): `number`
+
+Returns the size of the cache
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:67
+
+***
+
+### stats()
+
+> **stats**(`reset`?): `object`
+
+Returns a dict with cache stats
+
+#### Parameters
+
+• **reset?**: `boolean`
+
+#### Returns
+
+`object`
+
+##### dels
+
+> **dels**: `number`
+
+##### hits
+
+> **hits**: `number`
+
+##### reads
+
+> **reads**: `number`
+
+##### size
+
+> **size**: `number`
+
+##### writes
+
+> **writes**: `number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:72

--- a/docs/src/content/docs/reference/@tevm/state/classes/ContractCache.md
+++ b/docs/src/content/docs/reference/@tevm/state/classes/ContractCache.md
@@ -16,7 +16,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Parameters
 
-• **storageCache**: `StorageCache` = `...`
+• **storageCache**: [`StorageCache`](/reference/tevm/state/classes/storagecache/) = `...`
 
 #### Returns
 
@@ -30,7 +30,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 ### storageCache
 
-> **storageCache**: `StorageCache`
+> **storageCache**: [`StorageCache`](/reference/tevm/state/classes/storagecache/)
 
 #### Defined in
 

--- a/docs/src/content/docs/reference/@tevm/state/classes/StorageCache.md
+++ b/docs/src/content/docs/reference/@tevm/state/classes/StorageCache.md
@@ -1,0 +1,418 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "StorageCache"
+---
+
+## Extends
+
+- `Cache`
+
+## Constructors
+
+### new StorageCache()
+
+> **new StorageCache**(`opts`): [`StorageCache`](/reference/tevm/state/classes/storagecache/)
+
+#### Parameters
+
+• **opts**: `CacheOpts`
+
+#### Returns
+
+[`StorageCache`](/reference/tevm/state/classes/storagecache/)
+
+#### Overrides
+
+`Cache.constructor`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:26
+
+## Properties
+
+### \_checkpoints
+
+> **\_checkpoints**: `number`
+
+#### Inherited from
+
+`Cache._checkpoints`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:4
+
+***
+
+### \_debug
+
+> **\_debug**: `Debugger`
+
+#### Inherited from
+
+`Cache._debug`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:3
+
+***
+
+### \_diffCache
+
+> **\_diffCache**: `Map`\<`string`, `DiffStorageCacheMap`\>[]
+
+Diff cache collecting the state of the cache
+at the beginning of checkpoint height
+(respectively: before a first modification)
+
+If the whole cache element is undefined (in contrast
+to the account), the element didn't exist in the cache
+before.
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:25
+
+***
+
+### \_lruCache
+
+> **\_lruCache**: `undefined` \| `LRUCache`\<`string`, `StorageCacheMap`, `unknown`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:14
+
+***
+
+### \_orderedMapCache
+
+> **\_orderedMapCache**: `undefined` \| `OrderedMap`\<`string`, `StorageCacheMap`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:15
+
+***
+
+### \_stats
+
+> **\_stats**: `object`
+
+#### dels
+
+> **dels**: `number`
+
+#### hits
+
+> **hits**: `number`
+
+#### reads
+
+> **reads**: `number`
+
+#### size
+
+> **size**: `number`
+
+#### writes
+
+> **writes**: `number`
+
+#### Inherited from
+
+`Cache._stats`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:5
+
+## Methods
+
+### \_saveCachePreState()
+
+> **\_saveCachePreState**(`addressHex`, `keyHex`): `void`
+
+#### Parameters
+
+• **addressHex**: `string`
+
+• **keyHex**: `string`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:27
+
+***
+
+### checkpoint()
+
+> **checkpoint**(): `void`
+
+Marks current state of cache as checkpoint, which can
+later on be reverted or committed.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:72
+
+***
+
+### clear()
+
+> **clear**(): `void`
+
+Clears cache.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:92
+
+***
+
+### clearContractStorage()
+
+> **clearContractStorage**(`address`): `void`
+
+Deletes all storage slots for address from the cache
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:54
+
+***
+
+### commit()
+
+> **commit**(): `void`
+
+Commits to current state of cache (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:67
+
+***
+
+### del()
+
+> **del**(`address`, `key`): `void`
+
+Marks storage key for address as deleted in cache.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+Address
+
+• **key**: `Uint8Array`
+
+Storage key
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:49
+
+***
+
+### dump()
+
+> **dump**(`address`): `undefined` \| `StorageCacheMap`
+
+Dumps the RLP-encoded storage values for an `account` specified by `address`.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+The address of the `account` to return storage for
+
+#### Returns
+
+`undefined` \| `StorageCacheMap`
+
+- The storage values for the `account` or undefined if the `account` is not in the cache
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:98
+
+***
+
+### flush()
+
+> **flush**(): [`string`, `string`, `undefined` \| `Uint8Array`][]
+
+Flushes cache by returning storage slots that have been modified
+or deleted and resetting the diff cache (at checkpoint height).
+
+#### Returns
+
+[`string`, `string`, `undefined` \| `Uint8Array`][]
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:59
+
+***
+
+### get()
+
+> **get**(`address`, `key`): `undefined` \| `Uint8Array`
+
+Returns the queried slot as the RLP encoded storage value
+hexToBytes('0x80'): slot is known to be empty
+undefined: slot is not in cache
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+Address of account
+
+• **key**: `Uint8Array`
+
+Storage key
+
+#### Returns
+
+`undefined` \| `Uint8Array`
+
+Storage value or undefined
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:43
+
+***
+
+### put()
+
+> **put**(`address`, `key`, `value`): `void`
+
+Puts storage value to cache under address_key cache key.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](/reference/tevm/utils/classes/ethjsaddress/)
+
+Account address
+
+• **key**: `Uint8Array`
+
+Storage key
+
+• **value**: `Uint8Array`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:34
+
+***
+
+### revert()
+
+> **revert**(): `void`
+
+Revert changes to cache last checkpoint (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:63
+
+***
+
+### size()
+
+> **size**(): `number`
+
+Returns the size of the cache
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:77
+
+***
+
+### stats()
+
+> **stats**(`reset`?): `object`
+
+Returns a dict with cache stats
+
+#### Parameters
+
+• **reset?**: `boolean`
+
+#### Returns
+
+`object`
+
+##### dels
+
+> **dels**: `number`
+
+##### hits
+
+> **hits**: `number`
+
+##### reads
+
+> **reads**: `number`
+
+##### size
+
+> **size**: `number`
+
+##### writes
+
+> **writes**: `number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:82

--- a/docs/src/content/docs/reference/@tevm/state/enumerations/CacheType.md
+++ b/docs/src/content/docs/reference/@tevm/state/enumerations/CacheType.md
@@ -1,0 +1,26 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "CacheType"
+---
+
+## Enumeration Members
+
+### LRU
+
+> **LRU**: `"lru"`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/types.d.ts:2
+
+***
+
+### ORDERED\_MAP
+
+> **ORDERED\_MAP**: `"ordered_map"`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/types.d.ts:3

--- a/docs/src/content/docs/reference/@tevm/state/globals.md
+++ b/docs/src/content/docs/reference/@tevm/state/globals.md
@@ -5,9 +5,15 @@ prev: false
 title: "@tevm/state"
 ---
 
+## Enumerations
+
+- [CacheType](/reference/tevm/state/enumerations/cachetype/)
+
 ## Classes
 
+- [AccountCache](/reference/tevm/state/classes/accountcache/)
 - [ContractCache](/reference/tevm/state/classes/contractcache/)
+- [StorageCache](/reference/tevm/state/classes/storagecache/)
 
 ## Interfaces
 

--- a/docs/src/content/docs/reference/@tevm/state/type-aliases/StateCache.md
+++ b/docs/src/content/docs/reference/@tevm/state/type-aliases/StateCache.md
@@ -15,7 +15,7 @@ The shape of the internal cache
 
 ### accounts
 
-> **accounts**: `AccountCache`
+> **accounts**: [`AccountCache`](/reference/tevm/state/classes/accountcache/)
 
 ### contracts
 
@@ -23,7 +23,7 @@ The shape of the internal cache
 
 ### storage
 
-> **storage**: `StorageCache`
+> **storage**: [`StorageCache`](/reference/tevm/state/classes/storagecache/)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/state/type-aliases/StateOptions.md
+++ b/docs/src/content/docs/reference/@tevm/state/type-aliases/StateOptions.md
@@ -9,6 +9,18 @@ title: "StateOptions"
 
 ## Type declaration
 
+### accountsCache?
+
+> `readonly` `optional` **accountsCache**: [`AccountCache`](/reference/tevm/state/classes/accountcache/)
+
+Optionally configure the accounts cache
+
+### contractCache?
+
+> `readonly` `optional` **contractCache**: [`ContractCache`](/reference/tevm/state/classes/contractcache/)
+
+Optionally configure and pass in your own ContractCache
+
 ### currentStateRoot?
 
 > `optional` **currentStateRoot**: [`Hex`](/reference/tevm/utils/type-aliases/hex/)
@@ -45,6 +57,12 @@ Called when state manager commits state
 
 > `optional` **stateRoots**: [`StateRoots`](/reference/tevm/state/type-aliases/stateroots/)
 
+### storageCache?
+
+> `readonly` `optional` **storageCache**: [`StorageCache`](/reference/tevm/state/classes/storagecache/)
+
+Optionally configure and pass in your own StorageCache
+
 ## Defined in
 
-[packages/state/src/state-types/StateOptions.ts:8](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/state-types/StateOptions.ts#L8)
+[packages/state/src/state-types/StateOptions.ts:10](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/state-types/StateOptions.ts#L10)

--- a/packages/base-client/src/createBaseClient.js
+++ b/packages/base-client/src/createBaseClient.js
@@ -61,9 +61,9 @@ export const createBaseClient = (options = {}) => {
 		}
 		return {
 			loggingLevel,
-			...(options.storageCache ? { storageCache: options.storageCache } : {}),
-			...(options.contractCache ? { contractCache: options.contractCache } : {}),
-			...(options.accountsCache ? { accountsCache: options.accountsCache } : {}),
+			...(options.storageCache !== undefined ? { storageCache: options.storageCache } : {}),
+			...(options.contractCache !== undefined ? { contractCache: options.contractCache } : {}),
+			...(options.accountsCache !== undefined ? { accountsCache: options.accountsCache } : {}),
 			...(options.fork?.transport ? options.fork : {}),
 			...(options.persister !== undefined ? { onCommit: statePersister(options.persister, logger) } : {}),
 		}

--- a/packages/base-client/src/createBaseClient.js
+++ b/packages/base-client/src/createBaseClient.js
@@ -59,9 +59,11 @@ export const createBaseClient = (options = {}) => {
 				},
 			}
 		}
-		// handle normal mode
 		return {
 			loggingLevel,
+			...(options.storageCache ? { storageCache: options.storageCache } : {}),
+			...(options.contractCache ? { contractCache: options.contractCache } : {}),
+			...(options.accountsCache ? { accountsCache: options.accountsCache } : {}),
 			...(options.fork?.transport ? options.fork : {}),
 			...(options.persister !== undefined ? { onCommit: statePersister(options.persister, logger) } : {}),
 		}

--- a/packages/state/docs/classes/AccountCache.md
+++ b/packages/state/docs/classes/AccountCache.md
@@ -1,0 +1,359 @@
+[**@tevm/state**](../README.md) • **Docs**
+
+***
+
+[@tevm/state](../globals.md) / AccountCache
+
+# Class: AccountCache
+
+## Extends
+
+- `Cache`
+
+## Constructors
+
+### new AccountCache()
+
+> **new AccountCache**(`opts`): [`AccountCache`](AccountCache.md)
+
+#### Parameters
+
+• **opts**: `CacheOpts`
+
+#### Returns
+
+[`AccountCache`](AccountCache.md)
+
+#### Overrides
+
+`Cache.constructor`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:27
+
+## Properties
+
+### \_checkpoints
+
+> **\_checkpoints**: `number`
+
+#### Inherited from
+
+`Cache._checkpoints`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:4
+
+***
+
+### \_debug
+
+> **\_debug**: `Debugger`
+
+#### Inherited from
+
+`Cache._debug`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:3
+
+***
+
+### \_diffCache
+
+> **\_diffCache**: `Map`\<`string`, `undefined` \| `AccountCacheElement`\>[]
+
+Diff cache collecting the state of the cache
+at the beginning of checkpoint height
+(respectively: before a first modification)
+
+If the whole cache element is undefined (in contrast
+to the account), the element didn't exist in the cache
+before.
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:26
+
+***
+
+### \_lruCache
+
+> **\_lruCache**: `undefined` \| `LRUCache`\<`string`, `AccountCacheElement`, `unknown`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:15
+
+***
+
+### \_orderedMapCache
+
+> **\_orderedMapCache**: `undefined` \| `OrderedMap`\<`string`, `AccountCacheElement`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:16
+
+***
+
+### \_stats
+
+> **\_stats**: `object`
+
+#### dels
+
+> **dels**: `number`
+
+#### hits
+
+> **hits**: `number`
+
+#### reads
+
+> **reads**: `number`
+
+#### size
+
+> **size**: `number`
+
+#### writes
+
+> **writes**: `number`
+
+#### Inherited from
+
+`Cache._stats`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:5
+
+## Methods
+
+### \_saveCachePreState()
+
+> **\_saveCachePreState**(`cacheKeyHex`): `void`
+
+#### Parameters
+
+• **cacheKeyHex**: `string`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:28
+
+***
+
+### checkpoint()
+
+> **checkpoint**(): `void`
+
+Marks current state of cache as checkpoint, which can
+later on be reverted or committed.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:62
+
+***
+
+### clear()
+
+> **clear**(): `void`
+
+Clears cache.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:82
+
+***
+
+### commit()
+
+> **commit**(): `void`
+
+Commits to current state of cache (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:57
+
+***
+
+### del()
+
+> **del**(`address`): `void`
+
+Marks address as deleted in cache.
+
+#### Parameters
+
+• **address**: `Address`
+
+Address
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:44
+
+***
+
+### flush()
+
+> **flush**(): [`string`, `AccountCacheElement`][]
+
+Flushes cache by returning accounts that have been modified
+or deleted and resetting the diff cache (at checkpoint height).
+
+#### Returns
+
+[`string`, `AccountCacheElement`][]
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:49
+
+***
+
+### get()
+
+> **get**(`address`): `undefined` \| `AccountCacheElement`
+
+Returns the queried account or undefined if account doesn't exist
+
+#### Parameters
+
+• **address**: `Address`
+
+Address of account
+
+#### Returns
+
+`undefined` \| `AccountCacheElement`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:39
+
+***
+
+### put()
+
+> **put**(`address`, `account`): `void`
+
+Puts account to cache under its address.
+
+#### Parameters
+
+• **address**: `Address`
+
+Address of account
+
+• **account**: `undefined` \| `Account`
+
+Account or undefined if account doesn't exist in the trie
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:34
+
+***
+
+### revert()
+
+> **revert**(): `void`
+
+Revert changes to cache last checkpoint (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:53
+
+***
+
+### size()
+
+> **size**(): `number`
+
+Returns the size of the cache
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:67
+
+***
+
+### stats()
+
+> **stats**(`reset`?): `object`
+
+Returns a dict with cache stats
+
+#### Parameters
+
+• **reset?**: `boolean`
+
+#### Returns
+
+`object`
+
+##### dels
+
+> **dels**: `number`
+
+##### hits
+
+> **hits**: `number`
+
+##### reads
+
+> **reads**: `number`
+
+##### size
+
+> **size**: `number`
+
+##### writes
+
+> **writes**: `number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:72

--- a/packages/state/docs/classes/ContractCache.md
+++ b/packages/state/docs/classes/ContractCache.md
@@ -17,7 +17,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Parameters
 
-• **storageCache**: `StorageCache` = `...`
+• **storageCache**: [`StorageCache`](StorageCache.md) = `...`
 
 #### Returns
 
@@ -31,7 +31,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 ### storageCache
 
-> **storageCache**: `StorageCache`
+> **storageCache**: [`StorageCache`](StorageCache.md)
 
 #### Defined in
 

--- a/packages/state/docs/classes/StorageCache.md
+++ b/packages/state/docs/classes/StorageCache.md
@@ -1,0 +1,419 @@
+[**@tevm/state**](../README.md) • **Docs**
+
+***
+
+[@tevm/state](../globals.md) / StorageCache
+
+# Class: StorageCache
+
+## Extends
+
+- `Cache`
+
+## Constructors
+
+### new StorageCache()
+
+> **new StorageCache**(`opts`): [`StorageCache`](StorageCache.md)
+
+#### Parameters
+
+• **opts**: `CacheOpts`
+
+#### Returns
+
+[`StorageCache`](StorageCache.md)
+
+#### Overrides
+
+`Cache.constructor`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:26
+
+## Properties
+
+### \_checkpoints
+
+> **\_checkpoints**: `number`
+
+#### Inherited from
+
+`Cache._checkpoints`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:4
+
+***
+
+### \_debug
+
+> **\_debug**: `Debugger`
+
+#### Inherited from
+
+`Cache._debug`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:3
+
+***
+
+### \_diffCache
+
+> **\_diffCache**: `Map`\<`string`, `DiffStorageCacheMap`\>[]
+
+Diff cache collecting the state of the cache
+at the beginning of checkpoint height
+(respectively: before a first modification)
+
+If the whole cache element is undefined (in contrast
+to the account), the element didn't exist in the cache
+before.
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:25
+
+***
+
+### \_lruCache
+
+> **\_lruCache**: `undefined` \| `LRUCache`\<`string`, `StorageCacheMap`, `unknown`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:14
+
+***
+
+### \_orderedMapCache
+
+> **\_orderedMapCache**: `undefined` \| `OrderedMap`\<`string`, `StorageCacheMap`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:15
+
+***
+
+### \_stats
+
+> **\_stats**: `object`
+
+#### dels
+
+> **dels**: `number`
+
+#### hits
+
+> **hits**: `number`
+
+#### reads
+
+> **reads**: `number`
+
+#### size
+
+> **size**: `number`
+
+#### writes
+
+> **writes**: `number`
+
+#### Inherited from
+
+`Cache._stats`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:5
+
+## Methods
+
+### \_saveCachePreState()
+
+> **\_saveCachePreState**(`addressHex`, `keyHex`): `void`
+
+#### Parameters
+
+• **addressHex**: `string`
+
+• **keyHex**: `string`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:27
+
+***
+
+### checkpoint()
+
+> **checkpoint**(): `void`
+
+Marks current state of cache as checkpoint, which can
+later on be reverted or committed.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:72
+
+***
+
+### clear()
+
+> **clear**(): `void`
+
+Clears cache.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:92
+
+***
+
+### clearContractStorage()
+
+> **clearContractStorage**(`address`): `void`
+
+Deletes all storage slots for address from the cache
+
+#### Parameters
+
+• **address**: `Address`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:54
+
+***
+
+### commit()
+
+> **commit**(): `void`
+
+Commits to current state of cache (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:67
+
+***
+
+### del()
+
+> **del**(`address`, `key`): `void`
+
+Marks storage key for address as deleted in cache.
+
+#### Parameters
+
+• **address**: `Address`
+
+Address
+
+• **key**: `Uint8Array`
+
+Storage key
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:49
+
+***
+
+### dump()
+
+> **dump**(`address`): `undefined` \| `StorageCacheMap`
+
+Dumps the RLP-encoded storage values for an `account` specified by `address`.
+
+#### Parameters
+
+• **address**: `Address`
+
+The address of the `account` to return storage for
+
+#### Returns
+
+`undefined` \| `StorageCacheMap`
+
+- The storage values for the `account` or undefined if the `account` is not in the cache
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:98
+
+***
+
+### flush()
+
+> **flush**(): [`string`, `string`, `undefined` \| `Uint8Array`][]
+
+Flushes cache by returning storage slots that have been modified
+or deleted and resetting the diff cache (at checkpoint height).
+
+#### Returns
+
+[`string`, `string`, `undefined` \| `Uint8Array`][]
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:59
+
+***
+
+### get()
+
+> **get**(`address`, `key`): `undefined` \| `Uint8Array`
+
+Returns the queried slot as the RLP encoded storage value
+hexToBytes('0x80'): slot is known to be empty
+undefined: slot is not in cache
+
+#### Parameters
+
+• **address**: `Address`
+
+Address of account
+
+• **key**: `Uint8Array`
+
+Storage key
+
+#### Returns
+
+`undefined` \| `Uint8Array`
+
+Storage value or undefined
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:43
+
+***
+
+### put()
+
+> **put**(`address`, `key`, `value`): `void`
+
+Puts storage value to cache under address_key cache key.
+
+#### Parameters
+
+• **address**: `Address`
+
+Account address
+
+• **key**: `Uint8Array`
+
+Storage key
+
+• **value**: `Uint8Array`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:34
+
+***
+
+### revert()
+
+> **revert**(): `void`
+
+Revert changes to cache last checkpoint (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:63
+
+***
+
+### size()
+
+> **size**(): `number`
+
+Returns the size of the cache
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:77
+
+***
+
+### stats()
+
+> **stats**(`reset`?): `object`
+
+Returns a dict with cache stats
+
+#### Parameters
+
+• **reset?**: `boolean`
+
+#### Returns
+
+`object`
+
+##### dels
+
+> **dels**: `number`
+
+##### hits
+
+> **hits**: `number`
+
+##### reads
+
+> **reads**: `number`
+
+##### size
+
+> **size**: `number`
+
+##### writes
+
+> **writes**: `number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:82

--- a/packages/state/docs/enumerations/CacheType.md
+++ b/packages/state/docs/enumerations/CacheType.md
@@ -1,0 +1,27 @@
+[**@tevm/state**](../README.md) • **Docs**
+
+***
+
+[@tevm/state](../globals.md) / CacheType
+
+# Enumeration: CacheType
+
+## Enumeration Members
+
+### LRU
+
+> **LRU**: `"lru"`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/types.d.ts:2
+
+***
+
+### ORDERED\_MAP
+
+> **ORDERED\_MAP**: `"ordered_map"`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/types.d.ts:3

--- a/packages/state/docs/globals.md
+++ b/packages/state/docs/globals.md
@@ -4,9 +4,15 @@
 
 # @tevm/state
 
+## Enumerations
+
+- [CacheType](enumerations/CacheType.md)
+
 ## Classes
 
+- [AccountCache](classes/AccountCache.md)
 - [ContractCache](classes/ContractCache.md)
+- [StorageCache](classes/StorageCache.md)
 
 ## Interfaces
 

--- a/packages/state/docs/type-aliases/StateCache.md
+++ b/packages/state/docs/type-aliases/StateCache.md
@@ -16,7 +16,7 @@ The shape of the internal cache
 
 ### accounts
 
-> **accounts**: `AccountCache`
+> **accounts**: [`AccountCache`](../classes/AccountCache.md)
 
 ### contracts
 
@@ -24,7 +24,7 @@ The shape of the internal cache
 
 ### storage
 
-> **storage**: `StorageCache`
+> **storage**: [`StorageCache`](../classes/StorageCache.md)
 
 ## Defined in
 

--- a/packages/state/docs/type-aliases/StateOptions.md
+++ b/packages/state/docs/type-aliases/StateOptions.md
@@ -10,6 +10,18 @@
 
 ## Type declaration
 
+### accountsCache?
+
+> `readonly` `optional` **accountsCache**: [`AccountCache`](../classes/AccountCache.md)
+
+Optionally configure the accounts cache
+
+### contractCache?
+
+> `readonly` `optional` **contractCache**: [`ContractCache`](../classes/ContractCache.md)
+
+Optionally configure and pass in your own ContractCache
+
 ### currentStateRoot?
 
 > `optional` **currentStateRoot**: `Hex`
@@ -46,6 +58,12 @@ Called when state manager commits state
 
 > `optional` **stateRoots**: [`StateRoots`](StateRoots.md)
 
+### storageCache?
+
+> `readonly` `optional` **storageCache**: [`StorageCache`](../classes/StorageCache.md)
+
+Optionally configure and pass in your own StorageCache
+
 ## Defined in
 
-[packages/state/src/state-types/StateOptions.ts:8](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/state-types/StateOptions.ts#L8)
+[packages/state/src/state-types/StateOptions.ts:10](https://github.com/evmts/tevm-monorepo/blob/main/packages/state/src/state-types/StateOptions.ts#L10)

--- a/packages/state/src/ContractCache.js
+++ b/packages/state/src/ContractCache.js
@@ -10,8 +10,8 @@ const oneBytes = Uint8Array.from([1])
 export class ContractCache {
 	constructor(
 		storageCache = new StorageCache({
-			size: 100000,
-			type: CacheType.ORDERED_MAP,
+			size: 100_000,
+			type: CacheType.LRU,
 		}),
 	) {
 		this.storageCache = storageCache
@@ -69,7 +69,9 @@ export class ContractCache {
 	 */
 	has(address) {
 		const storageMap = this.storageCache._orderedMapCache?.getElementByKey(bytesToUnprefixedHex(address.bytes))
-		return storageMap?.has(bytesToUnprefixedHex(oneBytes)) ?? false
+		const hasOrderedMapCache = storageMap?.has(bytesToUnprefixedHex(oneBytes)) ?? false
+		const hasLruCache = this.storageCache._lruCache?.has(bytesToUnprefixedHex(address.bytes))
+		return Boolean(hasOrderedMapCache || hasLruCache)
 	}
 
 	get _checkpoints() {

--- a/packages/state/src/actions/dumpCannonicalGenesis.js
+++ b/packages/state/src/actions/dumpCannonicalGenesis.js
@@ -2,6 +2,7 @@ import { EthjsAddress, bytesToHex, getAddress, toHex } from '@tevm/utils'
 import { dumpStorage } from './dumpStorage.js'
 import { getAccount } from './getAccount.js'
 import { getContractCode } from './getContractCode.js'
+import { getAccountAddresses } from './getAccountAddresses.js'
 
 // might be good to cache this to optimize perf and memory
 
@@ -10,17 +11,10 @@ import { getContractCode } from './getContractCode.js'
  * @type {import("../state-types/index.js").StateAction<'dumpCanonicalGenesis'>}
  */
 export const dumpCanonicalGenesis = (baseState) => async () => {
-	const {
-		caches: { accounts },
-	} = baseState
-
 	/**
 	 * @type {string[]}
 	 */
-	const accountAddresses = []
-	accounts._orderedMapCache?.forEach((e) => {
-		accountAddresses.push(e[0])
-	})
+	const accountAddresses = getAccountAddresses(baseState)()
 
 	/**
 	 * @type {import('../state-types/TevmState.js').TevmState}
@@ -28,7 +22,7 @@ export const dumpCanonicalGenesis = (baseState) => async () => {
 	const state = {}
 
 	for (const address of accountAddresses) {
-		const hexAddress = getAddress(`0x${address}`)
+		const hexAddress = getAddress(address.startsWith('0x') ? address : `0x${address}`)
 		const ethAddress = EthjsAddress.fromString(hexAddress)
 		const account = await getAccount(baseState, true)(ethAddress)
 

--- a/packages/state/src/actions/dumpCannonicalGenesis.js
+++ b/packages/state/src/actions/dumpCannonicalGenesis.js
@@ -1,8 +1,8 @@
 import { EthjsAddress, bytesToHex, getAddress, toHex } from '@tevm/utils'
 import { dumpStorage } from './dumpStorage.js'
 import { getAccount } from './getAccount.js'
-import { getContractCode } from './getContractCode.js'
 import { getAccountAddresses } from './getAccountAddresses.js'
+import { getContractCode } from './getContractCode.js'
 
 // might be good to cache this to optimize perf and memory
 

--- a/packages/state/src/actions/getAccountAddresses.js
+++ b/packages/state/src/actions/getAccountAddresses.js
@@ -1,14 +1,23 @@
+import { getAddress } from '@tevm/utils'
+
 /**
  * @type {import("../state-types/index.js").StateAction<'getAccountAddresses'>}
  */
 export const getAccountAddresses = (baseState) => () => {
 	/**
-	 * @type {string[]}
+	 * @type {Array<import('@tevm/utils').Address>}
 	 */
 	const accountAddresses = []
 	//Tevm initializes stateManager account cache with an ordered map cache
 	baseState.caches.accounts._orderedMapCache?.forEach((e) => {
-		accountAddresses.push(e[0])
+		accountAddresses.push(getAddress(e[0].startsWith('0x') ? e[0] : `0x${e[0]}`))
 	})
-	return /** @type {import("viem").Address[]}*/ (accountAddresses)
+	const { _lruCache } = baseState.caches.accounts
+	if (_lruCache !== undefined) {
+		for (const address of _lruCache.rkeys()) {
+			accountAddresses.push(getAddress(address.startsWith('0x') ? address : `0x${address}`))
+		}
+	}
+
+	return accountAddresses
 }

--- a/packages/state/src/createBaseState.js
+++ b/packages/state/src/createBaseState.js
@@ -47,7 +47,7 @@ export const createBaseState = (options) => {
 		stateRoots,
 		options,
 		caches: {
-			contracts: options.contractCache ?? new ContractCache(),
+			contracts: options.contractCache ?? new ContractCache(new StorageCache({ size: 100_000, type: CacheType.LRU })),
 			accounts:
 				options.accountsCache ??
 				new AccountCache({

--- a/packages/state/src/createBaseState.js
+++ b/packages/state/src/createBaseState.js
@@ -51,14 +51,14 @@ export const createBaseState = (options) => {
 			accounts:
 				options.accountsCache ??
 				new AccountCache({
-					size: 1_000_000_000,
-					type: CacheType.ORDERED_MAP,
+					size: 100_000,
+					type: CacheType.LRU,
 				}),
 			storage:
 				options.storageCache ??
 				new StorageCache({
-					size: 1_000_000_000,
-					type: CacheType.ORDERED_MAP,
+					size: 100_000,
+					type: CacheType.LRU,
 				}),
 		},
 		ready: () => genesisPromise.then(() => true),

--- a/packages/state/src/createBaseState.js
+++ b/packages/state/src/createBaseState.js
@@ -47,15 +47,19 @@ export const createBaseState = (options) => {
 		stateRoots,
 		options,
 		caches: {
-			contracts: new ContractCache(),
-			accounts: new AccountCache({
-				size: 1_000_000_000,
-				type: CacheType.ORDERED_MAP,
-			}),
-			storage: new StorageCache({
-				size: 1_000_000_000,
-				type: CacheType.ORDERED_MAP,
-			}),
+			contracts: options.contractCache ?? new ContractCache(),
+			accounts:
+				options.accountsCache ??
+				new AccountCache({
+					size: 1_000_000_000,
+					type: CacheType.ORDERED_MAP,
+				}),
+			storage:
+				options.storageCache ??
+				new StorageCache({
+					size: 1_000_000_000,
+					type: CacheType.ORDERED_MAP,
+				}),
 		},
 		ready: () => genesisPromise.then(() => true),
 	}

--- a/packages/state/src/createBaseState.spec.ts
+++ b/packages/state/src/createBaseState.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { AccountCache, CacheType, StorageCache } from '@ethereumjs/statemanager'
+import { ContractCache } from './ContractCache.js'
+import { createBaseState } from './createBaseState.js'
+
+describe(createBaseState.name, () => {
+	it('should be able to pass in custom caches', () => {
+		const contractCache = new ContractCache(new StorageCache({ size: 100, type: CacheType.LRU }))
+		const storageCache = new StorageCache({ size: 100, type: CacheType.LRU })
+		const accountsCache = new AccountCache({ size: 100, type: CacheType.LRU })
+		const state = createBaseState({
+			contractCache,
+			storageCache,
+			accountsCache,
+		})
+		expect(state.caches.storage).toBe(storageCache)
+		expect(state.caches.contracts).toBe(contractCache)
+		expect(state.caches.accounts).toBe(accountsCache)
+	})
+})

--- a/packages/state/src/index.js
+++ b/packages/state/src/index.js
@@ -32,3 +32,4 @@ export {
 	generateCanonicalGenesis,
 	originalStorageCache,
 } from './actions/index.js'
+export { AccountCache, CacheType, StorageCache } from '@ethereumjs/statemanager'

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -46,3 +46,4 @@ export {
 	generateCanonicalGenesis,
 	originalStorageCache,
 } from './actions/index.js'
+export { AccountCache, CacheType, StorageCache } from '@ethereumjs/statemanager'

--- a/packages/state/src/state-types/StateOptions.ts
+++ b/packages/state/src/state-types/StateOptions.ts
@@ -1,6 +1,8 @@
+import type { AccountCache, StorageCache } from '@ethereumjs/statemanager'
 import type { LogOptions } from '@tevm/logger'
 import type { Hex } from 'viem'
 import type { BaseState } from '../BaseState.js'
+import type { ContractCache } from '../ContractCache.js'
 import type { ForkOptions } from './ForkOptions.js'
 import type { StateRoots } from './StateRoots.js'
 import type { TevmState } from './TevmState.js'
@@ -18,4 +20,16 @@ export type StateOptions = {
 	 * Configure logging options for the client
 	 */
 	readonly loggingLevel?: LogOptions['level']
+	/**
+	 * Optionally configure and pass in your own ContractCache
+	 */
+	readonly contractCache?: ContractCache
+	/**
+	 * Optionally configure and pass in your own StorageCache
+	 */
+	readonly storageCache?: StorageCache
+	/**
+	 * Optionally configure the accounts cache
+	 */
+	readonly accountsCache?: AccountCache
 }

--- a/tevm/docs/index/type-aliases/StateOptions.md
+++ b/tevm/docs/index/type-aliases/StateOptions.md
@@ -10,6 +10,18 @@
 
 ## Type declaration
 
+### accountsCache?
+
+> `readonly` `optional` **accountsCache**: [`AccountCache`](../../state/classes/AccountCache.md)
+
+Optionally configure the accounts cache
+
+### contractCache?
+
+> `readonly` `optional` **contractCache**: [`ContractCache`](../../state/classes/ContractCache.md)
+
+Optionally configure and pass in your own ContractCache
+
 ### currentStateRoot?
 
 > `optional` **currentStateRoot**: [`Hex`](Hex.md)
@@ -46,6 +58,12 @@ Called when state manager commits state
 
 > `optional` **stateRoots**: [`StateRoots`](../../state/type-aliases/StateRoots.md)
 
+### storageCache?
+
+> `readonly` `optional` **storageCache**: [`StorageCache`](../../state/classes/StorageCache.md)
+
+Optionally configure and pass in your own StorageCache
+
 ## Defined in
 
-packages/state/dist/index.d.ts:174
+packages/state/dist/index.d.ts:175

--- a/tevm/docs/index/type-aliases/TevmState.md
+++ b/tevm/docs/index/type-aliases/TevmState.md
@@ -14,4 +14,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:165
+packages/state/dist/index.d.ts:166

--- a/tevm/docs/state/README.md
+++ b/tevm/docs/state/README.md
@@ -8,9 +8,15 @@
 
 ## Index
 
+### Enumerations
+
+- [CacheType](enumerations/CacheType.md)
+
 ### Classes
 
+- [AccountCache](classes/AccountCache.md)
 - [ContractCache](classes/ContractCache.md)
+- [StorageCache](classes/StorageCache.md)
 
 ### Interfaces
 

--- a/tevm/docs/state/classes/AccountCache.md
+++ b/tevm/docs/state/classes/AccountCache.md
@@ -1,0 +1,359 @@
+[**tevm**](../../README.md) • **Docs**
+
+***
+
+[tevm](../../modules.md) / [state](../README.md) / AccountCache
+
+# Class: AccountCache
+
+## Extends
+
+- `Cache`
+
+## Constructors
+
+### new AccountCache()
+
+> **new AccountCache**(`opts`): [`AccountCache`](AccountCache.md)
+
+#### Parameters
+
+• **opts**: `CacheOpts`
+
+#### Returns
+
+[`AccountCache`](AccountCache.md)
+
+#### Overrides
+
+`Cache.constructor`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:27
+
+## Properties
+
+### \_checkpoints
+
+> **\_checkpoints**: `number`
+
+#### Inherited from
+
+`Cache._checkpoints`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:4
+
+***
+
+### \_debug
+
+> **\_debug**: `Debugger`
+
+#### Inherited from
+
+`Cache._debug`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:3
+
+***
+
+### \_diffCache
+
+> **\_diffCache**: `Map`\<`string`, `undefined` \| `AccountCacheElement`\>[]
+
+Diff cache collecting the state of the cache
+at the beginning of checkpoint height
+(respectively: before a first modification)
+
+If the whole cache element is undefined (in contrast
+to the account), the element didn't exist in the cache
+before.
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:26
+
+***
+
+### \_lruCache
+
+> **\_lruCache**: `undefined` \| `LRUCache`\<`string`, `AccountCacheElement`, `unknown`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:15
+
+***
+
+### \_orderedMapCache
+
+> **\_orderedMapCache**: `undefined` \| `OrderedMap`\<`string`, `AccountCacheElement`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:16
+
+***
+
+### \_stats
+
+> **\_stats**: `object`
+
+#### dels
+
+> **dels**: `number`
+
+#### hits
+
+> **hits**: `number`
+
+#### reads
+
+> **reads**: `number`
+
+#### size
+
+> **size**: `number`
+
+#### writes
+
+> **writes**: `number`
+
+#### Inherited from
+
+`Cache._stats`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:5
+
+## Methods
+
+### \_saveCachePreState()
+
+> **\_saveCachePreState**(`cacheKeyHex`): `void`
+
+#### Parameters
+
+• **cacheKeyHex**: `string`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:28
+
+***
+
+### checkpoint()
+
+> **checkpoint**(): `void`
+
+Marks current state of cache as checkpoint, which can
+later on be reverted or committed.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:62
+
+***
+
+### clear()
+
+> **clear**(): `void`
+
+Clears cache.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:82
+
+***
+
+### commit()
+
+> **commit**(): `void`
+
+Commits to current state of cache (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:57
+
+***
+
+### del()
+
+> **del**(`address`): `void`
+
+Marks address as deleted in cache.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+Address
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:44
+
+***
+
+### flush()
+
+> **flush**(): [`string`, `AccountCacheElement`][]
+
+Flushes cache by returning accounts that have been modified
+or deleted and resetting the diff cache (at checkpoint height).
+
+#### Returns
+
+[`string`, `AccountCacheElement`][]
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:49
+
+***
+
+### get()
+
+> **get**(`address`): `undefined` \| `AccountCacheElement`
+
+Returns the queried account or undefined if account doesn't exist
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+Address of account
+
+#### Returns
+
+`undefined` \| `AccountCacheElement`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:39
+
+***
+
+### put()
+
+> **put**(`address`, `account`): `void`
+
+Puts account to cache under its address.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+Address of account
+
+• **account**: `undefined` \| [`EthjsAccount`](../../utils/classes/EthjsAccount.md)
+
+Account or undefined if account doesn't exist in the trie
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:34
+
+***
+
+### revert()
+
+> **revert**(): `void`
+
+Revert changes to cache last checkpoint (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:53
+
+***
+
+### size()
+
+> **size**(): `number`
+
+Returns the size of the cache
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:67
+
+***
+
+### stats()
+
+> **stats**(`reset`?): `object`
+
+Returns a dict with cache stats
+
+#### Parameters
+
+• **reset?**: `boolean`
+
+#### Returns
+
+`object`
+
+##### dels
+
+> **dels**: `number`
+
+##### hits
+
+> **hits**: `number`
+
+##### reads
+
+> **reads**: `number`
+
+##### size
+
+> **size**: `number`
+
+##### writes
+
+> **writes**: `number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/account.d.ts:72

--- a/tevm/docs/state/classes/ContractCache.md
+++ b/tevm/docs/state/classes/ContractCache.md
@@ -17,7 +17,7 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Parameters
 
-• **storageCache?**: `StorageCache`
+• **storageCache?**: [`StorageCache`](StorageCache.md)
 
 #### Returns
 
@@ -25,17 +25,17 @@ It is implemented via extending StorageCache and hardcoding slot 0
 
 #### Defined in
 
-packages/state/dist/index.d.ts:52
+packages/state/dist/index.d.ts:53
 
 ## Properties
 
 ### storageCache
 
-> **storageCache**: `StorageCache`
+> **storageCache**: [`StorageCache`](StorageCache.md)
 
 #### Defined in
 
-packages/state/dist/index.d.ts:53
+packages/state/dist/index.d.ts:54
 
 ## Accessors
 
@@ -49,7 +49,7 @@ packages/state/dist/index.d.ts:53
 
 #### Defined in
 
-packages/state/dist/index.d.ts:87
+packages/state/dist/index.d.ts:88
 
 ## Methods
 
@@ -63,7 +63,7 @@ packages/state/dist/index.d.ts:87
 
 #### Defined in
 
-packages/state/dist/index.d.ts:81
+packages/state/dist/index.d.ts:82
 
 ***
 
@@ -77,7 +77,7 @@ packages/state/dist/index.d.ts:81
 
 #### Defined in
 
-packages/state/dist/index.d.ts:61
+packages/state/dist/index.d.ts:62
 
 ***
 
@@ -91,7 +91,7 @@ packages/state/dist/index.d.ts:61
 
 #### Defined in
 
-packages/state/dist/index.d.ts:57
+packages/state/dist/index.d.ts:58
 
 ***
 
@@ -109,7 +109,7 @@ packages/state/dist/index.d.ts:57
 
 #### Defined in
 
-packages/state/dist/index.d.ts:77
+packages/state/dist/index.d.ts:78
 
 ***
 
@@ -127,7 +127,7 @@ packages/state/dist/index.d.ts:77
 
 #### Defined in
 
-packages/state/dist/index.d.ts:66
+packages/state/dist/index.d.ts:67
 
 ***
 
@@ -147,7 +147,7 @@ if the cache has the key
 
 #### Defined in
 
-packages/state/dist/index.d.ts:86
+packages/state/dist/index.d.ts:87
 
 ***
 
@@ -167,7 +167,7 @@ packages/state/dist/index.d.ts:86
 
 #### Defined in
 
-packages/state/dist/index.d.ts:72
+packages/state/dist/index.d.ts:73
 
 ***
 
@@ -181,7 +181,7 @@ packages/state/dist/index.d.ts:72
 
 #### Defined in
 
-packages/state/dist/index.d.ts:92
+packages/state/dist/index.d.ts:93
 
 ***
 
@@ -195,4 +195,4 @@ packages/state/dist/index.d.ts:92
 
 #### Defined in
 
-packages/state/dist/index.d.ts:88
+packages/state/dist/index.d.ts:89

--- a/tevm/docs/state/classes/StorageCache.md
+++ b/tevm/docs/state/classes/StorageCache.md
@@ -1,0 +1,419 @@
+[**tevm**](../../README.md) • **Docs**
+
+***
+
+[tevm](../../modules.md) / [state](../README.md) / StorageCache
+
+# Class: StorageCache
+
+## Extends
+
+- `Cache`
+
+## Constructors
+
+### new StorageCache()
+
+> **new StorageCache**(`opts`): [`StorageCache`](StorageCache.md)
+
+#### Parameters
+
+• **opts**: `CacheOpts`
+
+#### Returns
+
+[`StorageCache`](StorageCache.md)
+
+#### Overrides
+
+`Cache.constructor`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:26
+
+## Properties
+
+### \_checkpoints
+
+> **\_checkpoints**: `number`
+
+#### Inherited from
+
+`Cache._checkpoints`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:4
+
+***
+
+### \_debug
+
+> **\_debug**: `Debugger`
+
+#### Inherited from
+
+`Cache._debug`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:3
+
+***
+
+### \_diffCache
+
+> **\_diffCache**: `Map`\<`string`, `DiffStorageCacheMap`\>[]
+
+Diff cache collecting the state of the cache
+at the beginning of checkpoint height
+(respectively: before a first modification)
+
+If the whole cache element is undefined (in contrast
+to the account), the element didn't exist in the cache
+before.
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:25
+
+***
+
+### \_lruCache
+
+> **\_lruCache**: `undefined` \| `LRUCache`\<`string`, `StorageCacheMap`, `unknown`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:14
+
+***
+
+### \_orderedMapCache
+
+> **\_orderedMapCache**: `undefined` \| `OrderedMap`\<`string`, `StorageCacheMap`\>
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:15
+
+***
+
+### \_stats
+
+> **\_stats**: `object`
+
+#### dels
+
+> **dels**: `number`
+
+#### hits
+
+> **hits**: `number`
+
+#### reads
+
+> **reads**: `number`
+
+#### size
+
+> **size**: `number`
+
+#### writes
+
+> **writes**: `number`
+
+#### Inherited from
+
+`Cache._stats`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/cache.d.ts:5
+
+## Methods
+
+### \_saveCachePreState()
+
+> **\_saveCachePreState**(`addressHex`, `keyHex`): `void`
+
+#### Parameters
+
+• **addressHex**: `string`
+
+• **keyHex**: `string`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:27
+
+***
+
+### checkpoint()
+
+> **checkpoint**(): `void`
+
+Marks current state of cache as checkpoint, which can
+later on be reverted or committed.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:72
+
+***
+
+### clear()
+
+> **clear**(): `void`
+
+Clears cache.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:92
+
+***
+
+### clearContractStorage()
+
+> **clearContractStorage**(`address`): `void`
+
+Deletes all storage slots for address from the cache
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:54
+
+***
+
+### commit()
+
+> **commit**(): `void`
+
+Commits to current state of cache (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:67
+
+***
+
+### del()
+
+> **del**(`address`, `key`): `void`
+
+Marks storage key for address as deleted in cache.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+Address
+
+• **key**: `Uint8Array`
+
+Storage key
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:49
+
+***
+
+### dump()
+
+> **dump**(`address`): `undefined` \| `StorageCacheMap`
+
+Dumps the RLP-encoded storage values for an `account` specified by `address`.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+The address of the `account` to return storage for
+
+#### Returns
+
+`undefined` \| `StorageCacheMap`
+
+- The storage values for the `account` or undefined if the `account` is not in the cache
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:98
+
+***
+
+### flush()
+
+> **flush**(): [`string`, `string`, `undefined` \| `Uint8Array`][]
+
+Flushes cache by returning storage slots that have been modified
+or deleted and resetting the diff cache (at checkpoint height).
+
+#### Returns
+
+[`string`, `string`, `undefined` \| `Uint8Array`][]
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:59
+
+***
+
+### get()
+
+> **get**(`address`, `key`): `undefined` \| `Uint8Array`
+
+Returns the queried slot as the RLP encoded storage value
+hexToBytes('0x80'): slot is known to be empty
+undefined: slot is not in cache
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+Address of account
+
+• **key**: `Uint8Array`
+
+Storage key
+
+#### Returns
+
+`undefined` \| `Uint8Array`
+
+Storage value or undefined
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:43
+
+***
+
+### put()
+
+> **put**(`address`, `key`, `value`): `void`
+
+Puts storage value to cache under address_key cache key.
+
+#### Parameters
+
+• **address**: [`EthjsAddress`](../../utils/classes/EthjsAddress.md)
+
+Account address
+
+• **key**: `Uint8Array`
+
+Storage key
+
+• **value**: `Uint8Array`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:34
+
+***
+
+### revert()
+
+> **revert**(): `void`
+
+Revert changes to cache last checkpoint (no effect on trie).
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:63
+
+***
+
+### size()
+
+> **size**(): `number`
+
+Returns the size of the cache
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:77
+
+***
+
+### stats()
+
+> **stats**(`reset`?): `object`
+
+Returns a dict with cache stats
+
+#### Parameters
+
+• **reset?**: `boolean`
+
+#### Returns
+
+`object`
+
+##### dels
+
+> **dels**: `number`
+
+##### hits
+
+> **hits**: `number`
+
+##### reads
+
+> **reads**: `number`
+
+##### size
+
+> **size**: `number`
+
+##### writes
+
+> **writes**: `number`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/storage.d.ts:82

--- a/tevm/docs/state/enumerations/CacheType.md
+++ b/tevm/docs/state/enumerations/CacheType.md
@@ -1,0 +1,27 @@
+[**tevm**](../../README.md) • **Docs**
+
+***
+
+[tevm](../../modules.md) / [state](../README.md) / CacheType
+
+# Enumeration: CacheType
+
+## Enumeration Members
+
+### LRU
+
+> **LRU**: `"lru"`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/types.d.ts:2
+
+***
+
+### ORDERED\_MAP
+
+> **ORDERED\_MAP**: `"ordered_map"`
+
+#### Defined in
+
+node\_modules/.pnpm/@ethereumjs+statemanager@2.3.0/node\_modules/@ethereumjs/statemanager/dist/esm/cache/types.d.ts:3

--- a/tevm/docs/state/functions/checkpoint.md
+++ b/tevm/docs/state/functions/checkpoint.md
@@ -27,4 +27,4 @@ last call to checkpoint.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:198
+packages/state/dist/index.d.ts:211

--- a/tevm/docs/state/functions/clearCaches.md
+++ b/tevm/docs/state/functions/clearCaches.md
@@ -28,4 +28,4 @@ Resets all internal caches
 
 ## Defined in
 
-packages/state/dist/index.d.ts:204
+packages/state/dist/index.d.ts:217

--- a/tevm/docs/state/functions/clearContractStorage.md
+++ b/tevm/docs/state/functions/clearContractStorage.md
@@ -30,4 +30,4 @@ Clears all storage entries for the account corresponding to `address`.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:210
+packages/state/dist/index.d.ts:223

--- a/tevm/docs/state/functions/commit.md
+++ b/tevm/docs/state/functions/commit.md
@@ -39,4 +39,4 @@ This api is not stable
 
 ## Defined in
 
-packages/state/dist/index.d.ts:217
+packages/state/dist/index.d.ts:230

--- a/tevm/docs/state/functions/createBaseState.md
+++ b/tevm/docs/state/functions/createBaseState.md
@@ -18,4 +18,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:191
+packages/state/dist/index.d.ts:204

--- a/tevm/docs/state/functions/createStateManager.md
+++ b/tevm/docs/state/functions/createStateManager.md
@@ -18,4 +18,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:189
+packages/state/dist/index.d.ts:202

--- a/tevm/docs/state/functions/deepCopy.md
+++ b/tevm/docs/state/functions/deepCopy.md
@@ -22,4 +22,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:219
+packages/state/dist/index.d.ts:232

--- a/tevm/docs/state/functions/deleteAccount.md
+++ b/tevm/docs/state/functions/deleteAccount.md
@@ -30,4 +30,4 @@ Deletes an account from state under the provided `address`.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:225
+packages/state/dist/index.d.ts:238

--- a/tevm/docs/state/functions/dumpCanonicalGenesis.md
+++ b/tevm/docs/state/functions/dumpCanonicalGenesis.md
@@ -28,4 +28,4 @@ Dumps the state of the state manager as a [TevmState](../../index/type-aliases/T
 
 ## Defined in
 
-packages/state/dist/index.d.ts:231
+packages/state/dist/index.d.ts:244

--- a/tevm/docs/state/functions/dumpStorage.md
+++ b/tevm/docs/state/functions/dumpStorage.md
@@ -32,4 +32,4 @@ Both are represented as `0x` prefixed hex strings.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:239
+packages/state/dist/index.d.ts:252

--- a/tevm/docs/state/functions/dumpStorageRange.md
+++ b/tevm/docs/state/functions/dumpStorageRange.md
@@ -32,4 +32,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:244
+packages/state/dist/index.d.ts:257

--- a/tevm/docs/state/functions/generateCanonicalGenesis.md
+++ b/tevm/docs/state/functions/generateCanonicalGenesis.md
@@ -30,4 +30,4 @@ Loads a [TevmState](../../index/type-aliases/TevmState.md) into the state manage
 
 ## Defined in
 
-packages/state/dist/index.d.ts:250
+packages/state/dist/index.d.ts:263

--- a/tevm/docs/state/functions/getAccount.md
+++ b/tevm/docs/state/functions/getAccount.md
@@ -30,4 +30,4 @@ Gets the code corresponding to the provided `address`.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:256
+packages/state/dist/index.d.ts:269

--- a/tevm/docs/state/functions/getAccountAddresses.md
+++ b/tevm/docs/state/functions/getAccountAddresses.md
@@ -24,4 +24,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:261
+packages/state/dist/index.d.ts:274

--- a/tevm/docs/state/functions/getAccountFromProvider.md
+++ b/tevm/docs/state/functions/getAccountFromProvider.md
@@ -26,4 +26,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:263
+packages/state/dist/index.d.ts:276

--- a/tevm/docs/state/functions/getAppliedKey.md
+++ b/tevm/docs/state/functions/getAppliedKey.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:271
+packages/state/dist/index.d.ts:284

--- a/tevm/docs/state/functions/getContractCode.md
+++ b/tevm/docs/state/functions/getContractCode.md
@@ -31,4 +31,4 @@ Returns an empty `Uint8Array` if the account has no associated code.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:278
+packages/state/dist/index.d.ts:291

--- a/tevm/docs/state/functions/getContractStorage.md
+++ b/tevm/docs/state/functions/getContractStorage.md
@@ -35,4 +35,4 @@ If this does not exist an empty `Uint8Array` is returned.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:287
+packages/state/dist/index.d.ts:300

--- a/tevm/docs/state/functions/getForkBlockTag.md
+++ b/tevm/docs/state/functions/getForkBlockTag.md
@@ -18,4 +18,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:289
+packages/state/dist/index.d.ts:302

--- a/tevm/docs/state/functions/getForkClient.md
+++ b/tevm/docs/state/functions/getForkClient.md
@@ -18,4 +18,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:295
+packages/state/dist/index.d.ts:308

--- a/tevm/docs/state/functions/getProof.md
+++ b/tevm/docs/state/functions/getProof.md
@@ -32,4 +32,4 @@ Get an EIP-1186 proof from the provider
 
 ## Defined in
 
-packages/state/dist/index.d.ts:301
+packages/state/dist/index.d.ts:314

--- a/tevm/docs/state/functions/getStateRoot.md
+++ b/tevm/docs/state/functions/getStateRoot.md
@@ -26,4 +26,4 @@ Gets the current state root
 
 ## Defined in
 
-packages/state/dist/index.d.ts:307
+packages/state/dist/index.d.ts:320

--- a/tevm/docs/state/functions/hasStateRoot.md
+++ b/tevm/docs/state/functions/hasStateRoot.md
@@ -30,4 +30,4 @@ Returns true if state root exists
 
 ## Defined in
 
-packages/state/dist/index.d.ts:313
+packages/state/dist/index.d.ts:326

--- a/tevm/docs/state/functions/modifyAccountFields.md
+++ b/tevm/docs/state/functions/modifyAccountFields.md
@@ -34,4 +34,4 @@ fields, then saves the account into state. Account fields can include
 
 ## Defined in
 
-packages/state/dist/index.d.ts:321
+packages/state/dist/index.d.ts:334

--- a/tevm/docs/state/functions/originalStorageCache.md
+++ b/tevm/docs/state/functions/originalStorageCache.md
@@ -41,4 +41,4 @@ last call to checkpoint.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:365
+packages/state/dist/index.d.ts:378

--- a/tevm/docs/state/functions/putAccount.md
+++ b/tevm/docs/state/functions/putAccount.md
@@ -32,4 +32,4 @@ Saves an account into state under the provided `address`.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:327
+packages/state/dist/index.d.ts:340

--- a/tevm/docs/state/functions/putContractCode.md
+++ b/tevm/docs/state/functions/putContractCode.md
@@ -33,4 +33,4 @@ corresponding to `address` to reference this.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:334
+packages/state/dist/index.d.ts:347

--- a/tevm/docs/state/functions/putContractStorage.md
+++ b/tevm/docs/state/functions/putContractStorage.md
@@ -37,4 +37,4 @@ If it is empty or filled with zeros, deletes the value.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:343
+packages/state/dist/index.d.ts:356

--- a/tevm/docs/state/functions/revert.md
+++ b/tevm/docs/state/functions/revert.md
@@ -27,4 +27,4 @@ last call to checkpoint.
 
 ## Defined in
 
-packages/state/dist/index.d.ts:350
+packages/state/dist/index.d.ts:363

--- a/tevm/docs/state/functions/setStateRoot.md
+++ b/tevm/docs/state/functions/setStateRoot.md
@@ -32,4 +32,4 @@ Changes the currently loaded state root
 
 ## Defined in
 
-packages/state/dist/index.d.ts:356
+packages/state/dist/index.d.ts:369

--- a/tevm/docs/state/functions/shallowCopy.md
+++ b/tevm/docs/state/functions/shallowCopy.md
@@ -22,4 +22,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:358
+packages/state/dist/index.d.ts:371

--- a/tevm/docs/state/interfaces/AccountStorage.md
+++ b/tevm/docs/state/interfaces/AccountStorage.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-packages/state/dist/index.d.ts:11
+packages/state/dist/index.d.ts:12
 
 ***
 
@@ -24,7 +24,7 @@ packages/state/dist/index.d.ts:11
 
 #### Defined in
 
-packages/state/dist/index.d.ts:13
+packages/state/dist/index.d.ts:14
 
 ***
 
@@ -34,7 +34,7 @@ packages/state/dist/index.d.ts:13
 
 #### Defined in
 
-packages/state/dist/index.d.ts:14
+packages/state/dist/index.d.ts:15
 
 ***
 
@@ -44,7 +44,7 @@ packages/state/dist/index.d.ts:14
 
 #### Defined in
 
-packages/state/dist/index.d.ts:10
+packages/state/dist/index.d.ts:11
 
 ***
 
@@ -54,7 +54,7 @@ packages/state/dist/index.d.ts:10
 
 #### Defined in
 
-packages/state/dist/index.d.ts:15
+packages/state/dist/index.d.ts:16
 
 ***
 
@@ -64,4 +64,4 @@ packages/state/dist/index.d.ts:15
 
 #### Defined in
 
-packages/state/dist/index.d.ts:12
+packages/state/dist/index.d.ts:13

--- a/tevm/docs/state/interfaces/ForkOptions.md
+++ b/tevm/docs/state/interfaces/ForkOptions.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-packages/state/dist/index.d.ts:22
+packages/state/dist/index.d.ts:23
 
 ***
 
@@ -28,4 +28,4 @@ packages/state/dist/index.d.ts:22
 
 #### Defined in
 
-packages/state/dist/index.d.ts:19
+packages/state/dist/index.d.ts:20

--- a/tevm/docs/state/interfaces/ParameterizedAccountStorage.md
+++ b/tevm/docs/state/interfaces/ParameterizedAccountStorage.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-packages/state/dist/index.d.ts:27
+packages/state/dist/index.d.ts:28
 
 ***
 
@@ -24,7 +24,7 @@ packages/state/dist/index.d.ts:27
 
 #### Defined in
 
-packages/state/dist/index.d.ts:29
+packages/state/dist/index.d.ts:30
 
 ***
 
@@ -34,7 +34,7 @@ packages/state/dist/index.d.ts:29
 
 #### Defined in
 
-packages/state/dist/index.d.ts:26
+packages/state/dist/index.d.ts:27
 
 ***
 
@@ -44,7 +44,7 @@ packages/state/dist/index.d.ts:26
 
 #### Defined in
 
-packages/state/dist/index.d.ts:30
+packages/state/dist/index.d.ts:31
 
 ***
 
@@ -54,4 +54,4 @@ packages/state/dist/index.d.ts:30
 
 #### Defined in
 
-packages/state/dist/index.d.ts:28
+packages/state/dist/index.d.ts:29

--- a/tevm/docs/state/interfaces/StateManager.md
+++ b/tevm/docs/state/interfaces/StateManager.md
@@ -20,7 +20,7 @@ The internal state representation
 
 #### Defined in
 
-packages/state/dist/index.d.ts:126
+packages/state/dist/index.d.ts:127
 
 ***
 
@@ -36,7 +36,7 @@ Returns contract addresses
 
 #### Defined in
 
-packages/state/dist/index.d.ts:131
+packages/state/dist/index.d.ts:132
 
 ***
 
@@ -82,7 +82,7 @@ node\_modules/.pnpm/@ethereumjs+common@4.3.0/node\_modules/@ethereumjs/common/di
 
 #### Defined in
 
-packages/state/dist/index.d.ts:127
+packages/state/dist/index.d.ts:128
 
 ## Methods
 
@@ -116,7 +116,7 @@ Resets all internal caches
 
 #### Defined in
 
-packages/state/dist/index.d.ts:143
+packages/state/dist/index.d.ts:144
 
 ***
 
@@ -168,7 +168,7 @@ This api is not stable
 
 #### Defined in
 
-packages/state/dist/index.d.ts:153
+packages/state/dist/index.d.ts:154
 
 ***
 
@@ -184,7 +184,7 @@ Returns a new instance of the ForkStateManager with the same opts and all storag
 
 #### Defined in
 
-packages/state/dist/index.d.ts:135
+packages/state/dist/index.d.ts:136
 
 ***
 
@@ -222,7 +222,7 @@ Dumps the state of the state manager as a [TevmState](../../index/type-aliases/T
 
 #### Defined in
 
-packages/state/dist/index.d.ts:139
+packages/state/dist/index.d.ts:140
 
 ***
 
@@ -587,7 +587,7 @@ THis API is considered unstable
 
 #### Defined in
 
-packages/state/dist/index.d.ts:149
+packages/state/dist/index.d.ts:150
 
 ***
 

--- a/tevm/docs/state/type-aliases/BaseState.md
+++ b/tevm/docs/state/type-aliases/BaseState.md
@@ -62,4 +62,4 @@ Mapping of hashes to State roots
 
 ## Defined in
 
-packages/state/dist/index.d.ts:109
+packages/state/dist/index.d.ts:110

--- a/tevm/docs/state/type-aliases/ParameterizedTevmState.md
+++ b/tevm/docs/state/type-aliases/ParameterizedTevmState.md
@@ -14,4 +14,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:33
+packages/state/dist/index.d.ts:34

--- a/tevm/docs/state/type-aliases/SerializableTevmState.md
+++ b/tevm/docs/state/type-aliases/SerializableTevmState.md
@@ -14,4 +14,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:37
+packages/state/dist/index.d.ts:38

--- a/tevm/docs/state/type-aliases/StateAction.md
+++ b/tevm/docs/state/type-aliases/StateAction.md
@@ -24,4 +24,4 @@
 
 ## Defined in
 
-packages/state/dist/index.d.ts:163
+packages/state/dist/index.d.ts:164

--- a/tevm/docs/state/type-aliases/StateCache.md
+++ b/tevm/docs/state/type-aliases/StateCache.md
@@ -16,7 +16,7 @@ The shape of the internal cache
 
 ### accounts
 
-> **accounts**: `AccountCache`
+> **accounts**: [`AccountCache`](../classes/AccountCache.md)
 
 ### contracts
 
@@ -24,8 +24,8 @@ The shape of the internal cache
 
 ### storage
 
-> **storage**: `StorageCache`
+> **storage**: [`StorageCache`](../classes/StorageCache.md)
 
 ## Defined in
 
-packages/state/dist/index.d.ts:99
+packages/state/dist/index.d.ts:100

--- a/tevm/docs/state/type-aliases/StateRoots.md
+++ b/tevm/docs/state/type-aliases/StateRoots.md
@@ -12,4 +12,4 @@ Mapping of state roots as hex string to the state
 
 ## Defined in
 
-packages/state/dist/index.d.ts:172
+packages/state/dist/index.d.ts:173


### PR DESCRIPTION
closes https://github.com/evmts/tevm-monorepo/issues/766

Added options to configure and pass in custom caches. For example caches that prune old state sooner.

---

## Description

_Concise description of proposed changes_

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced options to configure custom caches for state management, including `AccountCache`, `ContractCache`, and `StorageCache`.
  
- **Documentation**
  - Added detailed documentation for `AccountCache`, `ContractCache`, and `StorageCache`.
  - Introduced the `CacheType` enumeration.

- **Chores**
  - Updated GitHub actions to improve `pnpm` setup and caching.

- **Refactor**
  - Modified cache initialization to use default values from options if available.
  
- **Tests**
  - Added a test case to validate `createBaseState` function's ability to accept custom caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->