### PR TITLE
:bug: Fix: #1341 bug with remappings not using absolute paths

### DIFF
--- a/.changeset/wicked-ravens-retire.md
+++ b/.changeset/wicked-ravens-retire.md
@@ -1,0 +1,5 @@
+---
+"@tevm/config": patch
+---
+
+Fixed bug with remappings sometimes failing to append the rootdir. This would not cause issues in most bundlers but did cause issues in ts-plugin in some setups

--- a/bundler-packages/config/src/json/loadRemappingstxt.js
+++ b/bundler-packages/config/src/json/loadRemappingstxt.js
@@ -74,7 +74,8 @@ export const loadRemappings = (configFilePath) => {
 				remappings: Object.fromEntries(
 					remappingEntries.map((remapping) => {
 						const [from, to] = remapping.trim().split('=')
-						return /** @type {[string, string]}*/ ([from, `${configFilePath}${to}`])
+						// TODO this line of code won't work on windows
+						return /** @type {[string, string]}*/ ([from, `${configFilePath.endsWith('/') ? configFilePath : `${configFilePath}/`}${to?.startsWith('/') ? to.slice(1) : to}`])
 					}),
 				),
 			}

--- a/bundler-packages/config/src/json/loadRemappingstxt.js
+++ b/bundler-packages/config/src/json/loadRemappingstxt.js
@@ -74,7 +74,7 @@ export const loadRemappings = (configFilePath) => {
 				remappings: Object.fromEntries(
 					remappingEntries.map((remapping) => {
 						const [from, to] = remapping.trim().split('=')
-						return /** @type {[string, string]}*/ ([from, to])
+						return /** @type {[string, string]}*/ ([from, `${configFilePath}${to}`])
 					}),
 				),
 			}

--- a/bundler-packages/config/src/json/loadRemappingstxt.js
+++ b/bundler-packages/config/src/json/loadRemappingstxt.js
@@ -75,7 +75,10 @@ export const loadRemappings = (configFilePath) => {
 					remappingEntries.map((remapping) => {
 						const [from, to] = remapping.trim().split('=')
 						// TODO this line of code won't work on windows
-						return /** @type {[string, string]}*/ ([from, `${configFilePath.endsWith('/') ? configFilePath : `${configFilePath}/`}${to?.startsWith('/') ? to.slice(1) : to}`])
+						return /** @type {[string, string]}*/ ([
+							from,
+							`${configFilePath.endsWith('/') ? configFilePath : `${configFilePath}/`}${to?.startsWith('/') ? to.slice(1) : to}`,
+						])
 					}),
 				),
 			}

--- a/bundler-packages/config/src/loadConfig.spec.ts
+++ b/bundler-packages/config/src/loadConfig.spec.ts
@@ -87,17 +87,6 @@ describe(loadConfig.name, () => {
 	it('should be able to load a remappings.txt even when foundryConfig is not set', () => {
 		const configEffect = loadConfig(join(__dirname, 'fixtures/withRemappingsTxt'))
 		const config = runSync(configEffect)
-		expect(config.remappings['@solmate-utils/']).toBe('lib/solmate/src/utils/')
-		expect(config).toMatchInlineSnapshot(`
-			{
-			  "cacheDir": ".tevm",
-			  "debug": false,
-			  "foundryProject": false,
-			  "libs": [],
-			  "remappings": {
-			    "@solmate-utils/": "lib/solmate/src/utils/",
-			  },
-			}
-		`)
+		expect(config.remappings['@solmate-utils/']?.includes('lib/solmate/src/utils/')).toBe(true)
 	})
 })


### PR DESCRIPTION
## Description

fixes #1341 

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Resolved an issue with remappings in the "@tevm/config" package, enhancing compatibility and stability for affected users.
	- Improved remapping functionality to ensure the correct construction of paths relative to the configuration file, particularly in cross-platform scenarios.

- **Tests**
	- Updated test cases to broaden the criteria for validating remapping values, ensuring more comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->