### PR TITLE
Fix broken links

### DIFF
--- a/bundler-packages/rollup/README.md
+++ b/bundler-packages/rollup/README.md
@@ -2,7 +2,7 @@
 
 A rollup plugin for importing solidity files.
 
-Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/plugins) is underway
+Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/api/plugins#plugins) is underway
 
 ## Installation
 

--- a/bundler-packages/rollup/docs/README.md
+++ b/bundler-packages/rollup/docs/README.md
@@ -6,7 +6,7 @@
 
 A rollup plugin for importing solidity files.
 
-Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/plugins) is underway
+Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/api/plugins#plugins) is underway
 
 ## Installation
 

--- a/bundler-packages/vite/README.md
+++ b/bundler-packages/vite/README.md
@@ -2,7 +2,7 @@
 
 A rollup plugin for importing solidity files.
 
-Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/plugins) is underway
+Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/api/plugins#plugins) is underway
 
 ## Installation
 

--- a/bundler-packages/vite/docs/README.md
+++ b/bundler-packages/vite/docs/README.md
@@ -6,7 +6,7 @@
 
 A rollup plugin for importing solidity files.
 
-Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/plugins) is underway
+Currently @tevm/plugin only works in forge projects but work to make it support [all wagmi plugins](https://wagmi.sh/cli/api/plugins#plugins) is underway
 
 ## Installation
 


### PR DESCRIPTION
Updated the outdated Wagmi plugin link from https://wagmi.sh/cli/plugins to the correct section https://wagmi.sh/cli/api/plugins#plugins for better navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links to reference the latest wagmi plugins section for improved accuracy and clarity. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->