### PR TITLE
solc: fix storage layout output type

### DIFF
--- a/.changeset/kind-schools-burn.md
+++ b/.changeset/kind-schools-burn.md
@@ -1,0 +1,5 @@
+---
+"@tevm/solc": minor
+---
+
+Fix "storageLayout" output type, previously specified as an array of "StorageLayout", which was incorrect as it is a single object.

--- a/bundler-packages/solc/src/solcTypes.ts
+++ b/bundler-packages/solc/src/solcTypes.ts
@@ -414,7 +414,7 @@ export type SolcContractOutput = {
 	ir: string
 
 	// The storage layout output for all contracts provided as sources
-	storageLayout: SolcStorageLayoutOutput
+	storageLayout: SolcStorageLayout
 
 	// EVM-related outputs
 	evm: SolcEVMOutput
@@ -422,11 +422,6 @@ export type SolcContractOutput = {
 	// Ewasm related outputs
 	ewasm: SolcEwasmOutput
 }
-
-/**
- * The storage layout for each contract provided as sources.
- */
-export type SolcStorageLayoutOutput = Array<SolcStorageLayout>
 
 /**
  * The storage layout for a contract.


### PR DESCRIPTION
The `storageLayout` property of a contract output was wrongly labeled (by me) as an array of `StorageLayout`, when it is in fact a single `StorageLayout` object.

This PR fixes this, by removing the `type StorageLayoutOutput = Array<StorageLayout>` and directly assigning `StorageLayout` as the type in the contract output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The contract output now presents storage layout data as a single object rather than as an array, streamlining information access.

- **Chores**
  - Legacy type definitions were removed to simplify the data structure and improve output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->