### PR TITLE
chore: Connect zig to tauri app

### DIFF
--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -13,21 +13,35 @@ fn connect_zig() {
     let zig_out_path = repo_root_path.join("zig-out/lib");
     let out_dir_env = env::var("OUT_DIR").expect("OUT_DIR not set");
     let zig_build_status = Command::new("zig")
-        .args(&["build", "-O", "ReleaseSafe", "--target", &target])
+        .args(&["build", "-Doptimize=ReleaseSafe"])
         .current_dir(repo_root_path)
         .status()
         .expect("Failed to run zig compiler");
     assert!(zig_build_status.success(), "Zig compilation failed");
 
     let lib_name = if target.contains("windows") {
-        "libzigevm.lib"
+        "zigevm.lib"
     } else {
         "libzigevm.a"
     };
+    let link_name = if lib_name.starts_with("lib") {
+        &lib_name[3..lib_name.len() - 2]
+    } else {
+        &lib_name[..lib_name.len() - 4]
+    };
 
     let lib_path = zig_out_path.join(lib_name);
-    copy(lib_path, format!("{}/{}", out_dir_env, lib_name)).expect("Failed to move binary");
+    copy(&lib_path, format!("{}/{}", out_dir_env, lib_name)).expect("Failed to move binary");
 
     println!("cargo:rustc-link-search={}", out_dir_env);
-    println!("cargo:rustc-link-lib=static=libzigevm");
+    println!("cargo:rustc-link-lib=static={}", link_name);
+
+    println!(
+        "cargo:rerun-if-changed={}",
+        repo_root_path.join("src").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        repo_root_path.join("build.zig").display()
+    );
 }

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -1,3 +1,33 @@
+use std::{env, fs::copy, path::Path, process::Command};
+
 fn main() {
+    connect_zig();
     tauri_build::build()
+}
+
+fn connect_zig() {
+    let target = env::var("TARGET").expect("Target not set");
+    let manifest_env = env::var("CARGO_MANIFEST_DIR").expect("Manifest is not set");
+    let cargo_path = Path::new(&manifest_env);
+    let repo_root_path = cargo_path.parent().unwrap().parent().unwrap();
+    let zig_out_path = repo_root_path.join("zig-out/lib");
+    let out_dir_env = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let zig_build_status = Command::new("zig")
+        .args(&["build", "-O", "ReleaseSafe", "--target", &target])
+        .current_dir(repo_root_path)
+        .status()
+        .expect("Failed to run zig compiler");
+    assert!(zig_build_status.success(), "Zig compilation failed");
+
+    let lib_name = if target.contains("windows") {
+        "libzigevm.lib"
+    } else {
+        "libzigevm.a"
+    };
+
+    let lib_path = zig_out_path.join(lib_name);
+    copy(lib_path, format!("{}/{}", out_dir_env, lib_name)).expect("Failed to move binary");
+
+    println!("cargo:rustc-link-search={}", out_dir_env);
+    println!("cargo:rustc-link-lib=static=libzigevm");
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,7 +1,25 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+extern "C" {
+    // src/utils/keccak256.zig
+    fn keccak256(input: *const u8, input_len: usize, output: *mut u8);
+}
+
 #[tauri::command]
 fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+    let mut output = [0u8; 32];
+
+    unsafe {
+        keccak256(name.as_ptr(), name.len(), output.as_mut_ptr());
+    }
+
+    let hash = output
+        .iter()
+        .map(|byte| format!("{:02x}", byte))
+        .collect::<String>();
+
+    format!(
+        "Hello, {}! You've been greeted from Zig via rust! Your Kekkak256 of your name is {}",
+        name, hash
+    )
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/build.zig
+++ b/build.zig
@@ -93,22 +93,22 @@ pub fn build(b: *std.Build) void {
     evm_mod.addImport("Block", block_mod);
 
     // Create a ZigEVM module - our core EVM implementation
-    const zigevm_mod = b.createModule(.{
+    const target_architecture_mod = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     // Add package paths for absolute imports for all modules
-    zigevm_mod.addImport("Address", address_mod);
-    zigevm_mod.addImport("Abi", abi_mod);
-    zigevm_mod.addImport("Block", block_mod);
-    zigevm_mod.addImport("Bytecode", bytecode_mod);
-    zigevm_mod.addImport("Compiler", compiler_mod);
-    zigevm_mod.addImport("Evm", evm_mod);
-    zigevm_mod.addImport("Rlp", rlp_mod);
-    zigevm_mod.addImport("Token", token_mod);
-    zigevm_mod.addImport("Utils", utils_mod);
+    target_architecture_mod.addImport("Address", address_mod);
+    target_architecture_mod.addImport("Abi", abi_mod);
+    target_architecture_mod.addImport("Block", block_mod);
+    target_architecture_mod.addImport("Bytecode", bytecode_mod);
+    target_architecture_mod.addImport("Compiler", compiler_mod);
+    target_architecture_mod.addImport("Evm", evm_mod);
+    target_architecture_mod.addImport("Rlp", rlp_mod);
+    target_architecture_mod.addImport("Token", token_mod);
+    target_architecture_mod.addImport("Utils", utils_mod);
 
     // Create the native executable module
     const exe_mod = b.createModule(.{
@@ -121,7 +121,6 @@ pub fn build(b: *std.Build) void {
     const wasm_mod = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = wasm_target,
-        // For WASM we typically want small size
         .optimize = .ReleaseSmall,
     });
 
@@ -137,13 +136,13 @@ pub fn build(b: *std.Build) void {
     wasm_mod.addImport("Utils", utils_mod);
 
     // Modules can depend on one another using the `std.Build.Module.addImport` function.
-    exe_mod.addImport("zigevm", zigevm_mod);
+    exe_mod.addImport("zigevm", target_architecture_mod);
 
     // Create the ZigEVM static library artifact
     const lib = b.addLibrary(.{
         .linkage = .static,
         .name = "zigevm",
-        .root_module = zigevm_mod,
+        .root_module = target_architecture_mod,
     });
 
     // Create the CLI executable
@@ -213,7 +212,7 @@ pub fn build(b: *std.Build) void {
 
     // Creates a step for unit testing.
     const lib_unit_tests = b.addTest(.{
-        .root_module = zigevm_mod,
+        .root_module = target_architecture_mod,
     });
 
     // Add all modules to standalone tests

--- a/src/Utils/keccak256.zig
+++ b/src/Utils/keccak256.zig
@@ -17,12 +17,12 @@ export fn keccak256_hex(hex_ptr: [*]const u8, hex_len: usize, output_ptr: [*]u8)
     const hex = @import("hex.zig");
 
     // Convert hex to bytes using stdlib
-    const binary_len = hex.hexToBytes(hex_ptr, hex_len, &binary_buffer);
+    const binary_len = hex.zig_hexToBytes(hex_ptr, hex_len, &binary_buffer);
 
     // Compute keccak256 hash
     var hash: [32]u8 = undefined;
     std.crypto.hash.sha3.Keccak256.hash(binary_buffer[0..binary_len], &hash, .{});
 
     // Convert hash to hex string using stdlib
-    return hex.bytesToHex(&hash, 32, output_ptr);
+    return hex.zig_bytesToHex(&hash, 32, output_ptr);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -3,27 +3,9 @@ const std = @import("std");
 pub const evm = @import("Evm");
 pub const utils = @import("Utils");
 
-pub fn main() void {
-    // Create state manager
-    var stateManager = evm.frame.StateManager{};
-    
-    // Initialize EVM
-    var evm_instance = evm.Evm.init(std.heap.page_allocator, &stateManager);
-    
-    // Create a simple call input
-    var input = evm.frame.FrameInput{
-        .Call = .{
-            .callData = &[_]u8{},
-            .gasLimit = 100000,
-            .target = evm.address.ZERO_ADDRESS,
-            .codeAddress = evm.address.ZERO_ADDRESS,
-            .caller = evm.address.ZERO_ADDRESS,
-            .value = 0,
-            .callType = .Call,
-            .isStatic = false,
-        },
-    };
-    
-    // Execute
-    _ = evm_instance.execute(&input) catch unreachable;
+/// Wasm compatible kekkak256
+export fn keccak256(input_ptr: [*]const u8, input_len: usize, output_ptr: [*]u8) void {
+    const input = input_ptr[0..input_len];
+    const output = output_ptr[0..32];
+    std.crypto.hash.sha3.Keccak256.hash(input, output, .{});
 }


### PR DESCRIPTION
## Description

Integrate Zig with Tauri by adding a build script that compiles the Zig EVM library and links it to the Rust application. This PR:

- Adds a `connect_zig()` function in `build.rs` to compile the Zig code and link the static library
- Exposes the Keccak256 hash function from Zig to Rust through FFI
- Updates the `greet` command to demonstrate the integration by computing the Keccak256 hash of the input name
- Refactors the Zig root module to export the Keccak256 function for FFI usage

## Testing

- Verified the Zig compilation process works correctly across platforms
- Tested the FFI integration between Rust and Zig
- Confirmed the Keccak256 hash function produces correct results

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: