### PR TITLE
docs: fixed broken links `Foundry`

### DIFF
--- a/tevm/README.md
+++ b/tevm/README.md
@@ -18,7 +18,7 @@
 Tevm is an ethereum development toolkit that offers
 
 - Arbitrary EVM execution and forking akin to [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
-- A powerful solidity scripting environment akin to [foundry scripts](https://book.getfoundry.sh/tutorials/solidity-scripting)
+- A powerful solidity scripting environment akin to [foundry scripts](https://book.getfoundry.sh/guides/scripting-with-solidity)
 - Build tooling to create a smooth interface between your Solidity scripts and TypeScript code
 
 ```typescript

--- a/tevm/docs/README.md
+++ b/tevm/docs/README.md
@@ -22,7 +22,7 @@
 Tevm is an ethereum development toolkit that offers
 
 - Arbitrary EVM execution and forking akin to [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
-- A powerful solidity scripting environment akin to [foundry scripts](https://book.getfoundry.sh/tutorials/solidity-scripting)
+- A powerful solidity scripting environment akin to [foundry scripts](https://book.getfoundry.sh/guides/scripting-with-solidity)
 - Build tooling to create a smooth interface between your Solidity scripts and TypeScript code
 
 ```typescript


### PR DESCRIPTION
## Description

Hi! I fixed outdated links to the Foundry Solidity scripting guide in two README files

The new URL points to the current path under `guides/scripting-with-solidity`.

## Additional Information

- [x] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: 0xfC2d9450ee35Fc00ccc290E785d9e24BBaCF7D86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated reference hyperlinks in the project documentation to direct users to the current guides on Solidity scripting instead of the previous tutorial links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->