### PR TITLE
fix: private packagejson

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -103,7 +103,6 @@
     "@tevm/runtime-rs-win32-ia32-msvc": "0.1.0",
     "@tevm/primitives": "1.0.0-next.142",
     "@tevm/zig": "0.0.1",
-    "app": "0.1.0"
   },
   "changesets": [
     "add-deal-action",

--- a/.changeset/quick-oranges-doubt.md
+++ b/.changeset/quick-oranges-doubt.md
@@ -39,7 +39,6 @@
 "@tevm/vscode": patch
 "@tevm/lsp": patch
 "tevm": patch
-"app": patch
 "@tevm/cli": patch
 "@tevm/zig": patch
 ---

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "app",
   "version": "0.1.1-next.0",
+  "private": true,
   "description": "",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description

Mark the `app` package as private and remove it from the changeset pre.json and quick-oranges-doubt.md files to exclude it from the release process.

## Testing

Verified that the app package is properly marked as private in package.json and removed from the changeset files to ensure it won't be published.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Marked the app package as private to prevent accidental publishing.
  - Updated internal configuration to remove the app package from version tracking and release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->