### PR TITLE
Add `ethers` quickstart code and `TevmNode`

### DIFF
--- a/docs/node/docs/pages/getting-started.mdx
+++ b/docs/node/docs/pages/getting-started.mdx
@@ -57,7 +57,7 @@ console.log("Client ready")
 const blockNumber = await client.getBlockNumber()
 console.log(blockNumber)
 
-const account = `0x${baD60A7".padStart(40, "0")}` as const
+const account = `0x${"baD60A7".padStart(40, "0")}` as const
 const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
 
 const greetAbi = parseAbi(['function greet() view returns (string)'])
@@ -137,7 +137,7 @@ console.log(blockNumber)
 Report the fork block number. Any changes that happen on Optimism mainnet after this point will not be reflected in the `tevm` client.
 
 ```ts
-const account = "0x" + "baD60A7".padStart(40, "0")
+const account = `0x${"baD60A7".padStart(40, "0")}` as const
 const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
 ```
 

--- a/docs/node/docs/pages/getting-started.mdx
+++ b/docs/node/docs/pages/getting-started.mdx
@@ -3,6 +3,8 @@ title: Getting Started
 description: Get started with Tevm Node - A JavaScript Ethereum Virtual Machine
 ---
 
+import { Callout } from 'vocs/components'
+
 # Getting Started
 
 Tevm Node is an Ethereum Node that runs in all JavaScript environments. 
@@ -14,7 +16,7 @@ It's like [hardhat](https://hardhat.org/) or [anvil](https://book.getfoundry.sh/
 
 If you know how to use viem or ethers, you [already know how to use Tevm Node](./examples/ethers.mdx) and can get started right away.
 
-If you don't know how to use viem or ethers, don't worry, Tevm is a great way to learn Ethereumand TypeScript.
+If you don't know how to use viem or ethers, don't worry, Tevm is a great way to learn Ethereum and TypeScript.
 
 ## Installation
 
@@ -32,7 +34,7 @@ pnpm install tevm
 yarn add tevm
 :::
 
-## Quickstart
+## Using with Viem
 
 You can fork an existing blockchain and use [`viem` actions](https://viem.sh).
 
@@ -57,7 +59,7 @@ console.log("Client ready")
 const blockNumber = await client.getBlockNumber()
 console.log(blockNumber)
 
-const account = `0x${"baD60A7".padStart(40, "0")}` as const
+const account = "0x" + "baD60A7".padStart(40, "0")
 const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
 
 const greetAbi = parseAbi(['function greet() view returns (string)'])
@@ -137,7 +139,7 @@ console.log(blockNumber)
 Report the fork block number. Any changes that happen on Optimism mainnet after this point will not be reflected in the `tevm` client.
 
 ```ts
-const account = `0x${"baD60A7".padStart(40, "0")}` as const
+const account = "0x" + "baD60A7".padStart(40, "0")
 const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
 ```
 
@@ -221,57 +223,184 @@ So after we use [`<client>.sendTransaction`](https://viem.sh/docs/actions/wallet
 
 You can also use the tree shakeable api. See [`viem` tevm docs](./examples/viem.mdx)
 
-{/* 
+### Tevm actions
+
+**put something here**
 
 ## TevmNode
 
-In most cases you can use a standard API, either [`viem`](./examples/viem.mdx) API or [ethers](./examples/ethers.mdx), to control `tevm`.
-However, if you need a lower level API, it is available in the [`TevmNode`](https://github.com/evmts/tevm-monorepo/blob/main/packages/node/src/TevmNode.ts) object.
+In most cases, you can use a standard API, either [`viem`](./examples/viem.mdx) API or [ethers](./examples/ethers.mdx), to control `tevm`.
+These APIs let you communicate as you would with a real Ethernet node.
 
-- `TevmNode` starts and manages an Ethereum node in JavaScript while [`viem` actions](./examples/viem.mdx) or [`TevmNode` actions](./reference/actions.mdx) are how you communicate with the node.
-- `TevmNode` actions include tree shakeable actions for the entire ethereum JSON-RPC API including Anvil/Hardhat/Ganache methods.
+But if you need to access the node's internals, for example the EVM (Ethereum virtual machine), that is also available. The lower level API is available in the [`TevmNode`](https://github.com/evmts/tevm-monorepo/blob/main/packages/node/src/TevmNode.ts) object.
 
-```typescript
-const tevmNode = viemClient.transport.tevm
+For example, this code shows the trace of a `setGreeting` call.
+
+```ts [trace-execution.mts]
+import {createMemoryClient, http} from 'tevm'
+import {optimism} from 'tevm/common'
+import {createAddress} from `tevm/address`
+
+import {
+  encodeFunctionData, 
+  parseAbi, 
+  decodeFunctionResult, 
+  parseEther,
+  hexToBytes
+} from 'viem'
+
+const client = createMemoryClient({
+  fork: {
+    transport: http('https://mainnet.optimism.io')({}),
+    common: optimism,
+  },
+})
+
+console.log("Client created")
+
+await client.tevmReady()
+
+console.log("Client ready")
+
+const blockNumber = await client.getBlockNumber()
+console.log(blockNumber)
+
+const account = `0x${"baD60A7".padStart(40, "0")}` as const
+const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
+
+const greetAbi = parseAbi(['function greet() view returns (string)'])
+const setGreetingAbi = parseAbi(['function setGreeting(string memory _greeting) public'])
+
+const getGreeting = async () => {
+  const callResult = await client.call({
+    account,
+    to: greeterContractAddress,
+    data: encodeFunctionData({
+      abi: greetAbi
+    }),
+  })
+
+  const greeting = decodeFunctionResult({
+    abi: greetAbi,
+    data: callResult.data,
+  })
+
+  return greeting
+}
+
+await client.setBalance({
+  address: account,
+  value: parseEther("1")
+})
+
+const tevmNode = client.transport.tevm   // [!code hl]
+const vm = await tevmNode.getVm() // [!code hl]
+ 
+vm.evm.events.on("step", (data, next) => { // [!code hl]
+  try { // [!code hl]
+    console.log( // [!code hl]
+      data.pc.toString().padStart(5, " "), // [!code hl]
+      data.opcode.name.padEnd(9, " "), // [!code hl]
+      data.stack.length.toString().padStart(3, " "), // [!code hl]
+      data.stack.length<5 ? data.stack : data.stack.slice(-5)) // [!code hl]
+// [!code hl]
+  } catch (err) {  // [!code hl]
+    console.error(err)  // [!code hl]
+  }   // [!code hl]
+  next?.() // [!code hl]  
+}) // [!code hl]
+
+console.log(`Original greeting: ${await getGreeting()}`)
+
+const requestData = encodeFunctionData({ // [!code hl]
+  abi: setGreetingAbi, // [!code hl]
+  args: ["Hi"] // [!code hl]
+}) // [!code hl]
+
+await vm.evm.runCall({ // [!code hl]
+  to: createAddress(greeterContractAddress), // [!code hl]
+  caller: createAddress(account), // [!code hl]
+  data: hexToBytes(requestData) // [!code hl]
+}) // [!code hl]
+
+console.log(`Changed greeting: ${await getGreeting()}`) 
 ```
 
-We can create a TevmNode directly as well using `createTevmNode`
+:::details[Explanation]
 
-```typescript
-import { createTevmNode } from 'tevm'
-import { callHandler, setAccountHandler, getAccountHandler } from 'tevm/actions'
+```ts
+const tevmNode = client.transport.tevm
+const vm = await tevmNode.getVm()
+```
 
-const node = createTevmNode()
+Get a [`Vm`](/reference/vm#vm) object for the `tevmNode`.
+Note that this is *not* the `Vm` that runs when you mine a block to execute transactions.
+Mining is performed by new, pristine `Vm`s to ensure transactions are separated properly.
 
-// Execute a contract call
-const result = await callHandler(node)({
-  to: '0x1234567890123456789012345678901234567890',
-  data: '0x...',
-  value: 0n
-})
+```ts
+vm.evm.events.on("step", (data, next) => {
+```
 
-// Set account state
-await setAccountHandler(node)({
-  address: '0x1234567890123456789012345678901234567890',
-  balance: 1000000000000000000n // 1 ETH
-})
+The actual [`EVM`](https://github.com/evmts/tevm-monorepo/blob/main/packages/evm/docs/classes/Evm.md) is in `vm.evm`.
+It supports [three events](/api/evm-events#available-events).
+Here we listen to `step`, which is called for every opcode processed by the EVM.
 
-// Get account state
-const account = await getAccountHandler(node)({
-  address: '0x1234567890123456789012345678901234567890'
+```ts
+  try {
+```
+
+By default, when errors happen in event handlers they are discarded silently.
+By wrapping our code in a `try ... catch` statement, we make sure that we see the errors that are thrown.
+
+```ts
+    console.log(
+      data.pc.toString().padStart(5, " "),
+      data.opcode.name.padEnd(9, " "),
+      data.stack.length.toString().padStart(3, " "),
+      data.stack.length<5 ? data.stack : data.stack.slice(-5))
+```
+
+The `data` parameter is an [`InterpreterStep`](https://github.com/evmts/tevm-monorepo/blob/main/packages/evm/docs/interfaces/InterpreterStep.md).
+Here we output the interesting fields.
+
+```ts    
+  } catch (err) {
+    console.err(err)
+  }
+
+  next?.()
 })
 ```
 
-- Learn more about the TevmNode actions api in the [actions api reference](./reference/actions.mdx)
-- Learn more about TevmNode internals in the [TevmNode reference](./reference/node.mdx)
+The `next` parameter is the function to call after the event handler is done.
 
-*/}
+```ts
+const requestData = encodeFunctionData({
+  abi: setGreetingAbi,
+  args: ["Hi"]
+})
+```
+
+Create the ABI encoded data you would normally send with the transaction, using `viem`'s [`encodeFunctionData`](https://viem.sh/docs/contract/encodeFunctionData.html).
+
+```ts
+await vm.evm.runCall({
+  to: createAddress(greeterContractAddress),
+  caller: createAddress(account),
+  data: hexToBytes(requestData)
+})
+```
+
+This is the way we [call the EVM](http://localhost:5173/reference/evm#running-evm-calls), which activates the event handler registered earlier.
+This call modifies the state, so you can see the updated greeting.
+
+:::
 
 
 ## Using with Ethers
 
-Tevm is an EIP-1193 provider and works with any library that follows the same standard including `ethers`, `thirdweb`, `ponder` and many others. 
-Though it is primarily built for `viem` it stays provider agnostic.
+Tevm is an EIP-1193 provider and works with any library that follows the same standared including `ethers`, `thirdweb`, `ponder` and many others. 
+Though it is primarily built for `viem` it stays provider-agnostic.
 
 ```ts [ethers-quickstart.mts]
 import {createMemoryClient, http, parseAbi} from 'tevm'
@@ -329,7 +458,7 @@ console.log(`Changed greeting: ${await getGreeting()}`)
 
 :::details[Explanation]
 
-```ts [ethers-quickstart.mts]
+```ts
 import {createMemoryClient, http, parseAbi} from 'tevm'
 import {optimism} from 'tevm/common'
 import {requestEip1193} from 'tevm/decorators'
@@ -378,7 +507,7 @@ const signer = Wallet.createRandom(provider)
 ```
 
 Create [a random wallet](https://docs.ethers.org/v6/api/wallet/#Wallet_createRandom).
-The `ethers` library requires us to have a private key to submit a transaction, even if `tevm` will accept it without a valid signature, so we need a full fledged wallet and not just an address.
+The `ethers` library requires us to have a private key to submit a transaction, even if `tevm` will accept it without a valid signature, so we need a full-fledged wallet and not just an address.
 
 ```ts
 const blockNumber = await provider.getBlockNumber()
@@ -432,7 +561,8 @@ await client.mine({blocks: 1})
 console.log(`Changed greeting: ${await getGreeting()}`)
 ```
 
-Because we control the "node", we control when it mines a new block and processes transactions. So after we use a function that creates a transaction we need to use [`<client>.mine`](https://viem.sh/docs/actions/test/mine) for the transaction to take effect.
+Because we control the "node", we control when it mines a new block and processes transactions. 
+So after we use a function that creates a transaction, we need to use [`<client>.mine`](https://viem.sh/docs/actions/test/mine) for the transaction to take effect.
 
 :::
 

--- a/docs/node/docs/pages/getting-started.mdx
+++ b/docs/node/docs/pages/getting-started.mdx
@@ -136,7 +136,7 @@ const blockNumber = await client.getBlockNumber()
 console.log(blockNumber)
 ```
 
-Report the fork block number. Any changes that happen on Optimism mainnet after this point will not be reflected in the `tevm` client.
+Report the fork block number. Any changes on the Optimism mainnet after this point will not be reflected in the `tevm` client.
 
 ```ts
 const account = "0x" + "baD60A7".padStart(40, "0")
@@ -221,7 +221,7 @@ So after we use [`<client>.sendTransaction`](https://viem.sh/docs/actions/wallet
 
 :::
 
-You can also use the tree shakeable api. See [`viem` tevm docs](./examples/viem.mdx)
+You can also use the tree-shakeable API. See [`viem` tevm docs](./examples/viem.mdx)
 
 ### Tevm actions
 
@@ -239,7 +239,7 @@ For example, this code shows the trace of a `setGreeting` call.
 ```ts [trace-execution.mts]
 import {createMemoryClient, http} from 'tevm'
 import {optimism} from 'tevm/common'
-import {createAddress} from `tevm/address`
+import {createAddress} from 'tevm/address'
 
 import {
   encodeFunctionData, 
@@ -514,7 +514,7 @@ const blockNumber = await provider.getBlockNumber()
 console.log(blockNumber)
 ```
 
-Report the fork block number. Any changes that happen on Optimism mainnet after this point will not be reflected in the `tevm` client.
+Report the fork block number. Any changes on the Optimism mainnet after this point will not be reflected in the `tevm` client.
 
 ```ts
 const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"

--- a/docs/node/docs/pages/getting-started.mdx
+++ b/docs/node/docs/pages/getting-started.mdx
@@ -270,7 +270,7 @@ const account = await getAccountHandler(node)({
 
 ## Using with Ethers
 
-Tevm is an EIP-1193 provider and works with any library that follows the same standared including `ethers`, `thirdweb`, `ponder` and many others. 
+Tevm is an EIP-1193 provider and works with any library that follows the same standard including `ethers`, `thirdweb`, `ponder` and many others. 
 Though it is primarily built for `viem` it stays provider agnostic.
 
 ```ts [ethers-quickstart.mts]

--- a/docs/node/docs/pages/getting-started.mdx
+++ b/docs/node/docs/pages/getting-started.mdx
@@ -34,9 +34,9 @@ yarn add tevm
 
 ## Quickstart
 
-You can just fork an existing blockchain and use [viem actions](https://viem.sh).
+You can fork an existing blockchain and use [`viem` actions](https://viem.sh).
 
-```ts [quickstart.mts]
+```ts [viem-quickstart.mts]
 import {createMemoryClient, http} from 'tevm'
 import {optimism} from 'tevm/common'
 import {encodeFunctionData, parseAbi, decodeFunctionResult, parseEther} from 'viem'
@@ -134,8 +134,7 @@ const blockNumber = await client.getBlockNumber()
 console.log(blockNumber)
 ```
 
-Report the fork block number.
-Any changes that happen on Optimism mainnet after this point will not be reflected in the TEVM client.
+Report the fork block number. Any changes that happen on Optimism mainnet after this point will not be reflected in the `tevm` client.
 
 ```ts
 const account = "0x" + "baD60A7".padStart(40, "0")
@@ -207,7 +206,7 @@ The function we use is identical to [`viem`s `setBalance`](https://viem.sh/docs/
 console.log(`Original greeting: ${await getGreeting()}`)
 ```
 
-The way you get a greeting is identical to the way you'd do it with viem.
+The way you get a greeting is identical to the way you'd do it with `viem`.
 
 ```ts
 console.log(`Txn hash: ${await setGreeting("Hi")}`)
@@ -220,16 +219,17 @@ So after we use [`<client>.sendTransaction`](https://viem.sh/docs/actions/wallet
 
 :::
 
-You can also use the tree shakeable api. See [viem tevm docs](./examples/viem.mdx)
+You can also use the tree shakeable api. See [`viem` tevm docs](./examples/viem.mdx)
+
+{/* 
 
 ## TevmNode
 
-For 95% of use cases of Tevm you will only need to know the [viem](./examples/viem.mdx) and [ethers](./examples/ethers.mdx) apis to use Tevm.
+In most cases you can use a standard API, either [`viem`](./examples/viem.mdx) API or [ethers](./examples/ethers.mdx), to control `tevm`.
+However, if you need a lower level API, it is available in the [`TevmNode`](https://github.com/evmts/tevm-monorepo/blob/main/packages/node/src/TevmNode.ts) object.
 
-There is however a lower level API underpinning both of those APIs called TevmNode. Remember TevmNode was on our viem client earlier powering the transport.
-
-- TevmNode starts and manages an in-javascript ethereum node while [viem actions](./examples/viem.mdx) or [TevmNode actions](./reference/actions.mdx) are how you communicate with the node.
-- TevmNode actions include tree shakeable actions for the entire ethereum JSON-RPC api including Anvil/Hardhat/Ganache methods.
+- `TevmNode` starts and manages an Ethereum node in JavaScript while [`viem` actions](./examples/viem.mdx) or [`TevmNode` actions](./reference/actions.mdx) are how you communicate with the node.
+- `TevmNode` actions include tree shakeable actions for the entire ethereum JSON-RPC API including Anvil/Hardhat/Ganache methods.
 
 ```typescript
 const tevmNode = viemClient.transport.tevm
@@ -265,21 +265,177 @@ const account = await getAccountHandler(node)({
 - Learn more about the TevmNode actions api in the [actions api reference](./reference/actions.mdx)
 - Learn more about TevmNode internals in the [TevmNode reference](./reference/node.mdx)
 
+*/}
+
+
 ## Using with Ethers
 
-Tevm is an EIP-1193 provider and works with any library that follows the same standared including ethers, thirdweb, ponder and many others. Though it is primarily built for viem it stays provider agnostic.
+Tevm is an EIP-1193 provider and works with any library that follows the same standared including `ethers`, `thirdweb`, `ponder` and many others. 
+Though it is primarily built for `viem` it stays provider agnostic.
 
-```typescript
-import { createTevmNode } from 'tevm'
-import { requestEip1193 } from 'tevm/decorators'
-import { BrowserProvider } from 'ethers'
+```ts [ethers-quickstart.mts]
+import {createMemoryClient, http, parseAbi} from 'tevm'
+import {optimism} from 'tevm/common'
+import {requestEip1193} from 'tevm/decorators'
+import {BrowserProvider, Contract, Wallet} from 'ethers' 
+import {parseUnits} from 'ethers/utils'
 
-const node = createTevmNode().extend(requestEip1193())
-const provider = new BrowserProvider(node)
+const client = createMemoryClient({
+  fork: {
+    transport: http('https://mainnet.optimism.io')({}),
+    common: optimism
+  },
+})
 
-const block = await provider.getBlockNumber()
-const balance = await provider.getBalance('0x1234...')
+client.tevm.extend(requestEip1193())
+await client.tevmReady()
+ 
+console.log("Client ready")
+
+const provider = new BrowserProvider(client.tevm)
+const signer = Wallet.createRandom(provider)
+
+const blockNumber = await provider.getBlockNumber()
+console.log(blockNumber)
+ 
+const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
+
+const greeterAbi = parseAbi([
+    'function greet() view returns (string)',
+    'function setGreeting(string memory _greeting) public',
+])
+
+const greeter = new Contract(greeterContractAddress, greeterAbi, signer)
+
+ 
+const getGreeting = async () => await greeter.greet()
+ 
+const setGreeting = async newGreeting => {
+  const txn = await greeter.setGreeting(newGreeting)
+  return txn.hash
+}
+ 
+await client.setBalance({
+  address: signer.address,
+  value: parseUnits("1.0", "ether")
+})
+
+console.log(`Original greeting: ${await getGreeting()}`)
+console.log(`Txn hash: ${await setGreeting("Hi")}`)
+await client.mine({blocks: 1})
+console.log(`Changed greeting: ${await getGreeting()}`)
 ```
+
+
+:::details[Explanation]
+
+```ts [ethers-quickstart.mts]
+import {createMemoryClient, http, parseAbi} from 'tevm'
+import {optimism} from 'tevm/common'
+import {requestEip1193} from 'tevm/decorators'
+import {BrowserProvider, Contract, Wallet} from 'ethers' 
+import {parseUnits} from 'ethers/utils'
+```
+
+Import functions we need, which will be explained when we call them.
+
+```ts
+const client = createMemoryClient({
+  fork: {
+    transport: http('https://mainnet.optimism.io')({}),
+    common: optimism
+  },
+})
+```
+
+Create a client as a fork of the Optimism mainnet.
+
+```ts
+client.tevm.extend(requestEip1193())
+```
+
+Extend the `tevm` client with an [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) interface.
+This standard interface lets us use `tevm` with most Ethereum libraries.
+
+Note that we are not extending the [`MemoryClient`](/introduction/architecture-overview#memoryclient) directly, but the `tevm` object inside it.
+
+```ts
+await client.tevmReady()
+console.log("Client ready")
+```
+
+Wait until the client is ready.
+
+```ts
+const provider = new BrowserProvider(client.tevm)
+```
+
+Use `tevm` as a [`BrowserProvider`](https://docs.ethers.org/v6/api/providers/#BrowserProvider), which just means an EIP-1193 compatible provider.
+
+
+```ts
+const signer = Wallet.createRandom(provider)
+```
+
+Create [a random wallet](https://docs.ethers.org/v6/api/wallet/#Wallet_createRandom).
+The `ethers` library requires us to have a private key to submit a transaction, even if `tevm` will accept it without a valid signature, so we need a full fledged wallet and not just an address.
+
+```ts
+const blockNumber = await provider.getBlockNumber()
+console.log(blockNumber)
+```
+
+Report the fork block number. Any changes that happen on Optimism mainnet after this point will not be reflected in the `tevm` client.
+
+```ts
+const greeterContractAddress = "0x10ed0b176048c34d69ffc0712de06CbE95730748"
+
+const greeterAbi = parseAbi([
+    'function greet() view returns (string)',
+    'function setGreeting(string memory _greeting) public',
+])
+
+const greeter = new Contract(greeterContractAddress, greeterAbi, signer)
+```
+
+Create the [`Contract`](https://docs.ethers.org/v6/api/contract) object for [a `Greeter` contract on Optimism](https://optimism.blockscout.com/address/0x10ed0b176048c34d69ffc0712de06CbE95730748?tab=read_write_contract).
+
+```ts 
+const getGreeting = async () => await greeter.greet()
+ 
+const setGreeting = async newGreeting => {
+  const txn = await greeter.setGreeting(newGreeting)
+  return txn.hash
+}
+```
+
+The way you call `view` functions and send transactions is identical to what you'd do in a normal `ethers` program.
+
+```ts
+await client.setBalance({
+  address: signer.address,
+  value: parseUnits("1.0", "ether")
+})
+```
+
+Mint 1 ETH for our address so we'll be able to send transactions.
+
+```ts
+console.log(`Original greeting: ${await getGreeting()}`)
+```
+
+The way you get a greeting is identical to the way you'd do it with `ethers`.
+
+```ts
+console.log(`Txn hash: ${await setGreeting("Hi")}`)
+await client.mine({blocks: 1})
+console.log(`Changed greeting: ${await getGreeting()}`)
+```
+
+Because we control the "node", we control when it mines a new block and processes transactions. So after we use a function that creates a transaction we need to use [`<client>.mine`](https://viem.sh/docs/actions/test/mine) for the transaction to take effect.
+
+:::
+
 
 ## Next Steps
 

--- a/docs/node/docs/pages/getting-started.mdx
+++ b/docs/node/docs/pages/getting-started.mdx
@@ -391,7 +391,7 @@ await vm.evm.runCall({
 })
 ```
 
-This is the way we [call the EVM](http://localhost:5173/reference/evm#running-evm-calls), which activates the event handler registered earlier.
+This is the way we [call the EVM](/reference/evm#running-evm-calls), which activates the event handler registered earlier.
 This call modifies the state, so you can see the updated greeting.
 
 :::


### PR DESCRIPTION
## Description

Add this quickstart code to getting started, to do with the `viem` code we already have.

## Testing

N/A

## Additional Information

- [x] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: qbzzt.eth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced the "Getting Started" guide with refined text and improved formatting for clarity.
	- Standardized terminology and styling to ensure a consistent reading experience.
	- Expanded interactive examples, including new code snippets for creating a memory client and interacting with a greeter contract, to better illustrate integration workflows and usage patterns.
	- Updated section headers and added emphasis for clarity on key terms.
	- Clarified statements regarding the Optimism mainnet and `tevm` client interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->