### PR TITLE
fix: broken json

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -102,7 +102,7 @@
     "@tevm/runtime-rs-win32-arm64-msvc": "0.1.0",
     "@tevm/runtime-rs-win32-ia32-msvc": "0.1.0",
     "@tevm/primitives": "1.0.0-next.142",
-    "@tevm/zig": "0.0.1",
+    "@tevm/zig": "0.0.1"
   },
   "changesets": [
     "add-deal-action",


### PR DESCRIPTION
## Description

Fixed a syntax error in `.changeset/pre.json` by removing a trailing comma after the `@tevm/zig` version entry.

## Testing

Validated JSON syntax correctness.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed a trailing comma in configuration to improve formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->