### PR TITLE
fix(precompile): remove indexed topics from log data

### DIFF
--- a/.changeset/tame-phones-give.md
+++ b/.changeset/tame-phones-give.md
@@ -1,0 +1,6 @@
+---
+"@tevm/precompiles": minor
+"tevm": minor
+---
+
+Fixed issue where the indexed topics are also included in data when encoding logs for a precompile

--- a/docs/src/content/docs/reference/@tevm/actions/classes/BlobGasLimitExceededError.md
+++ b/docs/src/content/docs/reference/@tevm/actions/classes/BlobGasLimitExceededError.md
@@ -123,7 +123,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -137,35 +137,11 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
 ### captureStackTrace()
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`Error.captureStackTrace`
-
-##### Defined in
-
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
 
 #### captureStackTrace(targetObject, constructorOpt)
 
@@ -214,3 +190,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`Error.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/actions/classes/MissingAccountError.md
+++ b/docs/src/content/docs/reference/@tevm/actions/classes/MissingAccountError.md
@@ -147,7 +147,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -161,35 +161,11 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
 ### captureStackTrace()
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`Error.captureStackTrace`
-
-##### Defined in
-
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
 
 #### captureStackTrace(targetObject, constructorOpt)
 
@@ -238,3 +214,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`Error.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/actions/classes/NoForkUrlSetError.md
+++ b/docs/src/content/docs/reference/@tevm/actions/classes/NoForkUrlSetError.md
@@ -147,7 +147,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -161,35 +161,11 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
 ### captureStackTrace()
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`Error.captureStackTrace`
-
-##### Defined in
-
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
 
 #### captureStackTrace(targetObject, constructorOpt)
 
@@ -238,3 +214,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`Error.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/actions/functions/loadStateHandler.md
+++ b/docs/src/content/docs/reference/@tevm/actions/functions/loadStateHandler.md
@@ -48,9 +48,9 @@ if (result.errors) {
 
 ## See
 
- - [LoadStateParams](../../../../../../../reference/tevm/actions/type-aliases/loadstateparams)
- - [LoadStateResult](../../../../../../../reference/tevm/actions/type-aliases/loadstateresult)
- - [TevmLoadStateError](../../../../../../../reference/tevm/actions/type-aliases/tevmloadstateerror)
+ - [LoadStateParams](../../../../../../../../reference/tevm/actions/type-aliases/loadstateparams)
+ - [LoadStateResult](../../../../../../../../reference/tevm/actions/type-aliases/loadstateresult)
+ - [TevmLoadStateError](../../../../../../../../reference/tevm/actions/type-aliases/tevmloadstateerror)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/CallHandler.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/CallHandler.md
@@ -52,8 +52,8 @@ console.log(res)
 ## See
 
  - [tevmCall](https://tevm.sh/reference/tevm/memory-client/functions/tevmCall)
- - [CallParams](../../../../../../../reference/tevm/actions/type-aliases/callparams)
- - [CallResult](../../../../../../../reference/tevm/actions/type-aliases/callresult)
+ - [CallParams](../../../../../../../../reference/tevm/actions/type-aliases/callparams)
+ - [CallResult](../../../../../../../../reference/tevm/actions/type-aliases/callresult)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/ContractHandler.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/ContractHandler.md
@@ -65,8 +65,8 @@ console.log(res)
 ## See
 
  - [tevmContract](https://tevm.sh/reference/tevm/memory-client/functions/tevmContract)
- - [ContractParams](../../../../../../../reference/tevm/actions/type-aliases/contractparams)
- - [ContractResult](../../../../../../../reference/tevm/actions/type-aliases/contractresult)
+ - [ContractParams](../../../../../../../../reference/tevm/actions/type-aliases/contractparams)
+ - [ContractResult](../../../../../../../../reference/tevm/actions/type-aliases/contractresult)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/ContractParams.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/ContractParams.md
@@ -53,8 +53,8 @@ console.log(res)
 ## See
 
  - [tevmContract](https://tevm.sh/reference/tevm/memory-client/functions/tevmContract)
- - [BaseCallParams](../../../../../../../reference/tevm/actions/type-aliases/basecallparams)
- - [EncodeFunctionDataParameters](../../../../../../../reference/tevm/utils/type-aliases/encodefunctiondataparameters)
+ - [BaseCallParams](../../../../../../../../reference/tevm/actions/type-aliases/basecallparams)
+ - [EncodeFunctionDataParameters](../../../../../../../../reference/tevm/utils/type-aliases/encodefunctiondataparameters)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/ContractResult.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/ContractResult.md
@@ -57,7 +57,7 @@ if (result.errors) {
 
 ## See
 
-[CallResult](../../../../../../../reference/tevm/actions/type-aliases/callresult)
+[CallResult](../../../../../../../../reference/tevm/actions/type-aliases/callresult)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/LoadStateResult.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/LoadStateResult.md
@@ -42,7 +42,7 @@ if (result.errors) {
 
 ## See
 
-[TevmLoadStateError](../../../../../../../reference/tevm/actions/type-aliases/tevmloadstateerror)
+[TevmLoadStateError](../../../../../../../../reference/tevm/actions/type-aliases/tevmloadstateerror)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/MineHandler.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/MineHandler.md
@@ -30,8 +30,8 @@ console.log(res.errors) // undefined
 
 ## See
 
- - [MineParams](../../../../../../../reference/tevm/actions/type-aliases/mineparams) for details on the parameters.
- - [MineResult](../../../../../../../reference/tevm/actions/type-aliases/mineresult) for details on the result.
+ - [MineParams](../../../../../../../../reference/tevm/actions/type-aliases/mineparams) for details on the parameters.
+ - [MineResult](../../../../../../../../reference/tevm/actions/type-aliases/mineresult) for details on the result.
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmContractError.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmContractError.md
@@ -42,7 +42,7 @@ try {
 
 ## See
 
-[TevmCallError](../../../../../../../reference/tevm/actions/type-aliases/tevmcallerror)
+[TevmCallError](../../../../../../../../reference/tevm/actions/type-aliases/tevmcallerror)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmJsonRpcBulkRequestHandler.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmJsonRpcBulkRequestHandler.md
@@ -42,17 +42,17 @@ const [blockNumberResponse, gasPriceResponse] = await tevm.requestBulk([{
 
 #### tevm_call
 
-request - [CallJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcrequest)
-response - [CallJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcresponse)
+request - [CallJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcrequest)
+response - [CallJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcresponse)
 
 #### tevm_getAccount
 
-request - [GetAccountJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcrequest)
-response - [GetAccountJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcresponse)
+request - [GetAccountJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcrequest)
+response - [GetAccountJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcresponse)
 
 #### tevm_setAccount
 
-request - [SetAccountJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/setaccountjsonrpcrequest)
+request - [SetAccountJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/setaccountjsonrpcrequest)
 response - SetAccountJsonRpcResponse
 
 ### debug_* methods
@@ -66,33 +66,33 @@ response - DebugTraceCallJsonRpcResponse
 
 #### eth_blockNumber
 
-request - [EthBlockNumberJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcrequest)
-response - [EthBlockNumberJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcresponse)
+request - [EthBlockNumberJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcrequest)
+response - [EthBlockNumberJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcresponse)
 
 #### eth_chainId
 
-request - [EthChainIdJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcrequest)
-response - [EthChainIdJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcresponse)
+request - [EthChainIdJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcrequest)
+response - [EthChainIdJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcresponse)
 
 #### eth_getCode
 
-request - [EthGetCodeJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcrequest)
-response - [EthGetCodeJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcresponse)
+request - [EthGetCodeJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcrequest)
+response - [EthGetCodeJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcresponse)
 
 #### eth_getStorageAt
 
-request - [EthGetStorageAtJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcrequest)
-response - [EthGetStorageAtJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcresponse)
+request - [EthGetStorageAtJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcrequest)
+response - [EthGetStorageAtJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcresponse)
 
 #### eth_gasPrice
 
-request - [EthGasPriceJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcrequest)
-response - [EthGasPriceJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcresponse)
+request - [EthGasPriceJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcrequest)
+response - [EthGasPriceJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcresponse)
 
 #### eth_getBalance
 
-request - [EthGetBalanceJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcrequest)
-response - [EthGetBalanceJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcresponse)
+request - [EthGetBalanceJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcrequest)
+response - [EthGetBalanceJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcresponse)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmJsonRpcRequestHandler.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmJsonRpcRequestHandler.md
@@ -43,17 +43,17 @@ const accountResponse = await tevm.request({
 
 #### tevm_call
 
-request - [CallJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcrequest)
-response - [CallJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcresponse)
+request - [CallJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcrequest)
+response - [CallJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/calljsonrpcresponse)
 
 #### tevm_getAccount
 
-request - [GetAccountJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcrequest)
-response - [GetAccountJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcresponse)
+request - [GetAccountJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcrequest)
+response - [GetAccountJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/getaccountjsonrpcresponse)
 
 #### tevm_setAccount
 
-request - [SetAccountJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/setaccountjsonrpcrequest)
+request - [SetAccountJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/setaccountjsonrpcrequest)
 response - SetAccountJsonRpcResponse
 
 ### debug_* methods
@@ -67,33 +67,33 @@ response - DebugTraceCallJsonRpcResponse
 
 #### eth_blockNumber
 
-request - [EthBlockNumberJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcrequest)
-response - [EthBlockNumberJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcresponse)
+request - [EthBlockNumberJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcrequest)
+response - [EthBlockNumberJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethblocknumberjsonrpcresponse)
 
 #### eth_chainId
 
-request - [EthChainIdJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcrequest)
-response - [EthChainIdJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcresponse)
+request - [EthChainIdJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcrequest)
+response - [EthChainIdJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethchainidjsonrpcresponse)
 
 #### eth_getCode
 
-request - [EthGetCodeJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcrequest)
-response - [EthGetCodeJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcresponse)
+request - [EthGetCodeJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcrequest)
+response - [EthGetCodeJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgetcodejsonrpcresponse)
 
 #### eth_getStorageAt
 
-request - [EthGetStorageAtJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcrequest)
-response - [EthGetStorageAtJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcresponse)
+request - [EthGetStorageAtJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcrequest)
+response - [EthGetStorageAtJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgetstorageatjsonrpcresponse)
 
 #### eth_gasPrice
 
-request - [EthGasPriceJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcrequest)
-response - [EthGasPriceJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcresponse)
+request - [EthGasPriceJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcrequest)
+response - [EthGasPriceJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgaspricejsonrpcresponse)
 
 #### eth_getBalance
 
-request - [EthGetBalanceJsonRpcRequest](../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcrequest)
-response - [EthGetBalanceJsonRpcResponse](../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcresponse)
+request - [EthGetBalanceJsonRpcRequest](../../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcrequest)
+response - [EthGetBalanceJsonRpcResponse](../../../../../../../../reference/tevm/actions/type-aliases/ethgetbalancejsonrpcresponse)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmLoadStateError.md
+++ b/docs/src/content/docs/reference/@tevm/actions/type-aliases/TevmLoadStateError.md
@@ -30,7 +30,7 @@ if (result.errors) {
 
 ## See
 
-[InternalError](../../../../../../../reference/tevm/errors/classes/internalerror)
+[InternalError](../../../../../../../../reference/tevm/errors/classes/internalerror)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/address/classes/Address.md
+++ b/docs/src/content/docs/reference/@tevm/address/classes/Address.md
@@ -6,7 +6,7 @@ title: "Address"
 ---
 
 Utility class for Ethereum addresses.
-Wraps [EthjsAddress](../../../../../../../reference/tevm/utils/classes/ethjsaddress) with a tevm style API.
+Wraps [EthjsAddress](../../../../../../../../reference/tevm/utils/classes/ethjsaddress) with a tevm style API.
 toString returns a checksummed address rather than lowercase.
 
 ## Example

--- a/docs/src/content/docs/reference/@tevm/address/functions/create2ContractAddress.md
+++ b/docs/src/content/docs/reference/@tevm/address/functions/create2ContractAddress.md
@@ -7,7 +7,7 @@ title: "create2ContractAddress"
 
 > **create2ContractAddress**(`from`, `salt`, `code`): [`Address`](/reference/tevm/address/classes/address/)
 
-Generates an [Address](../../../../../../../reference/tevm/address/classes/address) for a contract created using CREATE2.
+Generates an [Address](../../../../../../../../reference/tevm/address/classes/address) for a contract created using CREATE2.
 
 ## Parameters
 

--- a/docs/src/content/docs/reference/@tevm/address/functions/createAddress.md
+++ b/docs/src/content/docs/reference/@tevm/address/functions/createAddress.md
@@ -7,8 +7,8 @@ title: "createAddress"
 
 > **createAddress**(`address`): [`Address`](/reference/tevm/address/classes/address/)
 
-Creates an [Address](../../../../../../../reference/tevm/address/classes/address) for safely interacting with an Ethereum address.
-Wraps [EthjsAddress](../../../../../../../reference/tevm/utils/classes/ethjsaddress) with a tevm style API.
+Creates an [Address](../../../../../../../../reference/tevm/address/classes/address) for safely interacting with an Ethereum address.
+Wraps [EthjsAddress](../../../../../../../../reference/tevm/utils/classes/ethjsaddress) with a tevm style API.
 
 ## Parameters
 

--- a/docs/src/content/docs/reference/@tevm/address/functions/createContractAddress.md
+++ b/docs/src/content/docs/reference/@tevm/address/functions/createContractAddress.md
@@ -7,7 +7,7 @@ title: "createContractAddress"
 
 > **createContractAddress**(`from`, `nonce`): [`Address`](/reference/tevm/address/classes/address/)
 
-Generates an [Address](../../../../../../../reference/tevm/address/classes/address) for a newly created contract.
+Generates an [Address](../../../../../../../../reference/tevm/address/classes/address) for a newly created contract.
 
 ## Parameters
 

--- a/docs/src/content/docs/reference/@tevm/block/classes/Block.md
+++ b/docs/src/content/docs/reference/@tevm/block/classes/Block.md
@@ -635,7 +635,7 @@ json of a beacon beacon fetched from beacon apis
 
 • **opts**: [`BlockOptions`](/reference/tevm/block/interfaces/blockoptions/)
 
-[BlockOptions](../../../../../../../reference/tevm/block/interfaces/blockoptions)
+[BlockOptions](../../../../../../../../reference/tevm/block/interfaces/blockoptions)
 
 #### Returns
 
@@ -683,7 +683,7 @@ Method to retrieve a block from an execution payload
 
 • **opts**: [`BlockOptions`](/reference/tevm/block/interfaces/blockoptions/)
 
-[BlockOptions](../../../../../../../reference/tevm/block/interfaces/blockoptions)
+[BlockOptions](../../../../../../../../reference/tevm/block/interfaces/blockoptions)
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/block/classes/BlockHeader.md
+++ b/docs/src/content/docs/reference/@tevm/block/classes/BlockHeader.md
@@ -566,7 +566,7 @@ Returns a list of signers
 
 This function throws if not called on an epoch
 transition block and should therefore be used
-in conjunction with [BlockHeader.cliqueIsEpochTransition](../../../../../../../reference/tevm/block/classes/blockheader/#cliqueisepochtransition)
+in conjunction with [BlockHeader.cliqueIsEpochTransition](../../../../../../../../reference/tevm/block/classes/blockheader/#cliqueisepochtransition)
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/block/functions/executionPayloadFromBeaconPayload.md
+++ b/docs/src/content/docs/reference/@tevm/block/functions/executionPayloadFromBeaconPayload.md
@@ -7,7 +7,7 @@ title: "executionPayloadFromBeaconPayload"
 
 > **executionPayloadFromBeaconPayload**(`payload`): [`ExecutionPayload`](/reference/tevm/block/type-aliases/executionpayload/)
 
-Converts a beacon block execution payload JSON object [BeaconPayloadJson](../../../../../../../reference/tevm/block/type-aliases/beaconpayloadjson) to the [ExecutionPayload](../../../../../../../reference/tevm/block/type-aliases/executionpayload) data needed to construct a [Block](../../../../../../../reference/tevm/block/classes/block).
+Converts a beacon block execution payload JSON object [BeaconPayloadJson](../../../../../../../../reference/tevm/block/type-aliases/beaconpayloadjson) to the [ExecutionPayload](../../../../../../../../reference/tevm/block/type-aliases/executionpayload) data needed to construct a [Block](../../../../../../../../reference/tevm/block/classes/block).
 The JSON data can be retrieved from a consensus layer (CL) client on this Beacon API `/eth/v2/beacon/blocks/[block number]`
 
 ## Parameters

--- a/docs/src/content/docs/reference/@tevm/block/interfaces/BlockOptions.md
+++ b/docs/src/content/docs/reference/@tevm/block/interfaces/BlockOptions.md
@@ -6,7 +6,7 @@ title: "BlockOptions"
 ---
 
 An object to set to which blockchain the blocks and their headers belong. This could be specified
-using a [Common](../../../../../../../reference/tevm/common/type-aliases/common) object, or `chain` and `hardfork`. Defaults to mainnet without specifying a
+using a [Common](../../../../../../../../reference/tevm/common/type-aliases/common) object, or `chain` and `hardfork`. Defaults to mainnet without specifying a
 hardfork.
 
 ## Extended by
@@ -17,7 +17,7 @@ hardfork.
 
 > `optional` **calcDifficultyFromHeader**: [`BlockHeader`](/reference/tevm/block/classes/blockheader/)
 
-If a preceding [BlockHeader](../../../../../../../reference/tevm/block/classes/blockheader) (usually the parent header) is given the preceding
+If a preceding [BlockHeader](../../../../../../../../reference/tevm/block/classes/blockheader) (usually the parent header) is given the preceding
 header will be used to calculate the difficulty for this block and the calculated
 difficulty takes precedence over a provided static `difficulty` value.
 
@@ -47,13 +47,13 @@ Will throw if provided on a non-PoA chain.
 
 > **common**: `object`
 
-A [Common](../../../../../../../reference/tevm/common/type-aliases/common) object defining the chain and the hardfork a block/block header belongs to.
+A [Common](../../../../../../../../reference/tevm/common/type-aliases/common) object defining the chain and the hardfork a block/block header belongs to.
 
 Object will be internally copied so that tx behavior don't incidentally
 change on future HF changes.
 
-Default: [Common](../../../../../../../reference/tevm/common/type-aliases/common) object set to `mainnet` and the HF currently defined as the default
-hardfork in the [Common](../../../../../../../reference/tevm/common/type-aliases/common) class.
+Default: [Common](../../../../../../../../reference/tevm/common/type-aliases/common) object set to `mainnet` and the HF currently defined as the default
+hardfork in the [Common](../../../../../../../../reference/tevm/common/type-aliases/common) class.
 
 Current default hardfork: `merge`
 
@@ -215,7 +215,7 @@ for older Hfs.
 Additionally it is possible to pass in a specific TD value to support live-Merge-HF
 transitions. Note that this should only be needed in very rare and specific scenarios.
 
-Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../reference/tevm/common/type-aliases/common) instance)
+Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../../reference/tevm/common/type-aliases/common) instance)
 
 #### Defined in
 

--- a/docs/src/content/docs/reference/@tevm/config/defineConfig/classes/DefineConfigError.md
+++ b/docs/src/content/docs/reference/@tevm/config/defineConfig/classes/DefineConfigError.md
@@ -5,7 +5,7 @@ prev: false
 title: "DefineConfigError"
 ---
 
-Error class for [defineConfig](../../../../../../../../reference/tevm/config/defineconfig/functions/defineconfig)
+Error class for [defineConfig](../../../../../../../../../reference/tevm/config/defineconfig/functions/defineconfig)
 
 ## Extends
 

--- a/docs/src/content/docs/reference/@tevm/config/loadConfig/classes/LoadConfigError.md
+++ b/docs/src/content/docs/reference/@tevm/config/loadConfig/classes/LoadConfigError.md
@@ -5,7 +5,7 @@ prev: false
 title: "LoadConfigError"
 ---
 
-Error class for [loadConfig](../../../../../../../../reference/tevm/config/loadconfig/functions/loadconfig)
+Error class for [loadConfig](../../../../../../../../../reference/tevm/config/loadconfig/functions/loadconfig)
 
 ## Extends
 

--- a/docs/src/content/docs/reference/@tevm/config/types/type-aliases/CompilerConfig.md
+++ b/docs/src/content/docs/reference/@tevm/config/types/type-aliases/CompilerConfig.md
@@ -8,7 +8,7 @@ title: "CompilerConfig"
 > **CompilerConfig**: `object`
 
 Configuration of the solidity compiler
-When resolved with defaults it is a [ResolvedCompilerConfig](../../../../../../../../reference/tevm/config/types/type-aliases/resolvedcompilerconfig)
+When resolved with defaults it is a [ResolvedCompilerConfig](../../../../../../../../../reference/tevm/config/types/type-aliases/resolvedcompilerconfig)
 
 ## Type declaration
 
@@ -33,7 +33,7 @@ Set to "path/to/forge/executable" to use a custom forge executable
 
 ### jsonAsConst?
 
-> `optional` **jsonAsConst**: `string` \| `string`[]
+> `optional` **jsonAsConst**: `string` \| readonly `string`[]
 
 A glob pattern or array of glob patterns indicating which ABIs should be resolved as const.
 This allows for more precise typing of ABIs in TypeScript.

--- a/docs/src/content/docs/reference/@tevm/config/types/type-aliases/ResolvedCompilerConfig.md
+++ b/docs/src/content/docs/reference/@tevm/config/types/type-aliases/ResolvedCompilerConfig.md
@@ -8,7 +8,7 @@ title: "ResolvedCompilerConfig"
 > **ResolvedCompilerConfig**: `object`
 
 A fully resolved compiler config with defaults filled in
-See [CompilerConfig](../../../../../../../../reference/tevm/config/types/type-aliases/compilerconfig)
+See [CompilerConfig](../../../../../../../../../reference/tevm/config/types/type-aliases/compilerconfig)
 
 ## Type declaration
 
@@ -33,7 +33,7 @@ Set to "path/to/forge/executable" to use a custom forge executable
 
 ### jsonAsConst
 
-> **jsonAsConst**: `string`[]
+> **jsonAsConst**: readonly `string`[]
 
 A glob pattern or array of glob patterns indicating which ABIs should be resolved as const.
 This allows for more precise typing of ABIs in TypeScript.

--- a/docs/src/content/docs/reference/@tevm/contract/functions/createContract.md
+++ b/docs/src/content/docs/reference/@tevm/contract/functions/createContract.md
@@ -95,7 +95,7 @@ const contract = createContract({
 
 ## See
 
- - [Contract](../../../../../../../reference/tevm/contract/type-aliases/contract) for the full API of the returned Contract instance.
+ - [Contract](../../../../../../../../reference/tevm/contract/type-aliases/contract) for the full API of the returned Contract instance.
  - [https://tevm.sh/learn/contracts/](https://tevm.sh/learn/contracts/) for more information on working with contracts in Tevm.
  - [https://tevm.sh/reference/tevm/contract/types/Contract/](https://tevm.sh/reference/tevm/contract/types/Contract/) for detailed Contract type documentation.
 

--- a/docs/src/content/docs/reference/@tevm/contract/type-aliases/CreateContractParams.md
+++ b/docs/src/content/docs/reference/@tevm/contract/type-aliases/CreateContractParams.md
@@ -7,7 +7,7 @@ title: "CreateContractParams"
 
 > **CreateContractParams**\<`TName`, `TAbi`, `TAddress`, `TBytecode`, `TDeployedBytecode`, `TCode`\>: `object` \| `object`
 
-Parameters for creating a [Contract](../../../../../../../reference/tevm/contract/type-aliases/contract) instance.
+Parameters for creating a [Contract](../../../../../../../../reference/tevm/contract/type-aliases/contract) instance.
 This type allows for two mutually exclusive ways of specifying the ABI:
 either as a human-readable ABI or as a JSON ABI.
 

--- a/docs/src/content/docs/reference/@tevm/errors/classes/AccountLockedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/AccountLockedError.md
@@ -282,7 +282,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -296,7 +296,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -352,30 +352,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -401,3 +377,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/AccountNotFoundError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/AccountNotFoundError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ResourceNotFoundError`](/reference/tevm/errors/classes/resourcenotfounderror/).[`captureStackTrace`](/reference/tevm/errors/classes/resourcenotfounderror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ResourceNotFoundError`](/reference/tevm/errors/classes/resourcenotfounderror/).[`captureStackTrace`](/reference/tevm/errors/classes/resourcenotfounderror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/AuthCallUnsetError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/AuthCallUnsetError.md
@@ -312,7 +312,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -326,7 +326,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -382,30 +382,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -431,3 +407,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381FpNotInFieldError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381FpNotInFieldError.md
@@ -304,7 +304,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -318,7 +318,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -374,30 +374,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -423,3 +399,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381InputEmptyError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381InputEmptyError.md
@@ -292,7 +292,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -306,7 +306,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -362,30 +362,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -411,3 +387,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381InvalidInputLengthError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381InvalidInputLengthError.md
@@ -292,7 +292,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -306,7 +306,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -362,30 +362,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -411,3 +387,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381PointNotOnCurveError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/BLS12381PointNotOnCurveError.md
@@ -292,7 +292,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -306,7 +306,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -362,30 +362,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -411,3 +387,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/BaseError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/BaseError.md
@@ -240,7 +240,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -254,7 +254,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -306,30 +306,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`Error.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -355,3 +331,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`Error.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/BlockGasLimitExceededError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/BlockGasLimitExceededError.md
@@ -291,7 +291,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -305,7 +305,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -361,30 +361,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -410,3 +386,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ChainIdMismatchError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ChainIdMismatchError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/CodeSizeExceedsMaximumError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/CodeSizeExceedsMaximumError.md
@@ -308,7 +308,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -322,7 +322,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -378,30 +378,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`GasLimitExceededError`](/reference/tevm/errors/classes/gaslimitexceedederror/).[`captureStackTrace`](/reference/tevm/errors/classes/gaslimitexceedederror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -427,3 +403,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`GasLimitExceededError`](/reference/tevm/errors/classes/gaslimitexceedederror/).[`captureStackTrace`](/reference/tevm/errors/classes/gaslimitexceedederror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/CodeStoreOutOfGasError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/CodeStoreOutOfGasError.md
@@ -297,7 +297,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -311,7 +311,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -367,30 +367,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`GasLimitExceededError`](/reference/tevm/errors/classes/gaslimitexceedederror/).[`captureStackTrace`](/reference/tevm/errors/classes/gaslimitexceedederror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -416,3 +392,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`GasLimitExceededError`](/reference/tevm/errors/classes/gaslimitexceedederror/).[`captureStackTrace`](/reference/tevm/errors/classes/gaslimitexceedederror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/CommonMismatchError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/CommonMismatchError.md
@@ -274,7 +274,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -288,7 +288,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -344,30 +344,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -393,3 +369,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ContractExecutionFailedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ContractExecutionFailedError.md
@@ -280,7 +280,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -294,7 +294,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -350,30 +350,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -399,3 +375,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/CreateCollisionError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/CreateCollisionError.md
@@ -302,7 +302,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -316,7 +316,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -372,30 +372,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -421,3 +397,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/DecodeFunctionDataError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/DecodeFunctionDataError.md
@@ -271,7 +271,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -285,7 +285,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -341,30 +341,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -390,3 +366,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/DefensiveNullCheckError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/DefensiveNullCheckError.md
@@ -290,7 +290,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -304,7 +304,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -360,30 +360,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -409,3 +385,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/EipNotEnabledError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/EipNotEnabledError.md
@@ -277,7 +277,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -291,7 +291,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -347,30 +347,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -396,3 +372,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/EncodeFunctionReturnDataError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/EncodeFunctionReturnDataError.md
@@ -274,7 +274,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -288,7 +288,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -344,30 +344,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -393,3 +369,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/EvmRevertError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/EvmRevertError.md
@@ -312,7 +312,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -326,7 +326,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -382,30 +382,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`RevertError`](/reference/tevm/errors/classes/reverterror/).[`captureStackTrace`](/reference/tevm/errors/classes/reverterror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -431,3 +407,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`RevertError`](/reference/tevm/errors/classes/reverterror/).[`captureStackTrace`](/reference/tevm/errors/classes/reverterror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ExecutionError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ExecutionError.md
@@ -303,7 +303,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -317,7 +317,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -373,30 +373,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -422,3 +398,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ForkError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ForkError.md
@@ -249,7 +249,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -263,7 +263,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -319,30 +319,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -368,3 +344,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/GasLimitExceededError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/GasLimitExceededError.md
@@ -266,7 +266,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -280,7 +280,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -336,30 +336,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -385,3 +361,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InitcodeSizeViolationError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InitcodeSizeViolationError.md
@@ -302,7 +302,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -316,7 +316,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -372,30 +372,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -421,3 +397,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InsufficientBalanceError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InsufficientBalanceError.md
@@ -304,7 +304,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -318,7 +318,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -374,30 +374,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -423,3 +399,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InsufficientFundsError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InsufficientFundsError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InsufficientPermissionsError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InsufficientPermissionsError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InternalError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InternalError.md
@@ -298,7 +298,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -312,7 +312,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -368,30 +368,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -417,3 +393,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InternalEvmError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InternalEvmError.md
@@ -286,7 +286,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -300,7 +300,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -356,30 +356,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -405,3 +381,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InternalRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InternalRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidAbiError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidAbiError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidAddressError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidAddressError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidArgsError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidArgsError.md
@@ -274,7 +274,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -288,7 +288,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -344,30 +344,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -393,3 +369,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBalanceError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBalanceError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBeginSubError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBeginSubError.md
@@ -302,7 +302,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -316,7 +316,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -372,30 +372,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -421,3 +397,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBlobVersionedHashesError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBlobVersionedHashesError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBlockError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBlockError.md
@@ -278,7 +278,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -292,7 +292,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -348,30 +348,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -397,3 +373,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBytecodeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBytecodeError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBytecodeResultError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBytecodeResultError.md
@@ -302,7 +302,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -316,7 +316,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -372,30 +372,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -421,3 +397,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBytesSizeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidBytesSizeError.md
@@ -321,7 +321,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -335,7 +335,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -391,30 +391,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -440,3 +416,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidCallerError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidCallerError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidCommitmentError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidCommitmentError.md
@@ -306,7 +306,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -320,7 +320,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -376,30 +376,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -425,3 +401,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidDataError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidDataError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidDeployedBytecodeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidDeployedBytecodeError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidDepthError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidDepthError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidEofFormatError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidEofFormatError.md
@@ -306,7 +306,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -320,7 +320,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -376,30 +376,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -425,3 +401,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidFunctionNameError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidFunctionNameError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidGasLimitError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidGasLimitError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidGasPriceError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidGasPriceError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidGasRefundError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidGasRefundError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidInputLengthError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidInputLengthError.md
@@ -300,7 +300,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -314,7 +314,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -370,30 +370,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -419,3 +395,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidInputRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidInputRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidJumpError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidJumpError.md
@@ -308,7 +308,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -322,7 +322,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -378,30 +378,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -427,3 +403,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidJumpSubError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidJumpSubError.md
@@ -316,7 +316,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -330,7 +330,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -386,30 +386,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -435,3 +411,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidKzgInputsError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidKzgInputsError.md
@@ -292,7 +292,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -306,7 +306,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -362,30 +362,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -411,3 +387,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidMaxFeePerGasError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidMaxFeePerGasError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidMaxPriorityFeePerGasError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidMaxPriorityFeePerGasError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidNonceError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidNonceError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidOpcodeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidOpcodeError.md
@@ -308,7 +308,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -322,7 +322,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -378,30 +378,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -427,3 +403,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidOriginError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidOriginError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidParamsError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidParamsError.md
@@ -301,7 +301,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -315,7 +315,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -371,30 +371,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -420,3 +396,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidParamsRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidParamsRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidProofError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidProofError.md
@@ -292,7 +292,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -306,7 +306,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -362,30 +362,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -411,3 +387,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidRequestError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidRequestError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidRequestRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidRequestRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidReturnSubError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidReturnSubError.md
@@ -302,7 +302,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -316,7 +316,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -372,30 +372,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -421,3 +397,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSaltError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSaltError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSelfdestructError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSelfdestructError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSignatureError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSignatureError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSkipBalanceError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidSkipBalanceError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidStorageRootError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidStorageRootError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidToError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidToError.md
@@ -273,7 +273,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -287,7 +287,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -343,30 +343,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -392,3 +368,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidTransactionError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidTransactionError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidUrlError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidUrlError.md
@@ -271,7 +271,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -285,7 +285,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -341,30 +341,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -390,3 +366,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/InvalidValueError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/InvalidValueError.md
@@ -276,7 +276,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -346,30 +346,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -395,3 +371,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InvalidParamsError`](/reference/tevm/errors/classes/invalidparamserror/).[`captureStackTrace`](/reference/tevm/errors/classes/invalidparamserror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/JsonRpcVersionUnsupportedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/JsonRpcVersionUnsupportedError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/LimitExceededError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/LimitExceededError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/LimitExceededRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/LimitExceededRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotFoundError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotFoundError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotFoundRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotFoundRpcError.md
@@ -213,7 +213,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -227,7 +227,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -295,30 +295,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -344,3 +320,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotSupportedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotSupportedError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotSupportedRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/MethodNotSupportedRpcError.md
@@ -213,7 +213,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -227,7 +227,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -295,30 +295,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -344,3 +320,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/MisconfiguredClientError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/MisconfiguredClientError.md
@@ -294,7 +294,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -308,7 +308,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -364,30 +364,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -413,3 +389,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/NoForkTransportSetError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/NoForkTransportSetError.md
@@ -242,7 +242,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -256,7 +256,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -312,30 +312,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -361,3 +337,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/NonceAlreadyUsedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/NonceAlreadyUsedError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/NonceTooHighError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/NonceTooHighError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/NonceTooLowError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/NonceTooLowError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/OutOfGasError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/OutOfGasError.md
@@ -301,7 +301,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -315,7 +315,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -371,30 +371,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`GasLimitExceededError`](/reference/tevm/errors/classes/gaslimitexceedederror/).[`captureStackTrace`](/reference/tevm/errors/classes/gaslimitexceedederror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -420,3 +396,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`GasLimitExceededError`](/reference/tevm/errors/classes/gaslimitexceedederror/).[`captureStackTrace`](/reference/tevm/errors/classes/gaslimitexceedederror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/OutOfRangeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/OutOfRangeError.md
@@ -310,7 +310,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -324,7 +324,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -380,30 +380,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -429,3 +405,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ParseError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ParseError.md
@@ -278,7 +278,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -292,7 +292,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -348,30 +348,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -397,3 +373,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ParseRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ParseRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/PendingTransactionTimeoutError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/PendingTransactionTimeoutError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ProviderDisconnectedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ProviderDisconnectedError.md
@@ -223,7 +223,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -237,7 +237,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -305,30 +305,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`ProviderRpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -354,3 +330,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`ProviderRpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/RateLimitExceededError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/RateLimitExceededError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/RefundExhaustedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/RefundExhaustedError.md
@@ -302,7 +302,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -316,7 +316,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -372,30 +372,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -421,3 +397,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ResourceNotFoundError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ResourceNotFoundError.md
@@ -266,7 +266,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -280,7 +280,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -336,30 +336,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -385,3 +361,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ResourceNotFoundRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ResourceNotFoundRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ResourceUnavailableError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ResourceUnavailableError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ResourceUnavailableRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ResourceUnavailableRpcError.md
@@ -209,7 +209,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -223,7 +223,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -291,30 +291,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -340,3 +316,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/RevertError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/RevertError.md
@@ -285,7 +285,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -299,7 +299,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -355,30 +355,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -404,3 +380,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/StackOverflowError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/StackOverflowError.md
@@ -311,7 +311,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -325,7 +325,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -381,30 +381,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -430,3 +406,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/StackUnderflowError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/StackUnderflowError.md
@@ -308,7 +308,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -322,7 +322,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -378,30 +378,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -427,3 +403,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/StaticStateChangeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/StaticStateChangeError.md
@@ -310,7 +310,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -324,7 +324,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -380,30 +380,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -429,3 +405,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/StopError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/StopError.md
@@ -300,7 +300,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -314,7 +314,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -370,30 +370,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -419,3 +395,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/TimeoutError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/TimeoutError.md
@@ -189,7 +189,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -203,7 +203,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -271,30 +271,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`BaseError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -320,3 +296,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`BaseError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/TransactionRejectedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/TransactionRejectedError.md
@@ -284,7 +284,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -298,7 +298,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -354,30 +354,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -403,3 +379,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/TransactionTooLargeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/TransactionTooLargeError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/TransactionUnderpricedError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/TransactionUnderpricedError.md
@@ -272,7 +272,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -286,7 +286,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -342,30 +342,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -391,3 +367,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/UnknownBlockError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/UnknownBlockError.md
@@ -279,7 +279,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -293,7 +293,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -349,30 +349,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -398,3 +374,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/UnknownRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/UnknownRpcError.md
@@ -199,7 +199,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -213,7 +213,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -281,30 +281,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`RpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -330,3 +306,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`RpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/UnreachableCodeError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/UnreachableCodeError.md
@@ -314,7 +314,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -328,7 +328,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -384,30 +384,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -433,3 +409,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`InternalError`](/reference/tevm/errors/classes/internalerror/).[`captureStackTrace`](/reference/tevm/errors/classes/internalerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/UnsupportedChainError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/UnsupportedChainError.md
@@ -262,7 +262,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -276,7 +276,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -332,30 +332,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -381,3 +357,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/UnsupportedProviderMethodError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/UnsupportedProviderMethodError.md
@@ -227,7 +227,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -241,7 +241,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -309,30 +309,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`ProviderRpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -358,3 +334,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`ProviderRpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/UserRejectedRequestError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/UserRejectedRequestError.md
@@ -223,7 +223,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -237,7 +237,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -305,30 +305,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`ProviderRpcError.captureStackTrace`
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -354,3 +330,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`ProviderRpcError.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/errors/classes/ValueOverflowError.md
+++ b/docs/src/content/docs/reference/@tevm/errors/classes/ValueOverflowError.md
@@ -300,7 +300,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -314,7 +314,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -370,30 +370,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -419,3 +395,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`ExecutionError`](/reference/tevm/errors/classes/executionerror/).[`captureStackTrace`](/reference/tevm/errors/classes/executionerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/memory-client/functions/createMemoryClient.md
+++ b/docs/src/content/docs/reference/@tevm/memory-client/functions/createMemoryClient.md
@@ -7,7 +7,7 @@ title: "createMemoryClient"
 
 > **createMemoryClient**\<`TCommon`, `TAccountOrAddress`, `TRpcSchema`\>(`options`?): `object`
 
-Creates a [MemoryClient](../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient) which is a viem client with an in-memory Ethereum client as its transport.
+Creates a [MemoryClient](../../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient) which is a viem client with an in-memory Ethereum client as its transport.
 It comes batteries included with all wallet, test, public, and tevm actions.
 
 ## Type Parameters
@@ -248,7 +248,7 @@ Creates a [`Filter`](https://viem.sh/docs/glossary/types#filter) to listen for n
 
 • **args?**: [`CreateEventFilterParameters`](/reference/tevm/utils/type-aliases/createeventfilterparameters/)\<`abiEvent`, `abiEvents`, `strict`, `fromBlock`, `toBlock`, `_EventName`, `_Args`\>
 
-[CreateEventFilterParameters](../../../../../../../reference/tevm/utils/type-aliases/createeventfilterparameters)
+[CreateEventFilterParameters](../../../../../../../../reference/tevm/utils/type-aliases/createeventfilterparameters)
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/memory-client/functions/createTevmTransport.md
+++ b/docs/src/content/docs/reference/@tevm/memory-client/functions/createTevmTransport.md
@@ -47,7 +47,7 @@ example()
 
 ## See
 
- - [createClient](../../../../../../../reference/tevm/memory-client/functions/createclient)
+ - [createClient](../../../../../../../../reference/tevm/memory-client/functions/createclient)
  - [Viem Client Docs](https://viem.sh/docs/clients/introduction)
  - [Client Guide](https://tevm.sh/learn/clients/)
  - [tevm JSON-RPC Guide](https://tevm.sh/learn/json-rpc/)

--- a/docs/src/content/docs/reference/@tevm/memory-client/type-aliases/CreateMemoryClientFn.md
+++ b/docs/src/content/docs/reference/@tevm/memory-client/type-aliases/CreateMemoryClientFn.md
@@ -7,7 +7,7 @@ title: "CreateMemoryClientFn"
 
 > **CreateMemoryClientFn**: \<`TCommon`, `TAccountOrAddress`, `TRpcSchema`\>(`options`?) => [`MemoryClient`](/reference/tevm/memory-client/type-aliases/memoryclient/)\<`TCommon`, `TAccountOrAddress`\>
 
-Type definition for the function that creates a [MemoryClient](../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient).
+Type definition for the function that creates a [MemoryClient](../../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient).
 This function initializes a MemoryClient with the provided options,
 including forking configurations, logging levels, and state persistence options.
 
@@ -54,7 +54,7 @@ const client = createMemoryClient({
 
 ## See
 
-For more details on using the MemoryClient, refer to [MemoryClient](../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient).
+For more details on using the MemoryClient, refer to [MemoryClient](../../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient).
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/memory-client/type-aliases/MemoryClient.md
+++ b/docs/src/content/docs/reference/@tevm/memory-client/type-aliases/MemoryClient.md
@@ -35,7 +35,7 @@ console.log(blockNumber);
 
 ## See
 
- - For creating a MemoryClient instance, see [createMemoryClient](../../../../../../../reference/tevm/memory-client/functions/creatememoryclient).
+ - For creating a MemoryClient instance, see [createMemoryClient](../../../../../../../../reference/tevm/memory-client/functions/creatememoryclient).
  - [Client Guide](https://tevm.sh/learn/clients/)
  - [Actions Guide](https://tevm.sh/learn/actions/)
  - [Reference Docs](https://tevm.sh/reference/tevm/memory-client/functions/creatememoryclient/)

--- a/docs/src/content/docs/reference/@tevm/memory-client/type-aliases/MemoryClientOptions.md
+++ b/docs/src/content/docs/reference/@tevm/memory-client/type-aliases/MemoryClientOptions.md
@@ -7,7 +7,7 @@ title: "MemoryClientOptions"
 
 > **MemoryClientOptions**\<`TCommon`, `TAccountOrAddress`, `TRpcSchema`\>: `TevmNodeOptions`\<`TCommon`\> & `Pick`\<`ClientConfig`\<`Transport`, `TCommon`, `TAccountOrAddress`, `TRpcSchema`\>, `"type"` \| `"key"` \| `"name"` \| `"account"` \| `"pollingInterval"` \| `"cacheTime"`\>
 
-Configuration options for creating a [MemoryClient](../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient).
+Configuration options for creating a [MemoryClient](../../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient).
 
 This type extends `TevmNodeOptions` and includes specific options for configuring the MemoryClient,
 such as the transport type, account, polling interval, and caching behavior.
@@ -48,8 +48,8 @@ const client = createMemoryClient(options);
 
 ## See
 
- - [MemoryClient](../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient)
- - [CreateMemoryClientFn](../../../../../../../reference/tevm/memory-client/type-aliases/creatememoryclientfn)
+ - [MemoryClient](../../../../../../../../reference/tevm/memory-client/type-aliases/memoryclient)
+ - [CreateMemoryClientFn](../../../../../../../../reference/tevm/memory-client/type-aliases/creatememoryclientfn)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/node/classes/ProviderRpcError.md
+++ b/docs/src/content/docs/reference/@tevm/node/classes/ProviderRpcError.md
@@ -137,7 +137,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -151,35 +151,11 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
 ### captureStackTrace()
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-`Error.captureStackTrace`
-
-##### Defined in
-
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
 
 #### captureStackTrace(targetObject, constructorOpt)
 
@@ -228,3 +204,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+`Error.captureStackTrace`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/server/classes/InvalidJsonError.md
+++ b/docs/src/content/docs/reference/@tevm/server/classes/InvalidJsonError.md
@@ -258,7 +258,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -272,7 +272,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -328,30 +328,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -377,3 +353,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/server/classes/ReadRequestBodyError.md
+++ b/docs/src/content/docs/reference/@tevm/server/classes/ReadRequestBodyError.md
@@ -245,7 +245,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:28
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:143
 
 ***
 
@@ -259,7 +259,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:30
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:145
 
 ## Methods
 
@@ -315,30 +315,6 @@ Create .stack property on a target object
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21
-
-#### captureStackTrace(targetObject, constructorOpt)
-
-> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
-
-Create .stack property on a target object
-
-##### Parameters
-
-• **targetObject**: `object`
-
-• **constructorOpt?**: `Function`
-
-##### Returns
-
-`void`
-
-##### Inherited from
-
-[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
-
-##### Defined in
-
 node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/globals.d.ts:136
 
 #### captureStackTrace(targetObject, constructorOpt)
@@ -364,3 +340,27 @@ Create .stack property on a target object
 ##### Defined in
 
 node\_modules/.pnpm/bun-types@1.1.29/node\_modules/bun-types/globals.d.ts:1630
+
+#### captureStackTrace(targetObject, constructorOpt)
+
+> `static` **captureStackTrace**(`targetObject`, `constructorOpt`?): `void`
+
+Create .stack property on a target object
+
+##### Parameters
+
+• **targetObject**: `object`
+
+• **constructorOpt?**: `Function`
+
+##### Returns
+
+`void`
+
+##### Inherited from
+
+[`BaseError`](/reference/tevm/errors/classes/baseerror/).[`captureStackTrace`](/reference/tevm/errors/classes/baseerror/#capturestacktrace)
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/globals.d.ts:21

--- a/docs/src/content/docs/reference/@tevm/state/functions/dumpCanonicalGenesis.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/dumpCanonicalGenesis.md
@@ -7,7 +7,7 @@ title: "dumpCanonicalGenesis"
 
 > **dumpCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): () => `Promise`\<[`TevmState`](/reference/tevm/state/type-aliases/tevmstate/)\>
 
-Dumps the state of the state manager as a [TevmState](../../../../../../../reference/tevm/state/type-aliases/tevmstate)
+Dumps the state of the state manager as a [TevmState](../../../../../../../../reference/tevm/state/type-aliases/tevmstate)
 
 ## Parameters
 
@@ -19,7 +19,7 @@ Dumps the state of the state manager as a [TevmState](../../../../../../../refer
 
 `Function`
 
-Dumps the state of the state manager as a [TevmState](../../../../../../../reference/tevm/state/type-aliases/tevmstate)
+Dumps the state of the state manager as a [TevmState](../../../../../../../../reference/tevm/state/type-aliases/tevmstate)
 
 ### Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/generateCanonicalGenesis.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/generateCanonicalGenesis.md
@@ -7,7 +7,7 @@ title: "generateCanonicalGenesis"
 
 > **generateCanonicalGenesis**(`baseState`, `skipFetchingFromFork`?): (`initState`) => `Promise`\<`void`\>
 
-Loads a [TevmState](../../../../../../../reference/tevm/state/type-aliases/tevmstate) into the state manager
+Loads a [TevmState](../../../../../../../../reference/tevm/state/type-aliases/tevmstate) into the state manager
 
 ## Parameters
 

--- a/docs/src/content/docs/reference/@tevm/state/functions/getForkClient.md
+++ b/docs/src/content/docs/reference/@tevm/state/functions/getForkClient.md
@@ -208,7 +208,7 @@ Creates a [`Filter`](https://viem.sh/docs/glossary/types#filter) to listen for n
 
 • **args?**: [`CreateEventFilterParameters`](/reference/tevm/utils/type-aliases/createeventfilterparameters/)\<`abiEvent`, `abiEvents`, `strict`, `fromBlock`, `toBlock`, `_EventName`, `_Args`\>
 
-[CreateEventFilterParameters](../../../../../../../reference/tevm/utils/type-aliases/createeventfilterparameters)
+[CreateEventFilterParameters](../../../../../../../../reference/tevm/utils/type-aliases/createeventfilterparameters)
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/state/interfaces/StateManager.md
+++ b/docs/src/content/docs/reference/@tevm/state/interfaces/StateManager.md
@@ -239,7 +239,7 @@ node\_modules/.pnpm/@ethereumjs+common@4.4.0/node\_modules/@ethereumjs/common/di
 
 > **dumpCanonicalGenesis**(): `Promise`\<[`TevmState`](/reference/tevm/state/type-aliases/tevmstate/)\>
 
-Dumps the state of the state manager as a [TevmState](../../../../../../../reference/tevm/state/type-aliases/tevmstate)
+Dumps the state of the state manager as a [TevmState](../../../../../../../../reference/tevm/state/type-aliases/tevmstate)
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/trie/classes/Trie.md
+++ b/docs/src/content/docs/reference/@tevm/trie/classes/Trie.md
@@ -21,7 +21,7 @@ Creates a new trie.
 
 Options for instantiating the trie
 
-Note: in most cases, the static [Trie.create](../../../../../../../reference/tevm/trie/classes/trie/#create) constructor should be used.  It uses the same API but provides sensible defaults
+Note: in most cases, the static [Trie.create](../../../../../../../../reference/tevm/trie/classes/trie/#create) constructor should be used.  It uses the same API but provides sensible defaults
 
 #### Returns
 
@@ -290,7 +290,7 @@ node\_modules/.pnpm/@ethereumjs+trie@6.2.1/node\_modules/@ethereumjs/trie/dist/e
 
 > **createProof**(`key`): `Promise`\<`Proof`\>
 
-Creates a proof from a trie and key that can be verified using [Trie.verifyProof](../../../../../../../reference/tevm/trie/classes/trie/#verifyproof-1). An (EIP-1186)[https://eips.ethereum.org/EIPS/eip-1186] proof contains
+Creates a proof from a trie and key that can be verified using [Trie.verifyProof](../../../../../../../../reference/tevm/trie/classes/trie/#verifyproof-1). An (EIP-1186)[https://eips.ethereum.org/EIPS/eip-1186] proof contains
 the encoded trie nodes from the root node to the leaf node storing state data. The returned proof will be in the format of an array that contains Uint8Arrays of
 serialized branch, extension, and/or leaf nodes.
 
@@ -760,7 +760,7 @@ node\_modules/.pnpm/@ethereumjs+trie@6.2.1/node\_modules/@ethereumjs/trie/dist/e
 
 A range proof is a proof that includes the encoded trie nodes from the root node to leaf node for one or more branches of a trie,
 allowing an entire range of leaf nodes to be validated. This is useful in applications such as snap sync where contiguous ranges
-of state trie data is received and validated for constructing world state, locally. Also see [verifyRangeProof](../../../../../../../reference/tevm/trie/classes/trie/#verifyrangeproof-1). A static
+of state trie data is received and validated for constructing world state, locally. Also see [verifyRangeProof](../../../../../../../../reference/tevm/trie/classes/trie/#verifyrangeproof-1). A static
 version of this function also exists.
 
 #### Parameters
@@ -998,7 +998,7 @@ node\_modules/.pnpm/@ethereumjs+trie@6.2.1/node\_modules/@ethereumjs/trie/dist/e
 
 A range proof is a proof that includes the encoded trie nodes from the root node to leaf node for one or more branches of a trie,
 allowing an entire range of leaf nodes to be validated. This is useful in applications such as snap sync where contiguous ranges
-of state trie data is received and validated for constructing world state, locally. Also see [verifyRangeProof](../../../../../../../reference/tevm/trie/classes/trie/#verifyrangeproof-1). A static
+of state trie data is received and validated for constructing world state, locally. Also see [verifyRangeProof](../../../../../../../../reference/tevm/trie/classes/trie/#verifyrangeproof-1). A static
 version of this function also exists.
 
 #### Parameters

--- a/docs/src/content/docs/reference/@tevm/tx/classes/AccessListEIP2930Transaction.md
+++ b/docs/src/content/docs/reference/@tevm/tx/classes/AccessListEIP2930Transaction.md
@@ -637,7 +637,7 @@ node\_modules/.pnpm/@ethereumjs+tx@5.4.0/node\_modules/@ethereumjs/tx/dist/esm/b
 Computes a sha3-256 hash of the serialized tx.
 
 This method can only be used for signed txs (it throws otherwise).
-Use [AccessListEIP2930Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/accesslisteip2930transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
+Use [AccessListEIP2930Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/accesslisteip2930transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
 
 #### Returns
 
@@ -702,12 +702,12 @@ Returns a Uint8Array Array of the raw Bytes of the EIP-2930 transaction, in orde
 Format: `[chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
 signatureYParity (v), signatureR (r), signatureS (s)]`
 
-Use [AccessListEIP2930Transaction.serialize](../../../../../../../reference/tevm/tx/classes/accesslisteip2930transaction/#serialize) to add a transaction to a block
+Use [AccessListEIP2930Transaction.serialize](../../../../../../../../reference/tevm/tx/classes/accesslisteip2930transaction/#serialize) to add a transaction to a block
 with Block.fromValuesArray.
 
 For an unsigned tx this method uses the empty Bytes values for the
 signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-representation for external signing use [AccessListEIP2930Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/accesslisteip2930transaction/#getmessagetosign).
+representation for external signing use [AccessListEIP2930Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/accesslisteip2930transaction/#getmessagetosign).
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/tx/classes/BlobEIP4844Transaction.md
+++ b/docs/src/content/docs/reference/@tevm/tx/classes/BlobEIP4844Transaction.md
@@ -700,7 +700,7 @@ node\_modules/.pnpm/@ethereumjs+tx@5.4.0/node\_modules/@ethereumjs/tx/dist/esm/b
 Computes a sha3-256 hash of the serialized tx.
 
 This method can only be used for signed txs (it throws otherwise).
-Use [BlobEIP4844Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/blobeip4844transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
+Use [BlobEIP4844Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/blobeip4844transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
 
 #### Returns
 
@@ -786,7 +786,7 @@ with {@link Block.fromValuesArray}.
 
 For an unsigned tx this method uses the empty Bytes values for the
 signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-representation for external signing use [BlobEIP4844Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/blobeip4844transaction/#getmessagetosign).
+representation for external signing use [BlobEIP4844Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/blobeip4844transaction/#getmessagetosign).
 
 #### Returns
 
@@ -1103,11 +1103,11 @@ The minimal representation is used when adding transactions to an execution payl
 
 • **txData**: [`BlobEIP4844Transaction`](/reference/tevm/tx/classes/blobeip4844transaction/)
 
-a [BlobEIP4844Transaction](../../../../../../../reference/tevm/tx/classes/blobeip4844transaction) containing optional blobs/kzg commitments
+a [BlobEIP4844Transaction](../../../../../../../../reference/tevm/tx/classes/blobeip4844transaction) containing optional blobs/kzg commitments
 
 • **opts?**: [`TxOptions`](/reference/tevm/tx/interfaces/txoptions/)
 
-dictionary of [TxOptions](../../../../../../../reference/tevm/tx/interfaces/txoptions)
+dictionary of [TxOptions](../../../../../../../../reference/tevm/tx/interfaces/txoptions)
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/tx/classes/FeeMarketEIP1559Transaction.md
+++ b/docs/src/content/docs/reference/@tevm/tx/classes/FeeMarketEIP1559Transaction.md
@@ -656,7 +656,7 @@ node\_modules/.pnpm/@ethereumjs+tx@5.4.0/node\_modules/@ethereumjs/tx/dist/esm/b
 Computes a sha3-256 hash of the serialized tx.
 
 This method can only be used for signed txs (it throws otherwise).
-Use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
+Use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
 
 #### Returns
 
@@ -721,12 +721,12 @@ Returns a Uint8Array Array of the raw Bytes of the EIP-1559 transaction, in orde
 Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
 accessList, signatureYParity, signatureR, signatureS]`
 
-Use [FeeMarketEIP1559Transaction.serialize](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#serialize) to add a transaction to a block
+Use [FeeMarketEIP1559Transaction.serialize](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#serialize) to add a transaction to a block
 with Block.fromValuesArray.
 
 For an unsigned tx this method uses the empty Bytes values for the
 signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-representation for external signing use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign).
+representation for external signing use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign).
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/tx/functions/createImpersonatedTx.md
+++ b/docs/src/content/docs/reference/@tevm/tx/functions/createImpersonatedTx.md
@@ -7,7 +7,7 @@ title: "createImpersonatedTx"
 
 > **createImpersonatedTx**(`txData`, `opts`?): [`ImpersonatedTx`](/reference/tevm/tx/interfaces/impersonatedtx/)
 
-Creates an impersonated tx that wraps [FeeMarketEIP1559Transaction](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction).
+Creates an impersonated tx that wraps [FeeMarketEIP1559Transaction](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction).
 Wraps following methods
 - 'isImpersonated'
 - 'hash'
@@ -26,7 +26,7 @@ Wraps following methods
 
 ## Throws
 
-Error if the constructor for [FeeMarketEIP1559Transaction](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction) throws
+Error if the constructor for [FeeMarketEIP1559Transaction](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction) throws
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/tx/interfaces/ImpersonatedTx.md
+++ b/docs/src/content/docs/reference/@tevm/tx/interfaces/ImpersonatedTx.md
@@ -652,7 +652,7 @@ node\_modules/.pnpm/@ethereumjs+tx@5.4.0/node\_modules/@ethereumjs/tx/dist/esm/b
 Computes a sha3-256 hash of the serialized tx.
 
 This method can only be used for signed txs (it throws otherwise).
-Use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
+Use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign) to get a tx hash for the purpose of signing.
 
 #### Returns
 
@@ -717,12 +717,12 @@ Returns a Uint8Array Array of the raw Bytes of the EIP-1559 transaction, in orde
 Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
 accessList, signatureYParity, signatureR, signatureS]`
 
-Use [FeeMarketEIP1559Transaction.serialize](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#serialize) to add a transaction to a block
+Use [FeeMarketEIP1559Transaction.serialize](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#serialize) to add a transaction to a block
 with Block.fromValuesArray.
 
 For an unsigned tx this method uses the empty Bytes values for the
 signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-representation for external signing use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign).
+representation for external signing use [FeeMarketEIP1559Transaction.getMessageToSign](../../../../../../../../reference/tevm/tx/classes/feemarketeip1559transaction/#getmessagetosign).
 
 #### Returns
 

--- a/docs/src/content/docs/reference/@tevm/utils/classes/AsyncEventEmitter.md
+++ b/docs/src/content/docs/reference/@tevm/utils/classes/AsyncEventEmitter.md
@@ -33,7 +33,7 @@ title: "AsyncEventEmitter"
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:113
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:134
 
 ## Properties
 
@@ -55,7 +55,7 @@ v13.4.0, v12.16.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:412
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:459
 
 ***
 
@@ -77,7 +77,7 @@ v13.4.0, v12.16.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:405
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:452
 
 ***
 
@@ -131,7 +131,7 @@ v0.11.2
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:451
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:498
 
 ***
 
@@ -154,7 +154,7 @@ v13.6.0, v12.17.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:398
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:445
 
 ## Methods
 
@@ -184,7 +184,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:3
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:115
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:136
 
 ***
 
@@ -214,7 +214,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:1
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:592
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:545
 
 ***
 
@@ -442,7 +442,7 @@ node\_modules/.pnpm/@ethereumjs+util@9.1.0/node\_modules/@ethereumjs/util/dist/e
 > **getMaxListeners**(): `number`
 
 Returns the current max listener value for the `EventEmitter` which is either
-set by `emitter.setMaxListeners(n)` or defaults to [defaultMaxListeners](../../../../../../../reference/tevm/utils/classes/asynceventemitter/#defaultmaxlisteners).
+set by `emitter.setMaxListeners(n)` or defaults to [defaultMaxListeners](../../../../../../../../reference/tevm/utils/classes/asynceventemitter/#defaultmaxlisteners).
 
 #### Returns
 
@@ -564,7 +564,7 @@ v10.0.0
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:700
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:747
 
 #### off(eventName, listener)
 
@@ -596,7 +596,7 @@ v10.0.0
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:747
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:700
 
 ***
 
@@ -868,7 +868,7 @@ v9.4.0
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:771
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:818
 
 #### rawListeners(eventName)
 
@@ -924,7 +924,7 @@ v9.4.0
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:818
+node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:771
 
 ***
 
@@ -1167,7 +1167,7 @@ v20.5.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:390
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:437
 
 ***
 
@@ -1220,7 +1220,7 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:311
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:358
 
 ***
 
@@ -1272,7 +1272,7 @@ v19.9.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:340
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:387
 
 ***
 
@@ -1320,13 +1320,15 @@ v0.9.12
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:283
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:330
 
 ***
 
 ### on()
 
-> `static` **on**(`emitter`, `eventName`, `options`?): `AsyncIterableIterator`\<`any`, `any`, `any`\>
+#### on(emitter, eventName, options)
+
+> `static` **on**(`emitter`, `eventName`, `options`?): `AsyncIterableIterator`\<`any`[], `any`, `any`\>
 
 ```js
 import { on, EventEmitter } from 'node:events';
@@ -1383,33 +1385,77 @@ const ac = new AbortController();
 process.nextTick(() => ac.abort());
 ```
 
-#### Parameters
+Use the `close` option to specify an array of event names that will end the iteration:
+
+```js
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
+const ee = new EventEmitter();
+
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+  ee.emit('close');
+});
+
+for await (const event of on(ee, 'foo', { close: ['close'] })) {
+  console.log(event); // prints ['bar'] [42]
+}
+// the loop will exit after 'close' is emitted
+console.log('done'); // prints 'done'
+```
+
+##### Parameters
 
 • **emitter**: `EventEmitter`\<`DefaultEventMap`\>
 
-• **eventName**: `string`
+• **eventName**: `string` \| `symbol`
 
-The name of the event being listened for
+• **options?**: `StaticEventEmitterIteratorOptions`
 
-• **options?**: `StaticEventEmitterOptions`
+##### Returns
 
-#### Returns
-
-`AsyncIterableIterator`\<`any`, `any`, `any`\>
+`AsyncIterableIterator`\<`any`[], `any`, `any`\>
 
 An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
 
-#### Since
+##### Since
 
 v13.6.0, v12.16.0
 
-#### Inherited from
+##### Inherited from
 
 `EventEmitter.on`
 
-#### Defined in
+##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:261
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:303
+
+#### on(emitter, eventName, options)
+
+> `static` **on**(`emitter`, `eventName`, `options`?): `AsyncIterableIterator`\<`any`[], `any`, `any`\>
+
+##### Parameters
+
+• **emitter**: `EventTarget`
+
+• **eventName**: `string`
+
+• **options?**: `StaticEventEmitterIteratorOptions`
+
+##### Returns
+
+`AsyncIterableIterator`\<`any`[], `any`, `any`\>
+
+##### Inherited from
+
+`EventEmitter.on`
+
+##### Defined in
+
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:308
 
 ***
 
@@ -1518,7 +1564,7 @@ v11.13.0, v10.16.0
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:196
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:217
 
 #### once(emitter, eventName, options)
 
@@ -1542,7 +1588,7 @@ node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:1
 
 ##### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:201
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:222
 
 ***
 
@@ -1581,4 +1627,4 @@ v15.4.0
 
 #### Defined in
 
-node\_modules/.pnpm/@types+node@20.12.14/node\_modules/@types/node/events.d.ts:355
+node\_modules/.pnpm/@types+node@22.7.3/node\_modules/@types/node/events.d.ts:402

--- a/docs/src/content/docs/reference/@tevm/utils/functions/parseAbi.md
+++ b/docs/src/content/docs/reference/@tevm/utils/functions/parseAbi.md
@@ -7,7 +7,7 @@ title: "parseAbi"
 
 > **parseAbi**\<`signatures`\>(`signatures`): [`ParseAbi`](/reference/tevm/utils/type-aliases/parseabi/)\<`signatures`\>
 
-Parses human-readable ABI into JSON [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi)
+Parses human-readable ABI into JSON [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi)
 
 ## Type Parameters
 

--- a/docs/src/content/docs/reference/@tevm/utils/interfaces/GenesisState.md
+++ b/docs/src/content/docs/reference/@tevm/utils/interfaces/GenesisState.md
@@ -7,7 +7,7 @@ title: "GenesisState"
 
 If you are using a custom chain Common, pass the genesis state.
 
-Pattern 1 (with genesis state see [GenesisState](../../../../../../../reference/tevm/utils/interfaces/genesisstate) for format):
+Pattern 1 (with genesis state see [GenesisState](../../../../../../../../reference/tevm/utils/interfaces/genesisstate) for format):
 
 ```javascript
 {

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/AbiItemType.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/AbiItemType.md
@@ -7,7 +7,7 @@ title: "AbiItemType"
 
 > **AbiItemType**: `"constructor"` \| `"error"` \| `"event"` \| `"fallback"` \| `"function"` \| `"receive"`
 
-`"type"` name for [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi) items.
+`"type"` name for [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi) items.
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiEvent.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiEvent.md
@@ -7,17 +7,17 @@ title: "ExtractAbiEvent"
 
 > **ExtractAbiEvent**\<`abi`, `eventName`\>: `Extract`\<[`ExtractAbiEvents`](/reference/tevm/utils/type-aliases/extractabievents/)\<`abi`\>, `object`\>
 
-Extracts [AbiEvent](../../../../../../../reference/tevm/utils/type-aliases/abievent) with name from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi).
+Extracts [AbiEvent](../../../../../../../../reference/tevm/utils/type-aliases/abievent) with name from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi).
 
 ## Type Parameters
 
 • **abi** *extends* [`Abi`](/reference/tevm/utils/type-aliases/abi/)
 
-[Abi](../../../../../../../reference/tevm/utils/type-aliases/abi) to extract [AbiEvent](../../../../../../../reference/tevm/utils/type-aliases/abievent) from
+[Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi) to extract [AbiEvent](../../../../../../../../reference/tevm/utils/type-aliases/abievent) from
 
 • **eventName** *extends* [`ExtractAbiEventNames`](/reference/tevm/utils/type-aliases/extractabieventnames/)\<`abi`\>
 
-String name of event to extract from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi)
+String name of event to extract from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi)
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiEventNames.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiEventNames.md
@@ -7,13 +7,13 @@ title: "ExtractAbiEventNames"
 
 > **ExtractAbiEventNames**\<`abi`\>: [`ExtractAbiEvents`](/reference/tevm/utils/type-aliases/extractabievents/)\<`abi`\>\[`"name"`\]
 
-Extracts all [AbiEvent](../../../../../../../reference/tevm/utils/type-aliases/abievent) names from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi).
+Extracts all [AbiEvent](../../../../../../../../reference/tevm/utils/type-aliases/abievent) names from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi).
 
 ## Type Parameters
 
 • **abi** *extends* [`Abi`](/reference/tevm/utils/type-aliases/abi/)
 
-[Abi](../../../../../../../reference/tevm/utils/type-aliases/abi) to extract event names from
+[Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi) to extract event names from
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiEvents.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiEvents.md
@@ -7,13 +7,13 @@ title: "ExtractAbiEvents"
 
 > **ExtractAbiEvents**\<`abi`\>: `Extract`\<`abi`\[`number`\], `object`\>
 
-Extracts all [AbiEvent](../../../../../../../reference/tevm/utils/type-aliases/abievent) types from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi).
+Extracts all [AbiEvent](../../../../../../../../reference/tevm/utils/type-aliases/abievent) types from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi).
 
 ## Type Parameters
 
 • **abi** *extends* [`Abi`](/reference/tevm/utils/type-aliases/abi/)
 
-[Abi](../../../../../../../reference/tevm/utils/type-aliases/abi) to extract events from
+[Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi) to extract events from
 
 ## Defined in
 

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiFunction.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiFunction.md
@@ -7,17 +7,17 @@ title: "ExtractAbiFunction"
 
 > **ExtractAbiFunction**\<`abi`, `functionName`, `abiStateMutability`\>: `Extract`\<`ExtractAbiFunctions`\<`abi`, `abiStateMutability`\>, `object`\>
 
-Extracts [AbiFunction](../../../../../../../reference/tevm/utils/type-aliases/abifunction) with name from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi).
+Extracts [AbiFunction](../../../../../../../../reference/tevm/utils/type-aliases/abifunction) with name from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi).
 
 ## Type Parameters
 
 • **abi** *extends* [`Abi`](/reference/tevm/utils/type-aliases/abi/)
 
-[Abi](../../../../../../../reference/tevm/utils/type-aliases/abi) to extract [AbiFunction](../../../../../../../reference/tevm/utils/type-aliases/abifunction) from
+[Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi) to extract [AbiFunction](../../../../../../../../reference/tevm/utils/type-aliases/abifunction) from
 
 • **functionName** *extends* [`ExtractAbiFunctionNames`](/reference/tevm/utils/type-aliases/extractabifunctionnames/)\<`abi`\>
 
-String name of function to extract from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi)
+String name of function to extract from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi)
 
 • **abiStateMutability** *extends* `AbiStateMutability` = `AbiStateMutability`
 

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiFunctionNames.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/ExtractAbiFunctionNames.md
@@ -7,13 +7,13 @@ title: "ExtractAbiFunctionNames"
 
 > **ExtractAbiFunctionNames**\<`abi`, `abiStateMutability`\>: `ExtractAbiFunctions`\<`abi`, `abiStateMutability`\>\[`"name"`\]
 
-Extracts all [AbiFunction](../../../../../../../reference/tevm/utils/type-aliases/abifunction) names from [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi).
+Extracts all [AbiFunction](../../../../../../../../reference/tevm/utils/type-aliases/abifunction) names from [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi).
 
 ## Type Parameters
 
 • **abi** *extends* [`Abi`](/reference/tevm/utils/type-aliases/abi/)
 
-[Abi](../../../../../../../reference/tevm/utils/type-aliases/abi) to extract function names from
+[Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi) to extract function names from
 
 • **abiStateMutability** *extends* `AbiStateMutability` = `AbiStateMutability`
 

--- a/docs/src/content/docs/reference/@tevm/utils/type-aliases/ParseAbi.md
+++ b/docs/src/content/docs/reference/@tevm/utils/type-aliases/ParseAbi.md
@@ -7,7 +7,7 @@ title: "ParseAbi"
 
 > **ParseAbi**\<`signatures`\>: `string`[] *extends* `signatures` ? [`Abi`](/reference/tevm/utils/type-aliases/abi/) : `signatures` *extends* readonly `string`[] ? `signatures` *extends* `Signatures`\<`signatures`\> ? `ParseStructs`\<`signatures`\> *extends* infer sructs ? `{ [key in keyof signatures]: signatures[key] extends string ? ParseSignature<signatures[key], sructs> : never }` *extends* infer mapped ? `Filter`\<`mapped`, `never`\> *extends* infer result ? `result` *extends* readonly [] ? `never` : `result` : `never` : `never` : `never` : `never` : `never`
 
-Parses human-readable ABI into JSON [Abi](../../../../../../../reference/tevm/utils/type-aliases/abi)
+Parses human-readable ABI into JSON [Abi](../../../../../../../../reference/tevm/utils/type-aliases/abi)
 
 ## Type Parameters
 

--- a/docs/src/content/docs/reference/@tevm/vm/interfaces/ApplyBlockResult.md
+++ b/docs/src/content/docs/reference/@tevm/vm/interfaces/ApplyBlockResult.md
@@ -5,7 +5,7 @@ prev: false
 title: "ApplyBlockResult"
 ---
 
-Result of [applyBlock](../../../../../../../reference/tevm/vm/functions/applyblock)
+Result of [applyBlock](../../../../../../../../reference/tevm/vm/functions/applyblock)
 
 ## Properties
 

--- a/docs/src/content/docs/reference/@tevm/vm/interfaces/BuilderOpts.md
+++ b/docs/src/content/docs/reference/@tevm/vm/interfaces/BuilderOpts.md
@@ -17,7 +17,7 @@ Options for the block builder.
 
 > `optional` **calcDifficultyFromHeader**: [`BlockHeader`](/reference/tevm/block/classes/blockheader/)
 
-If a preceding [BlockHeader](../../../../../../../reference/tevm/block/classes/blockheader) (usually the parent header) is given the preceding
+If a preceding [BlockHeader](../../../../../../../../reference/tevm/block/classes/blockheader) (usually the parent header) is given the preceding
 header will be used to calculate the difficulty for this block and the calculated
 difficulty takes precedence over a provided static `difficulty` value.
 
@@ -55,13 +55,13 @@ packages/block/types/types.d.ts:59
 
 > **common**: `object`
 
-A [Common](../../../../../../../reference/tevm/common/type-aliases/common) object defining the chain and the hardfork a block/block header belongs to.
+A [Common](../../../../../../../../reference/tevm/common/type-aliases/common) object defining the chain and the hardfork a block/block header belongs to.
 
 Object will be internally copied so that tx behavior don't incidentally
 change on future HF changes.
 
-Default: [Common](../../../../../../../reference/tevm/common/type-aliases/common) object set to `mainnet` and the HF currently defined as the default
-hardfork in the [Common](../../../../../../../reference/tevm/common/type-aliases/common) class.
+Default: [Common](../../../../../../../../reference/tevm/common/type-aliases/common) object set to `mainnet` and the HF currently defined as the default
+hardfork in the [Common](../../../../../../../../reference/tevm/common/type-aliases/common) class.
 
 Current default hardfork: `merge`
 
@@ -253,7 +253,7 @@ for older Hfs.
 Additionally it is possible to pass in a specific TD value to support live-Merge-HF
 transitions. Note that this should only be needed in very rare and specific scenarios.
 
-Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../reference/tevm/common/type-aliases/common) instance)
+Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../../reference/tevm/common/type-aliases/common) instance)
 
 #### Inherited from
 

--- a/docs/src/content/docs/reference/@tevm/vm/interfaces/RunBlockOpts.md
+++ b/docs/src/content/docs/reference/@tevm/vm/interfaces/RunBlockOpts.md
@@ -87,7 +87,7 @@ for older Hfs.
 Additionally it is possible to pass in a specific TD value to support live-Merge-HF
 transitions. Note that this should only be needed in very rare and specific scenarios.
 
-Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../reference/tevm/common/type-aliases/common) instance)
+Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../../reference/tevm/common/type-aliases/common) instance)
 
 #### Defined in
 

--- a/docs/src/content/docs/reference/@tevm/vm/interfaces/VMOpts.md
+++ b/docs/src/content/docs/reference/@tevm/vm/interfaces/VMOpts.md
@@ -47,7 +47,7 @@ A Blockchain object for storing/retrieving blocks
 
 > `optional` **common**: `object`
 
-Use a [Common](../../../../../../../reference/tevm/common/type-aliases/common) instance
+Use a [Common](../../../../../../../../reference/tevm/common/type-aliases/common) instance
 if you want to change the chain setup.
 
 ### Possible Values
@@ -230,7 +230,7 @@ for older Hfs.
 Additionally it is possible to pass in a specific TD value to support live-Merge-HF
 transitions. Note that this should only be needed in very rare and specific scenarios.
 
-Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../reference/tevm/common/type-aliases/common) instance)
+Default: `false` (HF is set to whatever default HF is set by the [Common](../../../../../../../../reference/tevm/common/type-aliases/common) instance)
 
 #### Defined in
 

--- a/packages/precompiles/src/logToEthjsLog.spec.ts
+++ b/packages/precompiles/src/logToEthjsLog.spec.ts
@@ -1,5 +1,5 @@
 import { SimpleContract } from '@tevm/contract'
-import { type AbiEvent, encodeAbiParameters, encodeEventTopics, hexToBytes } from '@tevm/utils'
+import { type AbiEvent, type Hex, encodeAbiParameters, encodeEventTopics, hexToBytes } from '@tevm/utils'
 import { describe, expect, it } from 'vitest'
 import { logToEthjsLog } from './logToEthjsLog.js'
 
@@ -70,5 +70,180 @@ describe('logToEthjsLog', () => {
 		const data = encodeAbiParameters(eventItem.inputs, [] as any)
 
 		expect(result).toEqual([hexToBytes(log.address), topics, hexToBytes(data)])
+	})
+
+	it('should handle indexed and non-indexed parameters correctly', () => {
+		const abiWithIndexed = [
+			{
+				name: 'IndexedEvent',
+				type: 'event',
+				inputs: [
+					{ name: 'indexedParam', type: 'uint256', indexed: true },
+					{ name: 'nonIndexedParam', type: 'string', indexed: false },
+				],
+			},
+		] as [AbiEvent]
+
+		const log = {
+			eventName: 'IndexedEvent',
+			args: {
+				indexedParam: 123n,
+				nonIndexedParam: 'test',
+			},
+			address: '0x0000000000000000000000000000000000000003',
+		} as const
+
+		const result = logToEthjsLog(abiWithIndexed, log)
+
+		const topics = encodeEventTopics({
+			abi: abiWithIndexed,
+			eventName: log.eventName,
+			args: log.args,
+		}).map((topic) => hexToBytes(topic as `0x${string}`))
+
+		const eventItem = abiWithIndexed[0]
+		const data = encodeAbiParameters(
+			eventItem.inputs.filter((input) => !input.indexed),
+			[log.args.nonIndexedParam],
+		)
+
+		expect(result).toEqual([hexToBytes(log.address), topics, hexToBytes(data)])
+		expect(result[1].length).toBe(2) // Event signature + 1 indexed parameter
+		expect(result[2].length).toBeGreaterThan(0) // Non-empty data for non-indexed parameter
+	})
+
+	it('should handle events with only indexed parameters', () => {
+		const abiWithOnlyIndexed = [
+			{
+				name: 'AllIndexedEvent',
+				type: 'event',
+				inputs: [
+					{ name: 'param1', type: 'uint256', indexed: true },
+					{ name: 'param2', type: 'address', indexed: true },
+				],
+			},
+		] as [AbiEvent]
+
+		const log = {
+			eventName: 'AllIndexedEvent',
+			args: {
+				param1: 42n,
+				param2: '0x1234567890123456789012345678901234567890',
+			},
+			address: '0x0000000000000000000000000000000000000004',
+		} as const
+
+		const result = logToEthjsLog(abiWithOnlyIndexed, log)
+
+		expect(result[1].length).toBe(3) // Event signature + 2 indexed parameters
+		expect(result[2].length).toBe(0) // Empty data for all indexed parameters
+	})
+
+	it('should handle events with array parameters', () => {
+		const abiWithArray = [
+			{
+				name: 'ArrayEvent',
+				type: 'event',
+				inputs: [
+					{ name: 'numbers', type: 'uint256[]', indexed: false },
+					{ name: 'flag', type: 'bool', indexed: true },
+				],
+			},
+		] as [AbiEvent]
+
+		const log = {
+			eventName: 'ArrayEvent',
+			args: {
+				numbers: [1n, 2n, 3n],
+				flag: true,
+			},
+			address: '0x0000000000000000000000000000000000000005',
+		} as const
+
+		const result = logToEthjsLog(abiWithArray, log)
+
+		expect(result[1].length).toBe(2) // Event signature + 1 indexed parameter
+		expect(result[2].length).toBeGreaterThan(0) // Non-empty data for array parameter
+	})
+
+	it('should handle events with bytes and string parameters', () => {
+		const abiWithBytesAndString = [
+			{
+				name: 'BytesAndStringEvent',
+				type: 'event',
+				inputs: [
+					{ name: 'data', type: 'bytes', indexed: false },
+					{ name: 'text', type: 'string', indexed: true },
+				],
+			},
+		] as [AbiEvent]
+
+		const log = {
+			eventName: 'BytesAndStringEvent',
+			args: {
+				data: '0x1234567890',
+				text: 'Hello, world!',
+			},
+			address: '0x0000000000000000000000000000000000000006',
+		} as const
+
+		const result = logToEthjsLog(abiWithBytesAndString, log)
+
+		expect(result[1].length).toBe(2) // Event signature + 1 indexed parameter (keccak256 hash of the string)
+		expect(result[2].length).toBeGreaterThan(0) // Non-empty data for bytes parameter
+	})
+
+	it('should correctly handle a Uniswap Ethereum log', () => {
+		// https://etherscan.io/tx/0x1c359b587a843deff89a4fa3d8d674ea3edefafd2801d262ab771a9baaaad6ad#eventlog#66
+		const exampleLog = {
+			address: '0x9081b50bad8beefac48cc616694c26b027c559bb',
+			topics: [
+				'0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822',
+				'0x0000000000000000000000001111111254eeb25477b68fb85ed929f73a960582',
+				'0x000000000000000000000000b4e16d0168e52d35cacd2c6185b44281ec28c9dc',
+			],
+			data: '0x000000000000000000000000000000000000000000000008a19685b3e7332498000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000551deaf9c04d1be',
+			blockHash: '0x9ab81662fa8a40baa50e09515f9c45c89e5c6cb5af3b11e6e37d13a1e6489036',
+			blockNumber: '0x13fd31c',
+			transactionHash: '0x1c359b587a843deff89a4fa3d8d674ea3edefafd2801d262ab771a9baaaad6ad',
+			transactionIndex: '0xc',
+			logIndex: '0x42',
+			removed: false,
+		}
+
+		const log = {
+			eventName: 'Swap',
+			args: {
+				sender: '0x1111111254eeb25477b68fb85ed929f73a960582',
+				to: '0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc',
+				amount0In: 159217593484013937816n,
+				amount1In: 0n,
+				amount0Out: 0n,
+				amount1Out: 383332289121407422n,
+			},
+			address: '0x9081b50bad8beefac48cc616694c26b027c559bb',
+		} as const
+
+		const uniswapV2PairAbi = [
+			{
+				anonymous: false,
+				inputs: [
+					{ indexed: true, name: 'sender', type: 'address' },
+					{ indexed: false, name: 'amount0In', type: 'uint256' },
+					{ indexed: false, name: 'amount1In', type: 'uint256' },
+					{ indexed: false, name: 'amount0Out', type: 'uint256' },
+					{ indexed: false, name: 'amount1Out', type: 'uint256' },
+					{ indexed: true, name: 'to', type: 'address' },
+				],
+				name: 'Swap',
+				type: 'event',
+			},
+		] as const
+
+		const [address, topics, data] = logToEthjsLog(uniswapV2PairAbi, log)
+
+		expect(address).toEqual(hexToBytes(exampleLog.address as Hex))
+		expect(topics).toEqual(exampleLog.topics.map((topic) => hexToBytes(topic as Hex)))
+		expect(data).toEqual(hexToBytes(exampleLog.data as Hex))
 	})
 })

--- a/packages/precompiles/src/logToEthjsLog.ts
+++ b/packages/precompiles/src/logToEthjsLog.ts
@@ -35,17 +35,11 @@ export const logToEthjsLog = <TAbi extends Abi>(
 			? (inputs?.map((x: any) => (log.args as any)[x.name]) ?? [])
 			: []
 
-	const argsArrayWithoutIndexed = argsArray.filter((_, index) => {
-		const input = eventItem.inputs[index]
-		if (input?.indexed) {
-			return false
-		}
-		return true
-	})
+	const nonIndexedArgs = argsArray.filter((_, index) => !eventItem.inputs[index]?.indexed)
 
 	const data = encodeAbiParameters(
 		inputs.filter((input) => !input.indexed),
-		argsArrayWithoutIndexed,
+		nonIndexedArgs,
 	)
 	return [hexToBytes(log.address), topics, hexToBytes(data)]
 }

--- a/packages/precompiles/src/logToEthjsLog.ts
+++ b/packages/precompiles/src/logToEthjsLog.ts
@@ -34,6 +34,18 @@ export const logToEthjsLog = <TAbi extends Abi>(
 		: Object.values(log.args ?? {}).length > 0
 			? (inputs?.map((x: any) => (log.args as any)[x.name]) ?? [])
 			: []
-	const data = encodeAbiParameters(eventItem.inputs, argsArray)
+
+	const argsArrayWithoutIndexed = argsArray.filter((_, index) => {
+		const input = eventItem.inputs[index]
+		if (input?.indexed) {
+			return false
+		}
+		return true
+	})
+
+	const data = encodeAbiParameters(
+		inputs.filter((input) => !input.indexed),
+		argsArrayWithoutIndexed,
+	)
 	return [hexToBytes(log.address), topics, hexToBytes(data)]
 }


### PR DESCRIPTION
## Description

Indexed values should only be included in the `topics`, not the `data` of a log

## Testing

Added tests that check against expected log encoding, including one from etherscan.

