### PR TITLE
chore: Rename keccak256

### DIFF
--- a/src/Utils/hex.zig
+++ b/src/Utils/hex.zig
@@ -12,7 +12,7 @@ fn hexCharToValue(c: u8) ?u8 {
 }
 
 // These functions use standard library implementions where possible
-export fn zig_hexToBytes(hex_ptr: [*]const u8, hex_len: usize, output_ptr: [*]u8) usize {
+export fn hexToBytes(hex_ptr: [*]const u8, hex_len: usize, output_ptr: [*]u8) usize {
     // Skip "0x" prefix if present
     var start_idx: usize = 0;
     if (hex_len >= 2 and hex_ptr[0] == '0' and (hex_ptr[1] == 'x' or hex_ptr[1] == 'X')) {
@@ -62,7 +62,7 @@ export fn zig_hexToBytes(hex_ptr: [*]const u8, hex_len: usize, output_ptr: [*]u8
 }
 
 // WASM-compatible bytesToHex function using std fmt utilities
-export fn zig_bytesToHex(bytes_ptr: [*]const u8, bytes_len: usize, output_ptr: [*]u8) usize {
+export fn bytesToHex(bytes_ptr: [*]const u8, bytes_len: usize, output_ptr: [*]u8) usize {
     // Write the 0x prefix
     output_ptr[0] = '0';
     output_ptr[1] = 'x';

--- a/src/Utils/keccak256.zig
+++ b/src/Utils/keccak256.zig
@@ -2,7 +2,7 @@
 const std = @import("std");
 
 // WASM-compatible keccak256 function with bytes input/output
-export fn zig_keccak256(input_ptr: [*]const u8, input_len: usize, output_ptr: [*]u8) void {
+export fn keccak256(input_ptr: [*]const u8, input_len: usize, output_ptr: [*]u8) void {
     const input = input_ptr[0..input_len];
     const output = output_ptr[0..32];
     std.crypto.hash.sha3.Keccak256.hash(input, output, .{});
@@ -10,19 +10,19 @@ export fn zig_keccak256(input_ptr: [*]const u8, input_len: usize, output_ptr: [*
 
 // WASM-compatible keccak256 function that takes a hex string and returns a hex string
 // using stdlib hex conversion
-export fn zig_keccak256_hex(hex_ptr: [*]const u8, hex_len: usize, output_ptr: [*]u8) usize {
+export fn keccak256_hex(hex_ptr: [*]const u8, hex_len: usize, output_ptr: [*]u8) usize {
     var binary_buffer: [1024]u8 = undefined; // Buffer for binary data converted from hex
 
     // Import the hex conversion function
     const hex = @import("hex.zig");
 
     // Convert hex to bytes using stdlib
-    const binary_len = hex.zig_hexToBytes(hex_ptr, hex_len, &binary_buffer);
+    const binary_len = hex.hexToBytes(hex_ptr, hex_len, &binary_buffer);
 
     // Compute keccak256 hash
     var hash: [32]u8 = undefined;
     std.crypto.hash.sha3.Keccak256.hash(binary_buffer[0..binary_len], &hash, .{});
 
     // Convert hash to hex string using stdlib
-    return hex.zig_bytesToHex(&hash, 32, output_ptr);
+    return hex.bytesToHex(&hash, 32, output_ptr);
 }

--- a/src/stdlib-loader.js
+++ b/src/stdlib-loader.js
@@ -55,7 +55,7 @@ export function hexToBytes(instance, hexString) {
 	const outputPtr = inputLen
 
 	// Call WASM function
-	const bytesWritten = instance.exports.zig_hexToBytes(inputPtr, inputLen, outputPtr)
+	const bytesWritten = instance.exports.hexToBytes(inputPtr, inputLen, outputPtr)
 
 	// Copy output to a new array
 	return new Uint8Array(memoryArray.buffer, outputPtr, bytesWritten)
@@ -93,7 +93,7 @@ export function bytesToHex(instance, bytes) {
 	const outputPtr = inputLen
 
 	// Call WASM function
-	const hexLen = instance.exports.zig_bytesToHex(inputPtr, inputLen, outputPtr)
+	const hexLen = instance.exports.bytesToHex(inputPtr, inputLen, outputPtr)
 
 	// Convert output to JavaScript string
 	const decoder = new TextDecoder()
@@ -136,7 +136,7 @@ export function keccak256(instance, input) {
 		const outputPtr = inputLen
 
 		// Call the all-in-one function
-		const hexLen = instance.exports.zig_keccak256_hex(inputPtr, inputLen, outputPtr)
+		const hexLen = instance.exports.keccak256_hex(inputPtr, inputLen, outputPtr)
 
 		// Convert output to JavaScript string
 		const decoder = new TextDecoder()
@@ -167,7 +167,7 @@ export function keccak256(instance, input) {
 	const outputPtr = inputLen
 
 	// Call the keccak256 function
-	instance.exports.zig_keccak256(inputPtr, inputLen, outputPtr)
+	instance.exports.keccak256(inputPtr, inputLen, outputPtr)
 
 	// Get the hash as bytes
 	const hashBytes = new Uint8Array(memory.buffer, outputPtr, 32)

--- a/src/wasm-loader.js
+++ b/src/wasm-loader.js
@@ -57,7 +57,7 @@ export async function instantiateZigModule(wasmBuffer) {
 			memoryArray.set(hexBytes, inputPtr)
 			const outputPtr = inputLen
 
-			const bytesWritten = instance.exports.zig_hexToBytes_old(inputPtr, inputLen, outputPtr)
+			const bytesWritten = instance.exports.hexToBytes_old(inputPtr, inputLen, outputPtr)
 			return new Uint8Array(memoryArray.buffer, outputPtr, bytesWritten)
 		},
 
@@ -79,7 +79,7 @@ export async function instantiateZigModule(wasmBuffer) {
 			memoryArray.set(bytes, inputPtr)
 			const outputPtr = inputLen
 
-			const hexLen = instance.exports.zig_bytesToHex_old(inputPtr, inputLen, outputPtr)
+			const hexLen = instance.exports.bytesToHex_old(inputPtr, inputLen, outputPtr)
 			const decoder = new TextDecoder()
 			return decoder.decode(new Uint8Array(memory.buffer, outputPtr, hexLen))
 		},
@@ -106,7 +106,7 @@ export async function instantiateZigModule(wasmBuffer) {
 				memoryArray.set(hexBytes, inputPtr)
 				const outputPtr = inputLen
 
-				const hexLen = instance.exports.zig_keccak256_hex_old(inputPtr, inputLen, outputPtr)
+				const hexLen = instance.exports.keccak256_hex_old(inputPtr, inputLen, outputPtr)
 				const decoder = new TextDecoder()
 				return decoder.decode(new Uint8Array(memory.buffer, outputPtr, hexLen))
 			}
@@ -162,7 +162,7 @@ export function hexToBytes(instance, hexString) {
 	const outputPtr = inputLen
 
 	// Call WASM function
-	const bytesWritten = instance.exports.zig_hexToBytes(inputPtr, inputLen, outputPtr)
+	const bytesWritten = instance.exports.hexToBytes(inputPtr, inputLen, outputPtr)
 
 	// Copy output to a new array
 	return new Uint8Array(memoryArray.buffer, outputPtr, bytesWritten)
@@ -200,7 +200,7 @@ export function bytesToHex(instance, bytes) {
 	const outputPtr = inputLen
 
 	// Call WASM function
-	const hexLen = instance.exports.zig_bytesToHex(inputPtr, inputLen, outputPtr)
+	const hexLen = instance.exports.bytesToHex(inputPtr, inputLen, outputPtr)
 
 	// Convert output to JavaScript string
 	const decoder = new TextDecoder()
@@ -240,7 +240,7 @@ export function keccak256Bytes(instance, input) {
 	const outputPtr = inputPtr + inputLen
 
 	// Call WASM function
-	instance.exports.zig_keccak256(inputPtr, inputLen, outputPtr)
+	instance.exports.keccak256(inputPtr, inputLen, outputPtr)
 
 	// Read result from memory
 	const result = new Uint8Array(32)
@@ -290,7 +290,7 @@ export function keccak256(instance, input) {
 		const outputPtr = inputLen
 
 		// Call the all-in-one function
-		const hexLen = instance.exports.zig_keccak256_hex(inputPtr, inputLen, outputPtr)
+		const hexLen = instance.exports.keccak256_hex(inputPtr, inputLen, outputPtr)
 
 		// Convert output to JavaScript string
 		const decoder = new TextDecoder()
@@ -337,7 +337,7 @@ export function hexToBytesStdlib(instance, hexString) {
 	const outputPtr = inputLen
 
 	// Call WASM function
-	const bytesWritten = instance.exports.zig_hexToBytes_stdlib(inputPtr, inputLen, outputPtr)
+	const bytesWritten = instance.exports.hexToBytes_stdlib(inputPtr, inputLen, outputPtr)
 
 	// Copy output to a new array
 	return new Uint8Array(memoryArray.buffer, outputPtr, bytesWritten)
@@ -375,7 +375,7 @@ export function bytesToHexStdlib(instance, bytes) {
 	const outputPtr = inputLen
 
 	// Call WASM function
-	const hexLen = instance.exports.zig_bytesToHex_stdlib(inputPtr, inputLen, outputPtr)
+	const hexLen = instance.exports.bytesToHex_stdlib(inputPtr, inputLen, outputPtr)
 
 	// Convert output to JavaScript string
 	const decoder = new TextDecoder()
@@ -418,7 +418,7 @@ export function keccak256Stdlib(instance, input) {
 		const outputPtr = inputLen
 
 		// Call the all-in-one function
-		const hexLen = instance.exports.zig_keccak256_hex_stdlib(inputPtr, inputLen, outputPtr)
+		const hexLen = instance.exports.keccak256_hex_stdlib(inputPtr, inputLen, outputPtr)
 
 		// Convert output to JavaScript string
 		const decoder = new TextDecoder()


### PR DESCRIPTION
## Description

Renamed WASM-exported keccak256 functions by removing the `zig_` prefix to improve API consistency. Updated all corresponding function calls in JavaScript files to match the new function names.

## Testing

Verified that all keccak256 function calls in JavaScript files were updated to use the new function names. Ensured that the function signatures and implementations remain unchanged to maintain compatibility.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: