### PR TITLE
fix: Broken logger

### DIFF
--- a/src/Server/middleware/Logger.zig
+++ b/src/Server/middleware/Logger.zig
@@ -3,7 +3,7 @@ const httpz = @import("httpz");
 
 const Logger = @This();
 
-pub fn init() !Logger {
+pub fn init(_: Config) !Logger {
     return .{};
 }
 
@@ -13,5 +13,7 @@ pub fn execute(_: *const Logger, req: *httpz.Request, res: *httpz.Response, exec
         const elapsed = std.time.microTimestamp() - start;
         std.debug.print("Request: {s} {s} -> Status: {d} (took {d}us)\n", .{ @tagName(req.method), req.url.path, res.status, elapsed });
     }
-    executor.next();
+    try executor.next();
 }
+
+pub const Config = struct {};


### PR DESCRIPTION
## Description

Updated the `Logger` middleware in the server to:
1. Accept a `Config` parameter in the `init` function
2. Add error handling to the `executor.next()` call
3. Define a new empty `Config` struct for configuration options

## Testing

Tested that the server middleware chain properly propagates errors and that the Logger middleware initializes correctly with the new Config parameter.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: