### PR TITLE
:recycle: Feat: Reset storage slot if more than one is found

### DIFF
--- a/.changeset/real-chairs-search.md
+++ b/.changeset/real-chairs-search.md
@@ -1,0 +1,5 @@
+---
+"@tevm/actions": patch
+---
+
+Fixed bug in anvilDeal to reset storage slot if more than one is found

--- a/packages/actions/docs/functions/dealHandler.md
+++ b/packages/actions/docs/functions/dealHandler.md
@@ -8,7 +8,7 @@
 
 > **dealHandler**(`client`): [`AnvilDealHandler`](../type-aliases/AnvilDealHandler.md)
 
-Defined in: [packages/actions/src/anvil/anvilDealHandler.js:14](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions/src/anvil/anvilDealHandler.js#L14)
+Defined in: [packages/actions/src/anvil/anvilDealHandler.js:16](https://github.com/evmts/tevm-monorepo/blob/main/packages/actions/src/anvil/anvilDealHandler.js#L16)
 
 Deals ERC20 tokens to an account by overriding the storage of balanceOf(account)
 


### PR DESCRIPTION
## Description

- regenerate docs
- Make TevmClient.deal reset the storage slot back to it's original value if it's not the correct storage slot for balanceOf when iterating over slots

## Testing

Explain the quality checks that have been done on the code changes

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation with refined reference details to improve clarity.
- **New Features**
	- Enhanced process reliability by verifying updates and preserving the original state when changes do not apply.
	- Improved error messaging to clearly inform users when an update fails.
- **Bug Fixes**
	- Resolved an issue in the `anvilDeal` function to ensure proper management of multiple storage slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->