### PR TITLE
fix: account/tx nonce in createTransaction

### DIFF
--- a/.changeset/chilly-geckos-go.md
+++ b/.changeset/chilly-geckos-go.md
@@ -1,0 +1,7 @@
+---
+"@tevm/actions": patch
+---
+
+Fixes tx nonce calculation from account state in `createTransaction`.
+
+This previously incremented the nonce by the number of transactions for this account in the tx pool, when the vm would actually already have incremented the nonce for the next transaction.

--- a/packages/actions/src/CreateTransaction/createTransaction.js
+++ b/packages/actions/src/CreateTransaction/createTransaction.js
@@ -77,10 +77,7 @@ export const createTransaction = (client, defaultThrowOnFail = true) => {
 
 		const sender = evmInput.origin ?? evmInput.caller ?? createAddress(`0x${'00'.repeat(20)}`)
 
-		const txPool = await client.getTxPool()
-		const txs = await txPool.getBySenderAddress(sender)
-
-		const nonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce + BigInt(txs.length)
+		const nonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce
 
 		client.logger.debug({ nonce, sender: sender.toString() }, 'creating tx with nonce')
 


### PR DESCRIPTION
## Description

TODO

## Testing

TODO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logic for transaction nonce calculation to prevent double counting, ensuring transactions use the correct nonce from the account state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->