### PR TITLE
fix: remove direnv pkg

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
           pkgs.nodejs_22
           pkgs.nodePackages.pnpm
           pkgs.bun
-          pkgs.direnv
           pkgs.foundry-bin
           pkgs.rust-bin.stable.latest.default # or pkgs.rust-bin.beta.latest.default
         ];


### PR DESCRIPTION
What I need to do is add instructions to getting started

```
# for direnv usage
nix shell nixpkgs#direnv
# then
direnv allow
```