### PR TITLE
fix: replace 'execute Javascript' with 'execute Solidity'

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -34,7 +34,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
 	<Card title="Powerful Tevm memory devnet" icon="pencil">
-		Execute JavaScript directly in your TypeScript code without the need for an external RPC. [EVM execution and forking](/learn/clients) akin to [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
+		Execute Solidity directly in your TypeScript code without the need for an external RPC. [EVM execution and forking](/learn/clients) akin to [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
 	</Card>
 	<Card title="Familiar Viem actions api" icon="open-book">
 		Tevm is built on top of the Viem api and plugs right into your existing Viem/Wagmi applications. Adapters exist for Ethers.js as well.


### PR DESCRIPTION
## Description

[💖](fix: replace 'execute Javascript' with 'execute Solidity')

## Testing

read

## Additional Information

💖

Your ENS/address:

manadacollective.eth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation to reflect the capability of executing Solidity code within TypeScript, enhancing user understanding of EVM execution integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->