### PR TITLE
Upgrade Node setup action to latest version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
       with:
         version: 0.14.0
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version-file: ".nvmrc"
         registry-url: https://registry.npmjs.org


### PR DESCRIPTION
v4 is the latest stable version of setup-node from GitHub Actions team. It includes performance improvements, better caching, and support for updated Node versions. Keeping CI tools up to date ensures smoother workflows and compatibility.

🔗 Official release reference:
[actions/setup-node v4.0.0](https://github.com/actions/setup-node/releases/tag/v4.0.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to use the latest version of the Node.js setup action for improved reliability and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->