### PR TITLE
fix: Cli not including built files on npm

### DIFF
--- a/.changeset/floppy-forks-yell.md
+++ b/.changeset/floppy-forks-yell.md
@@ -1,0 +1,5 @@
+---
+"@tevm/cli": patch
+---
+
+Fixed bug with cli dist not being published

--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,8 @@
 		"node": ">=16"
 	},
 	"scripts": {
-		"build": "tsc --skipLibCheck && mkdir -p dist/utils && cp src/utils/bun.lockb dist/utils/",
+		"build": "pnpm run build:dist",
+		"build:app": "tsc --skipLibCheck && mkdir -p dist/utils && cp src/utils/bun.lockb dist/utils/",
 		"dev": "tsx src/cli.tsx",
 		"test": "prettier --check . && xo && ava"
 	},


### PR DESCRIPTION
## Description

Fixed a bug in the CLI package where the distribution files were not being published correctly. Updated the build script to use `build:dist` and added a new `build:app` script that contains the previous build logic.

## Testing

Verified that the CLI distribution files are now properly published.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: