### PR TITLE
fix: parsing caller parameter on a call

### DIFF
--- a/.changeset/lovely-bees-swim.md
+++ b/.changeset/lovely-bees-swim.md
@@ -1,0 +1,7 @@
+---
+"@tevm/actions": patch
+---
+
+Fixes impersonated tx parameters parsing: a specified `caller` parameter would be overriden by the default `origin` as the sender of the transaction.
+
+This fix adds `caller` as a fallback value to `tx.origin`.

--- a/packages/actions/src/Call/callHandlerOpts.js
+++ b/packages/actions/src/Call/callHandlerOpts.js
@@ -133,6 +133,7 @@ export const callHandlerOpts = async (client, params) => {
 	const origin =
 		params.origin ||
 		params.from ||
+		params.caller ||
 		(params.createTransaction ? '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' : `0x${'00'.repeat(20)}`)
 	if (origin) {
 		if (params.skipBalance !== undefined) {


### PR DESCRIPTION
> [!NOTE]
> Addresses #1622 

## Description

Before, a specified `caller` parameter would always be overriden by the default `origin` as the sender of the transaction.

```ts
// callHandlerOpts.js
const caller =
  params.caller ||
  params.from ||
  params.origin ||
  (params.createTransaction ? '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' : `0x${'00'.repeat(20)}`)
if (caller) {
  opts.caller = createAddress(caller)
}
const origin =
  params.origin ||
  params.from ||
  (params.createTransaction ? '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' : `0x${'00'.repeat(20)}`)
```
```ts
// evmInputToImpersonatedTx.js
const sender =
    // when using callHandler, origin was assigned a default value
  evmInput.origin
  // so this won't ever be reached
  ?? evmInput.caller
  ?? createAddress(`0x${'00'.repeat(20)}`)
```

## Fix

This fix adds `caller` as a fallback value to `evmInput.origin`. Meaning that we won't have cases where only `caller` is specified but the sender is still assigned the default `origin`.

```diff
  # callHandlerOpts.js

  const origin =
    params.origin ||
    params.from ||
+   params.caller ||
    (params.createTransaction ? '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' : `0x${'00'.repeat(20)}`)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the specified caller in transaction parameters could be incorrectly overridden, ensuring the correct sender is recognized in impersonated transaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->