### PR TITLE
fix: account/tx nonce in createTransaction

### DIFF
--- a/.changeset/chilly-geckos-go.md
+++ b/.changeset/chilly-geckos-go.md
@@ -1,0 +1,7 @@
+---
+"@tevm/actions": patch
+---
+
+Fixes tx nonce calculation from account state in `createTransaction`.
+
+This previously incremented the nonce by the number of transactions for this account in the tx pool, when the vm would actually already have incremented the nonce for the next transaction.

--- a/packages/actions/src/CreateTransaction/createTransaction.js
+++ b/packages/actions/src/CreateTransaction/createTransaction.js
@@ -77,10 +77,7 @@ export const createTransaction = (client, defaultThrowOnFail = true) => {
 
 		const sender = evmInput.origin ?? evmInput.caller ?? createAddress(`0x${'00'.repeat(20)}`)
 
-		const txPool = await client.getTxPool()
-		const txs = await txPool.getBySenderAddress(sender)
-
-		const nonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce + BigInt(txs.length)
+		const nonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce
 
 		client.logger.debug({ nonce, sender: sender.toString() }, 'creating tx with nonce')
 

--- a/packages/actions/src/CreateTransaction/createTransaction.js
+++ b/packages/actions/src/CreateTransaction/createTransaction.js
@@ -77,8 +77,18 @@ export const createTransaction = (client, defaultThrowOnFail = true) => {
 
 		const sender = evmInput.origin ?? evmInput.caller ?? createAddress(`0x${'00'.repeat(20)}`)
 
-		const nonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce
+		const txPool = await client.getTxPool()
+		const txs = await txPool.getBySenderAddress(sender)
+		const accountNonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce
 
+		// Get the highest transaction nonce from the pool for this sender
+		let highestPoolNonce = accountNonce - 1n
+		for (const tx of txs) {
+			if (tx.tx.nonce > highestPoolNonce) highestPoolNonce = tx.tx.nonce
+		}
+
+		// This ensures we never reuse nor skip a nonce
+		const nonce = highestPoolNonce >= accountNonce ? highestPoolNonce + 1n : accountNonce
 		client.logger.debug({ nonce, sender: sender.toString() }, 'creating tx with nonce')
 
 		let maxFeePerGas = parentBlock.header.calcNextBaseFee() + priorityFee

--- a/packages/actions/src/CreateTransaction/createTransaction.spec.ts
+++ b/packages/actions/src/CreateTransaction/createTransaction.spec.ts
@@ -1,294 +1,145 @@
 import { createAddress } from '@tevm/address'
-import type { TevmNode } from '@tevm/node'
-import { EthjsAccount } from '@tevm/utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type TevmNode, createTevmNode } from '@tevm/node'
+import { TestERC20 } from '@tevm/test-utils'
+import {  bytesToHex, encodeFunctionData, type Address, type Hex } from '@tevm/utils'
+import { assert, beforeEach, describe, expect, it } from 'vitest'
+import type { CallParams } from '../Call/CallParams.js'
+import { callHandlerOpts } from '../Call/callHandlerOpts.js'
+import { executeCall } from '../Call/executeCall.js'
+import { setAccountHandler } from '../SetAccount/setAccountHandler.js'
 import { createTransaction } from './createTransaction.js'
 
-// Mock dependencies
-vi.mock('@tevm/tx', () => ({
-	createImpersonatedTx: vi.fn().mockImplementation((config) => {
-		return {
-			...config,
-			hash: () => new Uint8Array([1, 2, 3, 4]),
-			value: config.value || 0n,
-			maxFeePerGas: config.maxFeePerGas || 0n,
+const contract = TestERC20.withAddress(createAddress(420420420420420).toString())
+
+describe(createTransaction.name, async () => {
+	let client: TevmNode
+	beforeEach(async () => {
+		client = createTevmNode()
+		await setAccountHandler(client)({
+			address: contract.address,
+			deployedBytecode: contract.deployedBytecode,
+		})
+	})
+
+	const runTransaction = async (_params?: CallParams) => {
+		const params: CallParams = {
+			data: encodeFunctionData(contract.read.balanceOf(createAddress(25).toString())),
+			to: contract.address,
+			gas: 16784800n,
+			createTransaction: 'on-success',
+			..._params,
 		}
-	}),
-}))
 
-/**
- * Note: Most tests are skipped because they require complex mocking of TevmNode.
- * The implementation is complex and needs a full integration test environment
- * to properly test all edge cases. The current tests focus on error handling
- * with insufficient balance, which is easier to isolate and test.
- *
- * TODO: For complete testing, consider:
- * 1. Creating a proper TevmNode factory that handles all the complex interactions
- * 2. Using a real VM instance with proper blockchain setup
- * 3. Testing with real transactions and accounts
- */
+		const vm = await client.getVm().then((vm) => vm.deepCopy())
+		const { data: evmInput, errors: callHandlerOptsErrors } = await callHandlerOpts(client, params)
 
-describe('createTransaction', () => {
-	// Setup mock TevmNode
-	let mockAccount: EthjsAccount
+		assert(!callHandlerOptsErrors, 'callHandlerOptsErrors should be undefined')
+		assert(evmInput, 'evmInput should be defined')
 
-	const mockPool = {
-		add: vi.fn().mockResolvedValue({}),
-		removeByHash: vi.fn(),
-		getBySenderAddress: vi.fn().mockResolvedValue([]),
+		const executeCallResult = await executeCall({ ...client, getVm: async () => vm }, evmInput, params)
+		assert(!('errors' in executeCallResult), 'executeCallResult.errors should be undefined')
+
+		return {
+			throwOnFail: false,
+			evmInput,
+			evmOutput: executeCallResult.runTxResult,
+			maxPriorityFeePerGas: params.maxPriorityFeePerGas,
+			maxFeePerGas: params.maxFeePerGas,
+		}
 	}
 
-	const mockVm = {
-		stateManager: {
-			getAccount: vi.fn(), // We'll set this in beforeEach
-			revert: vi.fn(),
-		},
-		blockchain: {
-			getCanonicalHeadBlock: vi.fn().mockResolvedValue({
-				header: {
-					calcNextBaseFee: () => 10n,
-					baseFeePerGas: 8n,
-				},
-			}),
-		},
-		common: {
-			ethjsCommon: {
-				param: vi.fn((category, name) => {
-					if (category === 'gasPrices') {
-						if (name === 'tx') return 21000n
-						if (name === 'txDataZero') return 4n
-						if (name === 'txDataNonZero') return 16n
-						if (name === 'txCreation') return 32000n
-					}
-					return 0n
-				}),
-				gteHardfork: vi.fn().mockReturnValue(true),
-			},
-		},
-	}
+	it('should create a transaction and add it to the tx pool', async () => {
+		const options = await runTransaction()
+		const txRes = await createTransaction(client)(options)
 
-	const mockClient = {
-		getVm: vi.fn().mockResolvedValue(mockVm),
-		getTxPool: vi.fn().mockResolvedValue(mockPool),
-		logger: {
-			debug: vi.fn(),
-			error: vi.fn(),
-		},
-		emit: vi.fn(),
-	} as unknown as TevmNode
+		assert(!('errors' in txRes), 'txRes.errors should be undefined')
+		expect(txRes.txHash).toBeDefined()
 
-	beforeEach(() => {
-		vi.clearAllMocks()
-		// Create a fresh account with 1 ETH for each test
-		mockAccount = new EthjsAccount(0n, 1000000000000000000n) // 1 ETH
-		mockVm.stateManager.getAccount.mockResolvedValue(mockAccount)
+		assert(options.evmInput.origin, 'options.evmInput.origin should be defined')
+		const txPool = await client.getTxPool()
+		const txs = await txPool.getBySenderAddress(options.evmInput.origin)
+		expect(txs.length).toBe(1)
+		expect(`0x${txs[0]?.hash}`).toBe(txRes.txHash)
 	})
 
-	it.skip('should create a basic transaction successfully', async () => {
-		// Ensure account has ETH
-		const addr = '0x0000000000000000000000000000000000000001'
-		mockVm.stateManager.getAccount = vi.fn().mockImplementation((address) => {
-			if (address.toString() === addr) {
-				return Promise.resolve(new EthjsAccount(0n, 1000000000000000000n)) // 1 ETH
+	it('should create multiple transactions from the same account and add them to the tx pool', async () => {
+		const options = await runTransaction()
+		const TX_COUNT = 10
+		let txResponses: { txHash: string }[] = []
+		for (let i = 0; i < TX_COUNT; i++) {
+			const txRes = await createTransaction(client)(options)
+			assert(!('errors' in txRes), 'txRes.errors should be undefined')
+			assert(txRes.txHash, 'txRes.txHash should be defined')
+			txResponses.push(txRes)
+		}
+
+		assert(options.evmInput.origin, 'options.evmInput.origin should be defined')
+		const txPool = await client.getTxPool()
+		const poolTransactions = await txPool.getBySenderAddress(options.evmInput.origin)
+		expect(poolTransactions.length).toBe(TX_COUNT)
+		txResponses.forEach((txResponse, i) => {
+			expect(`0x${poolTransactions[i]?.hash}`).toBe(txResponse.txHash)
+		})
+	})
+
+	it('should emit a newPendingTransaction event on the client', async () => {
+		const options = await runTransaction()
+
+		// Wait for the event to be emitted and get the transaction hash
+		const emittedTxHash = await new Promise<Hex>(async (resolve, reject) => {
+			const timeout = setTimeout(() => reject(new Error('Timeout: newPendingTransaction event was not emitted')), 1000)
+			const onNewPendingTransaction = (tx: {hash: () => Uint8Array}) => {
+				clearTimeout(timeout)
+				client.removeListener('newPendingTransaction', onNewPendingTransaction)
+				resolve(bytesToHex(tx.hash()))
 			}
-			return Promise.resolve(mockAccount)
+
+			client.on('newPendingTransaction', onNewPendingTransaction)
+			const txRes = await createTransaction(client)(options)
+			assert(!('errors' in txRes), 'txRes.errors should be undefined')
 		})
 
-		const createTx = createTransaction(mockClient)
-
-		const result = await createTx({
-			evmInput: {
-				to: createAddress('0x1234567890123456789012345678901234567890'),
-				value: 1000n,
-				data: new Uint8Array([1, 2, 3, 4]),
-				origin: createAddress(addr),
-			},
-			evmOutput: {
-				execResult: {
-					executionGasUsed: 21000n,
-					returnValue: new Uint8Array(),
-				},
-			},
-		})
-
-		// Check transaction was added to pool
-		expect(mockPool.add).toHaveBeenCalled()
-
-		// Check event was emitted
-		expect(mockClient.emit).toHaveBeenCalledWith('newPendingTransaction', expect.anything())
-
-		// Result should have transaction hash
-		expect(result).toHaveProperty('txHash')
-		const txResult = result as { txHash: string }
-		expect(txResult.txHash).toBe('0x01020304')
+		// Verify the transaction was added to the pool
+		assert(options.evmInput.origin, 'options.evmInput.origin should be defined')
+		const txPool = await client.getTxPool()
+		const txs = await txPool.getBySenderAddress(options.evmInput.origin)
+		expect(txs.length).toBe(1)
+		expect(`0x${txs[0]?.hash}`).toBe(emittedTxHash)
 	})
 
-	it('should handle insufficient balance', async () => {
-		// Mock empty account with no balance
-		mockVm.stateManager.getAccount = vi.fn().mockResolvedValueOnce(new EthjsAccount(0n, 0n))
-
-		const createTx = createTransaction(mockClient)
-
-		const resultPromise = createTx({
-			evmInput: {
-				to: createAddress('0x1234567890123456789012345678901234567890'),
-				value: 1000n,
-				skipBalance: false,
-				origin: createAddress('0x0000000000000000000000000000000000000002'),
-			},
-			evmOutput: {
-				execResult: {
-					executionGasUsed: 21000n,
-					returnValue: new Uint8Array(),
-				},
-			},
-			throwOnFail: true,
+	it('should work with no ether if skipBalance is true', async () => {
+		const from = `0x${'1'.repeat(40)}` as Address
+		await setAccountHandler(client)({
+			address: from,
+			balance: 0n,
+			nonce: 0n,
 		})
 
-		// Should throw with InsufficientBalance error
-		await expect(resultPromise).rejects.toMatchObject({
-			_tag: 'InsufficientBalance',
-		})
+		const options = await runTransaction({from, skipBalance: true})
+		const txRes = await createTransaction(client)(options)
+
+		assert(!('errors' in txRes), 'txRes.errors should be undefined')
+		expect(txRes.txHash).toBeDefined()
+
+		assert(options.evmInput.origin, 'options.evmInput.origin should be defined')
+		const txPool = await client.getTxPool()
+		const txs = await txPool.getBySenderAddress(options.evmInput.origin)
+		expect(txs.length).toBe(1)
+		expect(`0x${txs[0]?.hash}`).toBe(txRes.txHash)
 	})
 
-	it('should not throw error if throwOnFail is false', async () => {
-		// Mock empty account with no balance
-		mockVm.stateManager.getAccount = vi.fn().mockResolvedValueOnce(new EthjsAccount(0n, 0n))
-
-		const createTx = createTransaction(mockClient)
-
-		const result = await createTx({
-			evmInput: {
-				to: createAddress('0x1234567890123456789012345678901234567890'),
-				value: 1000n,
-				skipBalance: false,
-				origin: createAddress('0x0000000000000000000000000000000000000002'),
-			},
-			evmOutput: {
-				execResult: {
-					executionGasUsed: 21000n,
-					returnValue: new Uint8Array(),
-				},
-			},
-			throwOnFail: false,
+	it('should throw error if the sender has no balance and skipBalance is false', async () => {
+		const from = `0x${'1'.repeat(40)}` as Address
+		await setAccountHandler(client)({
+			address: from,
+			balance: 0n,
+			nonce: 0n,
 		})
 
-		// Should return error object without throwing
-		expect(result).toHaveProperty('errors')
-		type ErrorResult = { errors: Array<{ _tag: string }> }
-		const errorResult = result as ErrorResult
-		expect(errorResult.errors?.[0]?._tag).toBe('InsufficientBalance')
-	})
+		const options = await runTransaction({from})
+		const txRes = await createTransaction(client)(options)
 
-	it.skip('should calculate gas parameters when not provided', async () => {
-		// Ensure account has ETH
-		const addr = '0x0000000000000000000000000000000000000003'
-		mockVm.stateManager.getAccount = vi.fn().mockImplementation((address) => {
-			if (address.toString() === addr) {
-				return Promise.resolve(new EthjsAccount(0n, 1000000000000000000n)) // 1 ETH
-			}
-			return Promise.resolve(mockAccount)
-		})
-
-		const createTx = createTransaction(mockClient)
-
-		await createTx({
-			evmInput: {
-				to: createAddress('0x1234567890123456789012345678901234567890'),
-				value: 1000n,
-				origin: createAddress(addr),
-			},
-			evmOutput: {
-				execResult: {
-					executionGasUsed: 21000n,
-					returnValue: new Uint8Array(),
-				},
-			},
-		})
-
-		// Check that transaction was created with appropriate gas parameters
-		expect(mockPool.add).toHaveBeenCalledWith(
-			expect.objectContaining({
-				gasLimit: expect.any(BigInt),
-				maxFeePerGas: 10n, // From mockVm.blockchain.getCanonicalHeadBlock().header.calcNextBaseFee()
-				maxPriorityFeePerGas: 0n,
-			}),
-			expect.anything(),
-			expect.anything(),
-		)
-	})
-
-	it.skip('should handle contract creation transactions', async () => {
-		// Ensure account has ETH
-		const addr = '0x0000000000000000000000000000000000000004'
-		mockVm.stateManager.getAccount = vi.fn().mockImplementation((address) => {
-			if (address.toString() === addr) {
-				return Promise.resolve(new EthjsAccount(0n, 1000000000000000000n)) // 1 ETH
-			}
-			return Promise.resolve(mockAccount)
-		})
-
-		const createTx = createTransaction(mockClient)
-
-		await createTx({
-			evmInput: {
-				// No 'to' field for contract creation
-				data: new Uint8Array([1, 2, 3, 4]), // Contract bytecode
-				value: 0n,
-				origin: createAddress(addr),
-			},
-			evmOutput: {
-				execResult: {
-					executionGasUsed: 100000n,
-					returnValue: new Uint8Array(),
-				},
-			},
-		})
-
-		// Check contract creation fee was included
-		expect(mockVm.common.ethjsCommon.param).toHaveBeenCalledWith('gasPrices', 'txCreation')
-
-		// Check transaction was added to pool
-		expect(mockPool.add).toHaveBeenCalled()
-	})
-
-	it.skip('should handle errors when adding transaction to pool', async () => {
-		// Ensure account has ETH
-		const addr = '0x0000000000000000000000000000000000000005'
-		mockVm.stateManager.getAccount = vi.fn().mockImplementation((address) => {
-			if (address.toString() === addr) {
-				return Promise.resolve(new EthjsAccount(0n, 1000000000000000000n)) // 1 ETH
-			}
-			return Promise.resolve(mockAccount)
-		})
-
-		// Mock the pool.add to throw an error - this needs to be after the account is verified
-		// but before the tx is added to the pool
-		mockPool.add = vi.fn().mockImplementation(() => {
-			throw new Error('Pool error')
-		})
-
-		const createTx = createTransaction(mockClient)
-
-		const result = await createTx({
-			evmInput: {
-				to: createAddress('0x1234567890123456789012345678901234567890'),
-				value: 1000n,
-				origin: createAddress(addr),
-			},
-			evmOutput: {
-				execResult: {
-					executionGasUsed: 21000n,
-					returnValue: new Uint8Array(),
-				},
-			},
-			throwOnFail: false,
-		})
-
-		// Should return error object with UnexpectedError
-		expect(result).toHaveProperty('errors')
-		type ErrorResult = { errors: Array<{ _tag: string }> }
-		const errorResult = result as ErrorResult
-		expect(errorResult.errors?.[0]?._tag).toBe('UnexpectedError')
+		assert('errors' in txRes, 'txRes.errors should be defined')
+		expect(txRes.errors[0]?.message).toEqual('Insufficientbalance: Account 0x1111111111111111111111111111111111111111 attempted to create a transaction with zero eth. Consider adding eth to account or using a different from or origin address')
 	})
 })


### PR DESCRIPTION
## Issue Summary

When executing multiple transactions with `blockTag: 'pending'` with `callHandler`, transaction nonces were being calculated incorrectly, causing gaps in the nonce sequence. This occurred because:

1. The pending client mines transactions in its vm state, incrementing account nonces
2. Transactions remained in the shared transaction pool
3. Subsequent nonce calculation used `account.nonce + txPool.length`, leading to double-counting

For example:
- First tx: nonce 0 calculated correctly
- After mining in pending client: account nonce = 1, tx still in pool
- Second tx: nonce calculated as 1 (account) + 1 (pool) = 2, skipping nonce 1

## Fix

We've implemented a more robust nonce calculation algorithm that doesn't rely on simply adding the transaction count to the account nonce. Instead, it:

1. Retrieves the account nonce from the vm state
2. Determines the highest nonce among existing transactions in the pool
3. Uses the maximum of (account nonce, highest pool nonce + 1)

```ts
// Get the account nonce from state
const accountNonce = ((await vm.stateManager.getAccount(sender)) ?? { nonce: 0n }).nonce

// Get the highest transaction nonce from the pool for this sender
let highestPoolNonce = accountNonce - 1n
for (const tx of txs) {
  if (tx.tx.nonce > highestPoolNonce) highestPoolNonce = tx.tx.nonce
}

// Use the maximum of (account nonce, highest pool nonce + 1) 
const nonce = highestPoolNonce >= accountNonce ? highestPoolNonce + 1n : accountNonce
```

This approach ensures:
- No nonce gaps or duplicates occur
- Works correctly in both normal and pending states
- Handles concurrent transactions properly

## Testing

- Adds comprehensive testing in `createTransaction.spec.ts`, replacing the AI tests that used mocks.
- The fix is validated with the `mineHandler.spec.ts` test that creates multiple transactions with `blockTag: 'pending'`, confirming that all transactions receive sequential nonces and are correctly included in a single block when mining. This fix is in [this subsequent PR](https://github.com/evmts/tevm-monorepo/pull/1637).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected transaction nonce calculation to ensure accurate and sequential nonce assignment, preventing nonce miscalculations during transaction creation.
- **Tests**
	- Refactored the test suite to use a real virtual machine and transaction pool, improving test coverage and reliability for transaction creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->