### PR TITLE
feat: Add middleware and tests to server

### DIFF
--- a/.github/workflows/nx.yml
+++ b/.github/workflows/nx.yml
@@ -85,6 +85,10 @@ jobs:
           zig build &&
           zig build wasm && echo "WASM size: $(ls -lh ./dist/zigevm.wasm | awk '{print $5}')"
 
+      - name: Run Zig tests
+        run: |
+          zig build test-server && echo "✅ Server tests passed"
+
       - name: Run verification
         uses: JamesHenry/parallel-bash-commands@v1.0
         with:

--- a/build.zig
+++ b/build.zig
@@ -21,6 +21,12 @@ pub fn build(b: *std.Build) void {
         .os_tag = .freestanding,
     });
 
+    // Get httpz dependency
+    const httpz_dep = b.dependency("httpz", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
     // First create individual modules for each component
     const address_mod = b.createModule(.{
         .root_source_file = b.path("src/Address/address.zig"),
@@ -33,7 +39,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     const utils_mod = b.createModule(.{
         .root_source_file = b.path("src/Utils/utils.zig"),
         .target = target,
@@ -45,7 +51,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     // Add imports to the block_mod
     block_mod.addImport("Address", address_mod);
 
@@ -60,13 +66,13 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     const rlp_mod = b.createModule(.{
         .root_source_file = b.path("src/Rlp/rlp.zig"),
         .target = target,
         .optimize = optimize,
     });
-    
+
     // Add imports to the rlp_mod
     rlp_mod.addImport("Utils", utils_mod);
 
@@ -75,13 +81,13 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     const evm_mod = b.createModule(.{
         .root_source_file = b.path("src/Evm/evm.zig"),
         .target = target,
         .optimize = optimize,
     });
-    
+
     // Add imports to the evm_mod
     evm_mod.addImport("Address", address_mod);
     evm_mod.addImport("Block", block_mod);
@@ -92,7 +98,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     // Add package paths for absolute imports for all modules
     zigevm_mod.addImport("Address", address_mod);
     zigevm_mod.addImport("Abi", abi_mod);
@@ -118,7 +124,7 @@ pub fn build(b: *std.Build) void {
         // For WASM we typically want small size
         .optimize = .ReleaseSmall,
     });
-    
+
     // Add package paths for absolute imports to WASM module
     wasm_mod.addImport("Address", address_mod);
     wasm_mod.addImport("Abi", abi_mod);
@@ -146,6 +152,17 @@ pub fn build(b: *std.Build) void {
         .root_module = exe_mod,
     });
 
+    // Create a separate executable for the server
+    const server_exe = b.addExecutable(.{
+        .name = "zigevm-server",
+        .root_source_file = b.path("src/Server/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add httpz dependency to the server
+    server_exe.root_module.addImport("httpz", httpz_dep.module("httpz"));
+
     // Create the WebAssembly artifact
     const wasm = b.addExecutable(.{
         .name = "zigevm",
@@ -162,6 +179,7 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
     b.installArtifact(exe);
     b.installArtifact(wasm);
+    b.installArtifact(server_exe);
 
     // This *creates* a Run step in the build graph
     const run_cmd = b.addRunArtifact(exe);
@@ -180,11 +198,24 @@ pub fn build(b: *std.Build) void {
     const build_wasm_step = b.step("wasm", "Build the WebAssembly artifact");
     build_wasm_step.dependOn(&install_wasm.step);
 
+    // Define a run server step
+    const run_server_cmd = b.addRunArtifact(server_exe);
+    run_server_cmd.step.dependOn(b.getInstallStep());
+
+    // Pass arguments to the server application
+    if (b.args) |args| {
+        run_server_cmd.addArgs(args);
+    }
+
+    // Define run server step
+    const run_server_step = b.step("run-server", "Run the JSON-RPC server");
+    run_server_step.dependOn(&run_server_cmd.step);
+
     // Creates a step for unit testing.
     const lib_unit_tests = b.addTest(.{
         .root_module = zigevm_mod,
     });
-    
+
     // Add all modules to standalone tests
     lib_unit_tests.root_module.addImport("Address", address_mod);
     lib_unit_tests.root_module.addImport("Abi", abi_mod);
@@ -203,7 +234,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     // Add all modules to frame_test
     frame_test.root_module.addImport("Address", address_mod);
     frame_test.root_module.addImport("Abi", abi_mod);
@@ -214,21 +245,21 @@ pub fn build(b: *std.Build) void {
     frame_test.root_module.addImport("Rlp", rlp_mod);
     frame_test.root_module.addImport("Token", token_mod);
     frame_test.root_module.addImport("Utils", utils_mod);
-    
+
     const run_frame_test = b.addRunArtifact(frame_test);
-    
+
     // Add a separate step for testing just the frame
     const frame_test_step = b.step("test-frame", "Run EVM frame tests");
     frame_test_step.dependOn(&run_frame_test.step);
-    
+
     // Add a test for evm.zig
     const evm_test = b.addTest(.{
         .name = "evm-test",
         .root_source_file = b.path("src/Evm/evm.zig"),
-        .target = target, 
+        .target = target,
         .optimize = optimize,
     });
-    
+
     // Add all modules to evm_test
     evm_test.root_module.addImport("Address", address_mod);
     evm_test.root_module.addImport("Abi", abi_mod);
@@ -239,12 +270,96 @@ pub fn build(b: *std.Build) void {
     evm_test.root_module.addImport("Rlp", rlp_mod);
     evm_test.root_module.addImport("Token", token_mod);
     evm_test.root_module.addImport("Utils", utils_mod);
-    
+
     const run_evm_test = b.addRunArtifact(evm_test);
-    
+
     // Add a separate step for testing the EVM
     const evm_test_step = b.step("test-evm", "Run EVM tests");
     evm_test_step.dependOn(&run_evm_test.step);
+
+    // Add a test for server.zig
+    const server_test = b.addTest(.{
+        .name = "server-test",
+        .root_source_file = b.path("src/Server/server.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add the httpz dependency to the server test
+    server_test.root_module.addImport("httpz", httpz_dep.module("httpz"));
+
+    const run_server_test = b.addRunArtifact(server_test);
+
+    // Add a separate step for testing the server
+    const server_test_step = b.step("test-server", "Run Server tests");
+    server_test_step.dependOn(&run_server_test.step);
+
+    // Add a test for rlp_test.zig
+    const rlp_specific_test = b.addTest(.{
+        .name = "rlp-test",
+        .root_source_file = b.path("src/Rlp/rlp_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add dependencies to rlp_test
+    rlp_specific_test.root_module.addImport("Rlp", rlp_mod);
+    rlp_specific_test.root_module.addImport("Utils", utils_mod);
+
+    const run_rlp_test = b.addRunArtifact(rlp_specific_test);
+
+    // Add a separate step for testing RLP
+    const rlp_test_step = b.step("test-rlp", "Run RLP tests");
+    rlp_test_step.dependOn(&run_rlp_test.step);
+
+    // Add a test for abi_test.zig
+    const abi_specific_test = b.addTest(.{
+        .name = "abi-test",
+        .root_source_file = b.path("src/Abi/abi_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add dependencies to abi_test
+    abi_specific_test.root_module.addImport("Abi", abi_mod);
+    abi_specific_test.root_module.addImport("Utils", utils_mod);
+
+    const run_abi_test = b.addRunArtifact(abi_specific_test);
+
+    // Add a separate step for testing ABI
+    const abi_test_step = b.step("test-abi", "Run ABI tests");
+    abi_test_step.dependOn(&run_abi_test.step);
+
+    // Add a test for Compiler tests
+    const compiler_test = b.addTest(.{
+        .name = "compiler-test",
+        .root_source_file = b.path("src/Compiler/resolutions.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Add dependencies to compiler_test
+    compiler_test.root_module.addImport("Compiler", compiler_mod);
+
+    const run_compiler_test = b.addRunArtifact(compiler_test);
+
+    // Add a separate step for testing Compiler
+    const compiler_test_step = b.step("test-compiler", "Run Compiler tests");
+    compiler_test_step.dependOn(&run_compiler_test.step);
+
+    // Add a test for Interpreter tests
+    const interpreter_test = b.addTest(.{
+        .name = "interpreter-test",
+        .root_source_file = b.path("src/Interpreter/JumpTable.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_interpreter_test = b.addRunArtifact(interpreter_test);
+
+    // Add a separate step for testing Interpreter
+    const interpreter_test_step = b.step("test-interpreter", "Run Interpreter tests");
+    interpreter_test_step.dependOn(&run_interpreter_test.step);
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
@@ -254,8 +369,19 @@ pub fn build(b: *std.Build) void {
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
-    // Define test step
+    // Define test step for all tests
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
+    test_step.dependOn(&run_frame_test.step);
+    test_step.dependOn(&run_evm_test.step);
+    test_step.dependOn(&run_server_test.step);
+    test_step.dependOn(&run_rlp_test.step);
+    test_step.dependOn(&run_abi_test.step);
+    test_step.dependOn(&run_compiler_test.step);
+    test_step.dependOn(&run_interpreter_test.step);
+
+    // Define a single test step that runs all tests
+    const test_all_step = b.step("test-all", "Run all unit tests");
+    test_all_step.dependOn(test_step);
 }

--- a/src/Server/main.zig
+++ b/src/Server/main.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const server_mod = @import("server.zig");
+const httpz = @import("httpz");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    // Create the JSON-RPC server on port 8546 with logging middleware
+    var server = try server_mod.createServer(allocator, 8546);
+    defer {
+        // Ensure server is always stopped before deinitialization
+        server.stop();
+        server.deinit();
+        std.debug.print("Server shutdown complete\n", .{});
+    }
+
+    std.debug.print("JSON-RPC server listening on port 8546 with request logging enabled\n", .{});
+
+    // This is blocking - the server will run until manually stopped or an error occurs
+    server.listen() catch |err| {
+        std.debug.print("Server error: {s}\n", .{@errorName(err)});
+        return err;
+    };
+}

--- a/src/Server/middleware/Logger.zig
+++ b/src/Server/middleware/Logger.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const httpz = @import("httpz");
+
+const Logger = @This();
+
+/// Initialize the logger middleware
+pub fn init(_: Config) !Logger {
+    return .{};
+}
+
+/// Execute the middleware
+pub fn execute(_: *const Logger, req: *httpz.Request, res: *httpz.Response, executor: anytype) !void {
+    // Record the start time
+    const start = std.time.microTimestamp();
+
+    // Process the request first
+    try executor.next();
+
+    // Log after the request is processed
+    const elapsed = std.time.microTimestamp() - start;
+    std.debug.print("Request: {s} {s} -> Status: {d} (took {d}us)\n", .{ @tagName(req.method), req.url.path, res.status, elapsed });
+}
+
+/// Configuration options for the Logger
+pub const Config = struct {};

--- a/src/Server/server.zig
+++ b/src/Server/server.zig
@@ -1,26 +1,31 @@
 const std = @import("std");
 const httpz = @import("httpz");
+const Logger = @import("middleware/Logger.zig");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = gpa.allocator();
+const JsonRpcRequest = struct { id: ?u32, method: []const u8, jsonrpc: []const u8, params: ?std.json.Value };
 
-    var server = try httpz.Server(void).init(allocator, .{ .port = 8545 }, {});
-    defer {
-        server.stop();
-        server.deinit();
-    }
+pub fn createServer(allocator: std.mem.Allocator, port: u16) !httpz.Server(void) {
+    // Initialize server with the specified port
+    var server = try httpz.Server(void).init(allocator, .{
+        .port = port,
+    }, {});
 
-    var router = try server.router(.{});
+    // Setup logging middleware
+    const logger = try server.middleware(Logger, .{});
+
+    // Create router with middleware
+    var router = try server.router(.{
+        .middlewares = &.{logger},
+    });
+
+    // Set up the JSON-RPC endpoint
     router.post("/", requestHandler, .{});
 
-    try server.listen();
+    return server;
 }
 
-const JsonRpcRequest = struct { id: ?u32, method: []const u8, jsonrpc: []const u8, params: ?.{} };
-
 fn requestHandler(req: *httpz.Request, res: *httpz.Response) !void {
-    const json = try req.json(JsonRpcRequest);
+    const json = (try req.json(JsonRpcRequest)).?;
     res.status = 200;
     try res.json(.{
         .id = json.id,
@@ -28,4 +33,74 @@ fn requestHandler(req: *httpz.Request, res: *httpz.Response) !void {
         .jsonrpc = "2.0",
         .result = .{},
     }, .{});
+}
+
+// Test that the server correctly handles a JSON-RPC request
+test "server handles JSON-RPC requests" {
+    std.debug.print("\n--- Starting server test ---\n", .{});
+
+    const allocator = std.testing.allocator;
+
+    // Create a server with a test port
+    const test_port = 18545;
+    std.debug.print("Creating server on port {d}\n", .{test_port});
+
+    var server = try createServer(allocator, test_port);
+    defer server.deinit();
+
+    // Start server in a separate thread
+    std.debug.print("Starting server thread\n", .{});
+
+    const server_ptr = &server;
+    const thread = try std.Thread.spawn(.{}, struct {
+        fn run(svr_ptr: *httpz.Server(void)) !void {
+            std.debug.print("Server thread started\n", .{});
+            try svr_ptr.listen();
+        }
+    }.run, .{server_ptr});
+
+    // Ensure server is stopped before thread is joined
+    defer {
+        std.debug.print("Stopping server\n", .{});
+        server.stop();
+        thread.join();
+    }
+
+    // Give server time to start
+    std.debug.print("Waiting for server to start\n", .{});
+    std.time.sleep(std.time.ns_per_ms * 100);
+
+    // Connect to the server
+    std.debug.print("Connecting to server\n", .{});
+    const address = try std.net.Address.parseIp4("127.0.0.1", test_port);
+    var client = try std.net.tcpConnectToAddress(address);
+    defer client.close();
+
+    // Create JSON-RPC request
+    std.debug.print("Creating request\n", .{});
+    const body = "{\"id\":1,\"method\":\"eth_blockNumber\",\"jsonrpc\":\"2.0\",\"params\":null}";
+
+    // Format HTTP request
+    const request = try std.fmt.allocPrint(allocator, "POST / HTTP/1.1\r\nHost: localhost:{d}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\n\r\n{s}", .{ test_port, body.len, body });
+    defer allocator.free(request);
+
+    std.debug.print("Sending request: {s}\n", .{request});
+    _ = try client.writeAll(request);
+
+    // Read response
+    std.debug.print("Reading response\n", .{});
+    var response_buffer: [1024]u8 = undefined;
+    const bytes_read = try client.read(&response_buffer);
+    const response = response_buffer[0..bytes_read];
+
+    std.debug.print("Received response: {s}\n", .{response});
+
+    // Verify response contains expected data
+    try std.testing.expect(std.mem.indexOf(u8, response, "HTTP/1.1 200") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "Content-Type: application/json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"id\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"jsonrpc\":\"2.0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"method\":\"eth_blockNumber\"") != null);
+
+    std.debug.print("--- Test completed successfully ---\n", .{});
 }


### PR DESCRIPTION
## Description

Added a JSON-RPC server implementation to the ZigEVM project. This includes:

- Created a server module with HTTP request handling capabilities
- Implemented logging middleware for request tracking
- Added server tests to verify JSON-RPC functionality
- Set up build configuration for the server executable
- Added dedicated test steps for individual components (RLP, ABI, Compiler, etc.)
- Integrated httpz dependency for HTTP server functionality

The server listens on port 8546 and currently responds to JSON-RPC requests with a basic structure. This lays the groundwork for implementing actual EVM JSON-RPC methods.

## Testing

- Added comprehensive server tests that verify HTTP request/response handling
- Updated CI workflow to run server tests
- Created individual test steps for each component to allow targeted testing
- All tests are included in the main test suite for complete coverage

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: