### PR TITLE
feat: @tevm/test-matchers - Base matchers

### DIFF
--- a/extensions/test-matchers/README.md
+++ b/extensions/test-matchers/README.md
@@ -1,0 +1,163 @@
+# @tevm/test-matchers
+
+Custom Vitest matchers for Tevm and EVM-related testing in TypeScript.
+
+## Installation
+
+```bash
+pnpm add @tevm/test-matchers -D
+# or
+npm install @tevm/test-matchers --save-dev
+```
+
+## Setup
+
+### Option 1: Automatic Setup (Recommended)
+
+Add to your `vitest.config.ts`:
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['@tevm/test-matchers'],
+  },
+})
+```
+
+### Option 2: Manual Import
+
+Import in your test files:
+
+```typescript
+import '@tevm/test-matchers'
+import { expect, test } from 'vitest'
+
+test('example', () => {
+  expect(BigInt(42)).toBeBigInt()
+})
+```
+
+## Available Matchers
+
+### `toBeBigInt()`
+
+Asserts that a value is a BigInt.
+
+```typescript
+// ✅ Passes
+expect(BigInt(42)).toBeBigInt()
+expect(123n).toBeBigInt()
+
+// ❌ Fails
+expect(42).toBeBigInt()
+expect('123').toBeBigInt()
+
+// Works with .not
+expect(42).not.toBeBigInt()
+```
+
+### `toBeAddress(opts?)`
+
+Asserts that a value is a valid Ethereum address with optional checksum validation.
+
+```typescript
+// ✅ Passes - checksummed addresses (default behavior)
+expect('0x742d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b').toBeAddress()
+expect('0x0000000000000000000000000000000000000000').toBeAddress()
+
+// ✅ Passes - any case when strict: false
+expect('0x742d35cc5db4c8e9f8d4dc1ef70c4c7c8e5b7a6b').toBeAddress({ strict: false })
+
+// ❌ Fails - incorrect checksum (default strict: true)
+expect('0x742d35cc5db4c8e9f8d4dc1ef70c4c7c8e5b7a6b').toBeAddress()
+
+// ❌ Fails - invalid format
+expect('0x123').toBeAddress() // too short
+expect('invalid').toBeAddress() // not hex
+expect(123).toBeAddress() // not string
+
+// Options
+expect(address).toBeAddress({ strict: true })  // enforce EIP-55 checksum (default)
+expect(address).toBeAddress({ strict: false }) // accept any case
+```
+
+### `toBeHex(opts?)`
+
+Asserts that a value is valid hex with optional strict mode and length validation.
+
+```typescript
+// ✅ Passes - basic hex validation
+expect('0x1234abcd').toBeHex()
+expect('0x').toBeHex()
+expect('0xABCDEF').toBeHex()
+
+// ✅ Passes - length validation
+expect('0x1234').toBeHex({ length: 2 }) // exactly 2 bytes (4 hex chars)
+expect('0x').toBeHex({ length: 0 }) // empty hex
+
+// ✅ Passes - non-strict mode
+expect('0x1234').toBeHex({ strict: false })
+
+// ❌ Fails - missing 0x prefix
+expect('1234').toBeHex() // missing 0x prefix
+
+// ❌ Fails - invalid hex characters
+expect('0xghij').toBeHex() // invalid hex characters
+
+// ❌ Fails - wrong length
+expect('0x123').toBeHex({ length: 2 }) // wrong length (1.5 bytes instead of 2)
+
+// Options
+expect(hex).toBeHex({ strict: true })           // strict hex validation (default)
+expect(hex).toBeHex({ strict: false })          // only check for 0x prefix
+expect(hex).toBeHex({ length: 32 })             // exactly 32 bytes (64 hex chars)
+expect(hex).toBeHex({ strict: true, length: 4 }) // both strict and length
+```
+
+## TypeScript Support
+
+All matchers include full TypeScript support with proper type definitions. The matchers will be available on the `expect` object after importing.
+
+## Examples
+
+```typescript
+import '@tevm/test-matchers'
+import { expect, test } from 'vitest'
+
+test('TEVM result validation', () => {
+  const result = {
+    executionGasUsed: 21000n,
+    to: '0x742d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b',
+    data: '0x1234abcd'
+  }
+
+  expect(result.executionGasUsed).toBeBigInt()
+  expect(result.to).toBeAddress() // validates checksum by default
+  expect(result.data).toBeHex()
+})
+
+test('Transaction hash validation', () => {
+  const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+  expect(txHash).toBeHex({ length: 32 }) // 32 bytes for transaction hash
+})
+
+test('Function selector validation', () => {
+  const selector = '0xa9059cbb' // transfer(address,uint256)
+  expect(selector).toBeHex({ length: 4 }) // 4 bytes for function selector
+})
+
+test('Address validation with different strictness', () => {
+  const checksummed = '0x742d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b'
+  const lowercase = '0x742d35cc5db4c8e9f8d4dc1ef70c4c7c8e5b7a6b'
+
+  expect(checksummed).toBeAddress() // passes (correct checksum)
+  expect(lowercase).not.toBeAddress() // fails (incorrect checksum)
+  expect(lowercase).toBeAddress({ strict: false }) // passes (any case allowed)
+})
+```
+
+## License
+
+MIT

--- a/extensions/test-matchers/README.md
+++ b/extensions/test-matchers/README.md
@@ -85,7 +85,7 @@ expect(address).toBeAddress({ strict: false }) // accept any case
 
 ### `toBeHex(opts?)`
 
-Asserts that a value is valid hex with optional strict mode and length validation.
+Asserts that a value is valid hex with optional strict mode and size validation.
 
 ```typescript
 // ✅ Passes - basic hex validation
@@ -93,9 +93,9 @@ expect('0x1234abcd').toBeHex()
 expect('0x').toBeHex()
 expect('0xABCDEF').toBeHex()
 
-// ✅ Passes - length validation
-expect('0x1234').toBeHex({ length: 2 }) // exactly 2 bytes (4 hex chars)
-expect('0x').toBeHex({ length: 0 }) // empty hex
+// ✅ Passes - size validation
+expect('0x1234').toBeHex({ size: 2 }) // exactly 2 bytes (4 hex chars)
+expect('0x').toBeHex({ size: 0 }) // empty hex
 
 // ✅ Passes - non-strict mode
 expect('0x1234').toBeHex({ strict: false })
@@ -106,14 +106,60 @@ expect('1234').toBeHex() // missing 0x prefix
 // ❌ Fails - invalid hex characters
 expect('0xghij').toBeHex() // invalid hex characters
 
-// ❌ Fails - wrong length
-expect('0x123').toBeHex({ length: 2 }) // wrong length (1.5 bytes instead of 2)
+// ❌ Fails - wrong size
+expect('0x123').toBeHex({ size: 2 }) // wrong size (1.5 bytes instead of 2)
 
 // Options
 expect(hex).toBeHex({ strict: true })           // strict hex validation (default)
 expect(hex).toBeHex({ strict: false })          // only check for 0x prefix
-expect(hex).toBeHex({ length: 32 })             // exactly 32 bytes (64 hex chars)
-expect(hex).toBeHex({ strict: true, length: 4 }) // both strict and length
+expect(hex).toBeHex({ size: 32 })             // exactly 32 bytes (64 hex chars)
+expect(hex).toBeHex({ strict: true, size: 4 }) // both strict and size
+```
+
+### `toEqualAddress(expected)`
+
+Asserts that two addresses are equal (case-insensitive comparison using viem's `isAddressEqual`).
+
+```typescript
+// ✅ Passes - same address different cases
+expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toEqualAddress('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac')
+expect('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed').toEqualAddress('0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED')
+
+// ❌ Fails - different addresses
+expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
+
+// Works with .not
+expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').not.toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
+```
+
+### `toEqualHex(expected, opts?)`
+
+Asserts that two hex strings are equal by comparing their byte values. By default, normalizes hex strings before comparison.
+
+```typescript
+// ✅ Passes - same hex different cases
+expect('0x1234abcd').toEqualHex('0x1234ABCD')
+expect('0xdeadbeef').toEqualHex('0xDEADBEEF')
+
+// ✅ Passes - normalized comparison (default behavior)
+expect('0x0').toEqualHex('0x00')        // leading zeros trimmed
+expect('0x000123').toEqualHex('0x123')  // leading zeros trimmed
+expect('0x0000').toEqualHex('0x0')      // both normalize to same value
+
+// ❌ Fails - different hex values
+expect('0x1234abcd').toEqualHex('0x1234abce')
+
+// Exact comparison (no normalization)
+expect('0x00123').toEqualHex('0x00123', { exact: true })  // ✅ passes
+expect('0x00123').toEqualHex('0x123', { exact: true })    // ❌ fails
+
+// Options
+expect(hex1).toEqualHex(hex2)                    // normalized comparison (default)
+expect(hex1).toEqualHex(hex2, { exact: false }) // normalized comparison
+expect(hex1).toEqualHex(hex2, { exact: true })  // exact string comparison
+
+// Works with .not
+expect('0x1234abcd').not.toEqualHex('0x1234abce')
 ```
 
 ## TypeScript Support
@@ -138,14 +184,47 @@ test('TEVM result validation', () => {
   expect(result.data).toBeHex()
 })
 
+test('Transaction comparison', () => {
+  const tx1 = {
+    to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+    data: '0x1234abcd'
+  }
+
+  const tx2 = {
+    to: '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac', // different case
+    data: '0x1234ABCD' // different case
+  }
+
+  // These should be equal despite case differences
+  expect(tx1.to).toEqualAddress(tx2.to)
+  expect(tx1.data).toEqualHex(tx2.data)
+})
+
+test('Hex comparison with normalization', () => {
+  // Default behavior normalizes leading zeros
+  expect('0x000123').toEqualHex('0x123')     // ✅ passes (normalized)
+  expect('0x0').toEqualHex('0x00')           // ✅ passes (normalized)
+
+  // Exact comparison preserves leading zeros
+  expect('0x000123').toEqualHex('0x123', { exact: true })  // ❌ fails
+  expect('0x000123').toEqualHex('0x000123', { exact: true }) // ✅ passes
+})
+
 test('Transaction hash validation', () => {
   const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-  expect(txHash).toBeHex({ length: 32 }) // 32 bytes for transaction hash
+  expect(txHash).toBeHex({ size: 32 }) // 32 bytes for transaction hash
+
+  // Compare with different case
+  const sameHashDifferentCase = '0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF'
+  expect(txHash).toEqualHex(sameHashDifferentCase)
 })
 
 test('Function selector validation', () => {
   const selector = '0xa9059cbb' // transfer(address,uint256)
-  expect(selector).toBeHex({ length: 4 }) // 4 bytes for function selector
+  expect(selector).toBeHex({ size: 4 }) // 4 bytes for function selector
+
+  // Compare with different case
+  expect(selector).toEqualHex('0xA9059CBB')
 })
 
 test('Address validation with different strictness', () => {
@@ -155,6 +234,9 @@ test('Address validation with different strictness', () => {
   expect(checksummed).toBeAddress() // passes (correct checksum)
   expect(lowercase).not.toBeAddress() // fails (incorrect checksum)
   expect(lowercase).toBeAddress({ strict: false }) // passes (any case allowed)
+
+  // But they should be equal as addresses
+  expect(checksummed).toEqualAddress(lowercase) // passes (same address)
 })
 ```
 

--- a/extensions/test-matchers/src/index.ts
+++ b/extensions/test-matchers/src/index.ts
@@ -3,12 +3,16 @@ import type { IsAddressOptions } from 'viem'
 import { toBeBigInt } from './matchers/toBeBigInt.js'
 import { toBeAddress } from './matchers/toBeAddress.js'
 import { toBeHex, type IsHexOptions } from './matchers/toBeHex.js'
+import { toEqualAddress } from './matchers/toEqualAddress.js'
+import { toEqualHex, type EqualHexOptions } from './matchers/toEqualHex.js'
 
 // Define all matchers
 const matchers = {
   toBeBigInt,
   toBeAddress,
   toBeHex,
+  toEqualAddress,
+  toEqualHex,
 }
 
 // Extend expect with all matchers
@@ -21,6 +25,8 @@ export { matchers }
 export { toBeBigInt } from './matchers/toBeBigInt.js'
 export { toBeAddress } from './matchers/toBeAddress.js'
 export { toBeHex } from './matchers/toBeHex.js'
+export { toEqualAddress } from './matchers/toEqualAddress.js'
+export { toEqualHex } from './matchers/toEqualHex.js'
 
 // Type declarations for TypeScript
 declare module 'vitest' {
@@ -28,10 +34,14 @@ declare module 'vitest' {
     toBeBigInt(): T
     toBeAddress(opts?: IsAddressOptions): T
     toBeHex(opts?: IsHexOptions): T
+    toEqualAddress(expected: string): T
+    toEqualHex(expected: string, opts?: EqualHexOptions): T
   }
   interface AsymmetricMatchersContaining {
     toBeBigInt(): any
     toBeAddress(): any
     toBeHex(opts?: IsHexOptions): any
+    toEqualAddress(expected: string): any
+    toEqualHex(expected: string, opts?: EqualHexOptions): any
   }
 }

--- a/extensions/test-matchers/src/index.ts
+++ b/extensions/test-matchers/src/index.ts
@@ -1,18 +1,18 @@
-import { expect } from 'vitest'
 import type { IsAddressOptions } from 'viem'
-import { toBeBigInt } from './matchers/toBeBigInt.js'
+import { expect } from 'vitest'
 import { toBeAddress } from './matchers/toBeAddress.js'
-import { toBeHex, type IsHexOptions } from './matchers/toBeHex.js'
+import { toBeBigInt } from './matchers/toBeBigInt.js'
+import { type IsHexOptions, toBeHex } from './matchers/toBeHex.js'
 import { toEqualAddress } from './matchers/toEqualAddress.js'
-import { toEqualHex, type EqualHexOptions } from './matchers/toEqualHex.js'
+import { type EqualHexOptions, toEqualHex } from './matchers/toEqualHex.js'
 
 // Define all matchers
 const matchers = {
-  toBeBigInt,
-  toBeAddress,
-  toBeHex,
-  toEqualAddress,
-  toEqualHex,
+	toBeBigInt,
+	toBeAddress,
+	toBeHex,
+	toEqualAddress,
+	toEqualHex,
 }
 
 // Extend expect with all matchers
@@ -30,18 +30,18 @@ export { toEqualHex } from './matchers/toEqualHex.js'
 
 // Type declarations for TypeScript
 declare module 'vitest' {
-  interface Assertion<T = any> {
-    toBeBigInt(): T
-    toBeAddress(opts?: IsAddressOptions): T
-    toBeHex(opts?: IsHexOptions): T
-    toEqualAddress(expected: string): T
-    toEqualHex(expected: string, opts?: EqualHexOptions): T
-  }
-  interface AsymmetricMatchersContaining {
-    toBeBigInt(): any
-    toBeAddress(): any
-    toBeHex(opts?: IsHexOptions): any
-    toEqualAddress(expected: string): any
-    toEqualHex(expected: string, opts?: EqualHexOptions): any
-  }
+	interface Assertion<T = any> {
+		toBeBigInt(): T
+		toBeAddress(opts?: IsAddressOptions): T
+		toBeHex(opts?: IsHexOptions): T
+		toEqualAddress(expected: string): T
+		toEqualHex(expected: string, opts?: EqualHexOptions): T
+	}
+	interface AsymmetricMatchersContaining {
+		toBeBigInt(): any
+		toBeAddress(): any
+		toBeHex(opts?: IsHexOptions): any
+		toEqualAddress(expected: string): any
+		toEqualHex(expected: string, opts?: EqualHexOptions): any
+	}
 }

--- a/extensions/test-matchers/src/index.ts
+++ b/extensions/test-matchers/src/index.ts
@@ -1,0 +1,37 @@
+import { expect } from 'vitest'
+import type { IsAddressOptions } from 'viem'
+import { toBeBigInt } from './matchers/toBeBigInt.js'
+import { toBeAddress } from './matchers/toBeAddress.js'
+import { toBeHex, type IsHexOptions } from './matchers/toBeHex.js'
+
+// Define all matchers
+const matchers = {
+  toBeBigInt,
+  toBeAddress,
+  toBeHex,
+}
+
+// Extend expect with all matchers
+expect.extend(matchers)
+
+// Export matchers for manual usage if needed
+export { matchers }
+
+// Export individual matchers
+export { toBeBigInt } from './matchers/toBeBigInt.js'
+export { toBeAddress } from './matchers/toBeAddress.js'
+export { toBeHex } from './matchers/toBeHex.js'
+
+// Type declarations for TypeScript
+declare module 'vitest' {
+  interface Assertion<T = any> {
+    toBeBigInt(): T
+    toBeAddress(opts?: IsAddressOptions): T
+    toBeHex(opts?: IsHexOptions): T
+  }
+  interface AsymmetricMatchersContaining {
+    toBeBigInt(): any
+    toBeAddress(): any
+    toBeHex(opts?: IsHexOptions): any
+  }
+}

--- a/extensions/test-matchers/src/matchers/toBeAddress.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeAddress.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import '../index.js' // Import to extend expect with our matchers
+
+describe('toBeAddress', () => {
+  const validAddressesWithCorrectChecksum = [
+    '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+    '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+    '0x0000000000000000000000000000000000000000',
+    '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+    '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
+    '0x000000000000000000000000000000000000dEaD',
+  ]
+
+  const validAddressesWithInvalidChecksum = [
+    '0xA5CC3C03994DB5B0D9A5EEDD10CABAB0813678AC',
+    '0xA5CC3C03994DB5B0D9A5EEDD10CABAB0813678Ac',
+    '0xFB6916095CA1DF60BB79CE92CE3EA74C37C5D359',
+    '0xDE0B295669A9FD93D5F28D9EC85E40F4CB697BAE',
+  ]
+
+  const invalidAddresses = [
+    '0x123', // too short
+    '0x', // empty
+    '0x1234567890abcdef1234567890abcdef123456789', // too long
+    '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AG', // invalid hex char 'G'
+    '0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ', // invalid hex chars
+    '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678A!', // invalid char '!'
+    'a5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // missing 0x prefix
+    '5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', // missing 0x prefix
+    'invalid', // completely invalid
+    123, // not string
+    null,
+    undefined,
+    {},
+    [],
+    BigInt(123),
+  ]
+
+  describe('valid addresses (strict: true)', () => {
+    it('should pass for properly checksummed Ethereum addresses', () => {
+      validAddressesWithCorrectChecksum.forEach(address => {
+        expect(address).toBeAddress({ strict: true })
+        expect(address).toBeAddress() // strict: true is default
+      })
+    })
+
+    it('should fail for addresses with incorrect checksum', () => {
+      validAddressesWithInvalidChecksum.forEach(address => {
+        expect(() => expect(address).toBeAddress({ strict: true })).toThrow()
+        expect(() => expect(address).toBeAddress()).toThrow()
+      })
+    })
+  })
+
+  describe('non-strict mode (strict: false)', () => {
+    it('should pass for valid addresses regardless of checksum when strict: false', () => {
+      validAddressesWithCorrectChecksum.forEach(address =>
+        expect(address).toBeAddress({ strict: false })
+      )
+      validAddressesWithInvalidChecksum.forEach(address =>
+        expect(address).toBeAddress({ strict: false })
+      )
+    })
+  })
+
+  describe('invalid addresses', () => {
+    it('should fail for invalid addresses in all modes', () => {
+      // Default mode (strict)
+      invalidAddresses.forEach(address =>
+        expect(() => expect(address).toBeAddress()).toThrow()
+      )
+      // Explicit strict: true
+      invalidAddresses.forEach(address =>
+        expect(() => expect(address).toBeAddress({ strict: true })).toThrow()
+      )
+      // Even with strict: false
+      invalidAddresses.forEach(address =>
+        expect(() => expect(address).toBeAddress({ strict: false })).toThrow()
+      )
+    })
+
+  describe('.not modifier', () => {
+    it('should work with .not for invalid addresses', () => {
+      invalidAddresses.forEach(address =>
+        expect(address).not.toBeAddress()
+      )
+    })
+
+    it('should work with .not for checksum violations in strict mode', () => {
+      validAddressesWithInvalidChecksum.forEach(address => {
+        expect(address).not.toBeAddress()
+        expect(address).not.toBeAddress({ strict: true })
+      })
+    })
+
+    it('should fail with .not for valid checksummed addresses', () => {
+      validAddressesWithCorrectChecksum.forEach(address =>
+        expect(() => expect(address).not.toBeAddress()).toThrow()
+      )
+    })
+
+    it('should fail with .not for valid addresses in non-strict mode', () => {
+      [...validAddressesWithCorrectChecksum, ...validAddressesWithInvalidChecksum].forEach(address =>
+        expect(() => expect(address).not.toBeAddress({ strict: false })).toThrow()
+      )
+    })
+  })
+
+  describe('error messages', () => {
+    it('should provide helpful error messages for invalid format', () => {
+      try {
+        expect('0x123').toBeAddress()
+      } catch (error) {
+        expect(error.message).toContain('Expected "0x123" to be a valid Ethereum address')
+      }
+
+      try {
+        expect(123).toBeAddress()
+      } catch (error) {
+        expect(error.message).toContain('received number')
+      }
+    })
+
+    it('should mention checksum in error messages when strict mode fails', () => {
+      try {
+        expect('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac').toBeAddress({ strict: true })
+      } catch (error) {
+        expect(error.message).toContain('(checksummed)')
+      }
+    })
+
+    it('should mention checksum in error messages for default mode (which is strict)', () => {
+      try {
+        expect('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac').toBeAddress()
+      } catch (error) {
+        expect(error.message).toContain('(checksummed)')
+      }
+    })
+
+    it('should not mention checksum when strict: false', () => {
+      try {
+        expect('invalid').toBeAddress({ strict: false })
+      } catch (error) {
+        expect(error.message).not.toContain('(checksummed)')
+      }
+    })
+  })
+})
+})

--- a/extensions/test-matchers/src/matchers/toBeAddress.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeAddress.spec.ts
@@ -2,149 +2,137 @@ import { describe, expect, it } from 'vitest'
 import '../index.js' // Import to extend expect with our matchers
 
 describe('toBeAddress', () => {
-  const validAddressesWithCorrectChecksum = [
-    '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
-    '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
-    '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
-    '0x0000000000000000000000000000000000000000',
-    '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
-    '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
-    '0x000000000000000000000000000000000000dEaD',
-  ]
+	const validAddressesWithCorrectChecksum = [
+		'0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+		'0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+		'0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+		'0x0000000000000000000000000000000000000000',
+		'0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+		'0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
+		'0x000000000000000000000000000000000000dEaD',
+	]
 
-  const validAddressesWithInvalidChecksum = [
-    '0xA5CC3C03994DB5B0D9A5EEDD10CABAB0813678AC',
-    '0xA5CC3C03994DB5B0D9A5EEDD10CABAB0813678Ac',
-    '0xFB6916095CA1DF60BB79CE92CE3EA74C37C5D359',
-    '0xDE0B295669A9FD93D5F28D9EC85E40F4CB697BAE',
-  ]
+	const validAddressesWithInvalidChecksum = [
+		'0xA5CC3C03994DB5B0D9A5EEDD10CABAB0813678AC',
+		'0xA5CC3C03994DB5B0D9A5EEDD10CABAB0813678Ac',
+		'0xFB6916095CA1DF60BB79CE92CE3EA74C37C5D359',
+		'0xDE0B295669A9FD93D5F28D9EC85E40F4CB697BAE',
+	]
 
-  const invalidAddresses = [
-    '0x123', // too short
-    '0x', // empty
-    '0x1234567890abcdef1234567890abcdef123456789', // too long
-    '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AG', // invalid hex char 'G'
-    '0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ', // invalid hex chars
-    '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678A!', // invalid char '!'
-    'a5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // missing 0x prefix
-    '5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', // missing 0x prefix
-    'invalid', // completely invalid
-    123, // not string
-    null,
-    undefined,
-    {},
-    [],
-    BigInt(123),
-  ]
+	const invalidAddresses = [
+		'0x123', // too short
+		'0x', // empty
+		'0x1234567890abcdef1234567890abcdef123456789', // too long
+		'0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AG', // invalid hex char 'G'
+		'0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ', // invalid hex chars
+		'0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678A!', // invalid char '!'
+		'a5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', // missing 0x prefix
+		'5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', // missing 0x prefix
+		'invalid', // completely invalid
+		123, // not string
+		null,
+		undefined,
+		{},
+		[],
+		BigInt(123),
+	]
 
-  describe('valid addresses (strict: true)', () => {
-    it('should pass for properly checksummed Ethereum addresses', () => {
-      validAddressesWithCorrectChecksum.forEach(address => {
-        expect(address).toBeAddress({ strict: true })
-        expect(address).toBeAddress() // strict: true is default
-      })
-    })
+	describe('valid addresses (strict: true)', () => {
+		it('should pass for properly checksummed Ethereum addresses', () => {
+			validAddressesWithCorrectChecksum.forEach((address) => {
+				expect(address).toBeAddress({ strict: true })
+				expect(address).toBeAddress() // strict: true is default
+			})
+		})
 
-    it('should fail for addresses with incorrect checksum', () => {
-      validAddressesWithInvalidChecksum.forEach(address => {
-        expect(() => expect(address).toBeAddress({ strict: true })).toThrow()
-        expect(() => expect(address).toBeAddress()).toThrow()
-      })
-    })
-  })
+		it('should fail for addresses with incorrect checksum', () => {
+			validAddressesWithInvalidChecksum.forEach((address) => {
+				expect(() => expect(address).toBeAddress({ strict: true })).toThrow()
+				expect(() => expect(address).toBeAddress()).toThrow()
+			})
+		})
+	})
 
-  describe('non-strict mode (strict: false)', () => {
-    it('should pass for valid addresses regardless of checksum when strict: false', () => {
-      validAddressesWithCorrectChecksum.forEach(address =>
-        expect(address).toBeAddress({ strict: false })
-      )
-      validAddressesWithInvalidChecksum.forEach(address =>
-        expect(address).toBeAddress({ strict: false })
-      )
-    })
-  })
+	describe('non-strict mode (strict: false)', () => {
+		it('should pass for valid addresses regardless of checksum when strict: false', () => {
+			validAddressesWithCorrectChecksum.forEach((address) => expect(address).toBeAddress({ strict: false }))
+			validAddressesWithInvalidChecksum.forEach((address) => expect(address).toBeAddress({ strict: false }))
+		})
+	})
 
-  describe('invalid addresses', () => {
-    it('should fail for invalid addresses in all modes', () => {
-      // Default mode (strict)
-      invalidAddresses.forEach(address =>
-        expect(() => expect(address).toBeAddress()).toThrow()
-      )
-      // Explicit strict: true
-      invalidAddresses.forEach(address =>
-        expect(() => expect(address).toBeAddress({ strict: true })).toThrow()
-      )
-      // Even with strict: false
-      invalidAddresses.forEach(address =>
-        expect(() => expect(address).toBeAddress({ strict: false })).toThrow()
-      )
-    })
+	describe('invalid addresses', () => {
+		it('should fail for invalid addresses in all modes', () => {
+			// Default mode (strict)
+			invalidAddresses.forEach((address) => expect(() => expect(address).toBeAddress()).toThrow())
+			// Explicit strict: true
+			invalidAddresses.forEach((address) => expect(() => expect(address).toBeAddress({ strict: true })).toThrow())
+			// Even with strict: false
+			invalidAddresses.forEach((address) => expect(() => expect(address).toBeAddress({ strict: false })).toThrow())
+		})
 
-  describe('.not modifier', () => {
-    it('should work with .not for invalid addresses', () => {
-      invalidAddresses.forEach(address =>
-        expect(address).not.toBeAddress()
-      )
-    })
+		describe('.not modifier', () => {
+			it('should work with .not for invalid addresses', () => {
+				invalidAddresses.forEach((address) => expect(address).not.toBeAddress())
+			})
 
-    it('should work with .not for checksum violations in strict mode', () => {
-      validAddressesWithInvalidChecksum.forEach(address => {
-        expect(address).not.toBeAddress()
-        expect(address).not.toBeAddress({ strict: true })
-      })
-    })
+			it('should work with .not for checksum violations in strict mode', () => {
+				validAddressesWithInvalidChecksum.forEach((address) => {
+					expect(address).not.toBeAddress()
+					expect(address).not.toBeAddress({ strict: true })
+				})
+			})
 
-    it('should fail with .not for valid checksummed addresses', () => {
-      validAddressesWithCorrectChecksum.forEach(address =>
-        expect(() => expect(address).not.toBeAddress()).toThrow()
-      )
-    })
+			it('should fail with .not for valid checksummed addresses', () => {
+				validAddressesWithCorrectChecksum.forEach((address) =>
+					expect(() => expect(address).not.toBeAddress()).toThrow(),
+				)
+			})
 
-    it('should fail with .not for valid addresses in non-strict mode', () => {
-      [...validAddressesWithCorrectChecksum, ...validAddressesWithInvalidChecksum].forEach(address =>
-        expect(() => expect(address).not.toBeAddress({ strict: false })).toThrow()
-      )
-    })
-  })
+			it('should fail with .not for valid addresses in non-strict mode', () => {
+				;[...validAddressesWithCorrectChecksum, ...validAddressesWithInvalidChecksum].forEach((address) =>
+					expect(() => expect(address).not.toBeAddress({ strict: false })).toThrow(),
+				)
+			})
+		})
 
-  describe('error messages', () => {
-    it('should provide helpful error messages for invalid format', () => {
-      try {
-        expect('0x123').toBeAddress()
-      } catch (error) {
-        expect(error.message).toContain('Expected "0x123" to be a valid Ethereum address')
-      }
+		describe('error messages', () => {
+			it('should provide helpful error messages for invalid format', () => {
+				try {
+					expect('0x123').toBeAddress()
+				} catch (error) {
+					expect(error.message).toContain('Expected "0x123" to be a valid Ethereum address')
+				}
 
-      try {
-        expect(123).toBeAddress()
-      } catch (error) {
-        expect(error.message).toContain('received number')
-      }
-    })
+				try {
+					expect(123).toBeAddress()
+				} catch (error) {
+					expect(error.message).toContain('received number')
+				}
+			})
 
-    it('should mention checksum in error messages when strict mode fails', () => {
-      try {
-        expect('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac').toBeAddress({ strict: true })
-      } catch (error) {
-        expect(error.message).toContain('(checksummed)')
-      }
-    })
+			it('should mention checksum in error messages when strict mode fails', () => {
+				try {
+					expect('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac').toBeAddress({ strict: true })
+				} catch (error) {
+					expect(error.message).toContain('(checksummed)')
+				}
+			})
 
-    it('should mention checksum in error messages for default mode (which is strict)', () => {
-      try {
-        expect('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac').toBeAddress()
-      } catch (error) {
-        expect(error.message).toContain('(checksummed)')
-      }
-    })
+			it('should mention checksum in error messages for default mode (which is strict)', () => {
+				try {
+					expect('0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac').toBeAddress()
+				} catch (error) {
+					expect(error.message).toContain('(checksummed)')
+				}
+			})
 
-    it('should not mention checksum when strict: false', () => {
-      try {
-        expect('invalid').toBeAddress({ strict: false })
-      } catch (error) {
-        expect(error.message).not.toContain('(checksummed)')
-      }
-    })
-  })
-})
+			it('should not mention checksum when strict: false', () => {
+				try {
+					expect('invalid').toBeAddress({ strict: false })
+				} catch (error) {
+					expect(error.message).not.toContain('(checksummed)')
+				}
+			})
+		})
+	})
 })

--- a/extensions/test-matchers/src/matchers/toBeAddress.ts
+++ b/extensions/test-matchers/src/matchers/toBeAddress.ts
@@ -1,0 +1,23 @@
+import { isAddress, type IsAddressOptions } from "viem"
+
+/**
+ * Custom Vitest matcher to assert that a value is a valid Ethereum address
+ * @param received - The value to test
+ * @param opts - Options for address validation (strict checksum by default)
+ * @returns Object with pass boolean and message function
+ */
+export function toBeAddress(received: string, opts?: IsAddressOptions) {
+  const pass = isAddress(received, opts)
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return `Expected "${received}" not to be a valid Ethereum address`
+      } else {
+        // Default is strict: true, so mention checksum unless explicitly strict: false
+        return `Expected "${received}" to be a valid Ethereum address${opts?.strict !== false ? ' (checksummed)' : ''}, but received ${typeof received === 'string' ? 'invalid format' : typeof received}`
+      }
+    },
+  }
+}

--- a/extensions/test-matchers/src/matchers/toBeAddress.ts
+++ b/extensions/test-matchers/src/matchers/toBeAddress.ts
@@ -1,4 +1,4 @@
-import { isAddress, type IsAddressOptions } from "viem"
+import { type IsAddressOptions, isAddress } from 'viem'
 
 /**
  * Custom Vitest matcher to assert that a value is a valid Ethereum address
@@ -7,17 +7,16 @@ import { isAddress, type IsAddressOptions } from "viem"
  * @returns Object with pass boolean and message function
  */
 export function toBeAddress(received: string, opts?: IsAddressOptions) {
-  const pass = isAddress(received, opts)
+	const pass = isAddress(received, opts)
 
-  return {
-    pass,
-    message: () => {
-      if (pass) {
-        return `Expected "${received}" not to be a valid Ethereum address`
-      } else {
-        // Default is strict: true, so mention checksum unless explicitly strict: false
-        return `Expected "${received}" to be a valid Ethereum address${opts?.strict !== false ? ' (checksummed)' : ''}, but received ${typeof received === 'string' ? 'invalid format' : typeof received}`
-      }
-    },
-  }
+	return {
+		pass,
+		message: () => {
+			if (pass) {
+				return `Expected "${received}" not to be a valid Ethereum address`
+			}
+			// Default is strict: true, so mention checksum unless explicitly strict: false
+			return `Expected "${received}" to be a valid Ethereum address${opts?.strict !== false ? ' (checksummed)' : ''}, but received ${typeof received === 'string' ? 'invalid format' : typeof received}`
+		},
+	}
 }

--- a/extensions/test-matchers/src/matchers/toBeBigInt.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeBigInt.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import '../index.js' // Import to extend expect with our matchers
+
+describe('toBeBigInt', () => {
+  const bigints = [
+    BigInt(42),
+    123n,
+    BigInt(0),
+    BigInt('999999999999999999999'),
+  ]
+
+  const nonBigints = [
+    42,
+    '42',
+    null,
+    undefined,
+    {},
+    [],
+  ]
+
+  it('should pass for BigInt values', () => {
+    bigints.forEach(bigint => expect(bigint).toBeBigInt())
+  })
+
+  it('should fail for non-BigInt values', () => {
+    nonBigints.forEach(nonBigint => expect(() => expect(nonBigint).toBeBigInt()).toThrow())
+  })
+
+  it('should work with .not modifier', () => {
+    nonBigints.forEach(nonBigint => expect(nonBigint).not.toBeBigInt())
+    bigints.forEach(bigint => expect(() => expect(bigint).not.toBeBigInt()).toThrow())
+  })
+
+  it('should provide helpful error messages', () => {
+    try {
+      expect(42).toBeBigInt()
+    } catch (error) {
+      expect(error.message).toContain('Expected 42 to be a BigInt, but received number')
+    }
+
+    try {
+      expect('hello').toBeBigInt()
+    } catch (error) {
+      expect(error.message).toContain('Expected hello to be a BigInt, but received string')
+    }
+  })
+})

--- a/extensions/test-matchers/src/matchers/toBeBigInt.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeBigInt.spec.ts
@@ -2,46 +2,34 @@ import { describe, expect, it } from 'vitest'
 import '../index.js' // Import to extend expect with our matchers
 
 describe('toBeBigInt', () => {
-  const bigints = [
-    BigInt(42),
-    123n,
-    BigInt(0),
-    BigInt('999999999999999999999'),
-  ]
+	const bigints = [BigInt(42), 123n, BigInt(0), BigInt('999999999999999999999')]
 
-  const nonBigints = [
-    42,
-    '42',
-    null,
-    undefined,
-    {},
-    [],
-  ]
+	const nonBigints = [42, '42', null, undefined, {}, []]
 
-  it('should pass for BigInt values', () => {
-    bigints.forEach(bigint => expect(bigint).toBeBigInt())
-  })
+	it('should pass for BigInt values', () => {
+		bigints.forEach((bigint) => expect(bigint).toBeBigInt())
+	})
 
-  it('should fail for non-BigInt values', () => {
-    nonBigints.forEach(nonBigint => expect(() => expect(nonBigint).toBeBigInt()).toThrow())
-  })
+	it('should fail for non-BigInt values', () => {
+		nonBigints.forEach((nonBigint) => expect(() => expect(nonBigint).toBeBigInt()).toThrow())
+	})
 
-  it('should work with .not modifier', () => {
-    nonBigints.forEach(nonBigint => expect(nonBigint).not.toBeBigInt())
-    bigints.forEach(bigint => expect(() => expect(bigint).not.toBeBigInt()).toThrow())
-  })
+	it('should work with .not modifier', () => {
+		nonBigints.forEach((nonBigint) => expect(nonBigint).not.toBeBigInt())
+		bigints.forEach((bigint) => expect(() => expect(bigint).not.toBeBigInt()).toThrow())
+	})
 
-  it('should provide helpful error messages', () => {
-    try {
-      expect(42).toBeBigInt()
-    } catch (error) {
-      expect(error.message).toContain('Expected 42 to be a BigInt, but received number')
-    }
+	it('should provide helpful error messages', () => {
+		try {
+			expect(42).toBeBigInt()
+		} catch (error) {
+			expect(error.message).toContain('Expected 42 to be a BigInt, but received number')
+		}
 
-    try {
-      expect('hello').toBeBigInt()
-    } catch (error) {
-      expect(error.message).toContain('Expected hello to be a BigInt, but received string')
-    }
-  })
+		try {
+			expect('hello').toBeBigInt()
+		} catch (error) {
+			expect(error.message).toContain('Expected hello to be a BigInt, but received string')
+		}
+	})
 })

--- a/extensions/test-matchers/src/matchers/toBeBigInt.ts
+++ b/extensions/test-matchers/src/matchers/toBeBigInt.ts
@@ -4,16 +4,15 @@
  * @returns Object with pass boolean and message function
  */
 export function toBeBigInt(received: unknown) {
-  const pass = typeof received === 'bigint'
+	const pass = typeof received === 'bigint'
 
-  return {
-    pass,
-    message: () => {
-      if (pass) {
-        return `Expected ${received} not to be a BigInt`
-      } else {
-        return `Expected ${received} to be a BigInt, but received ${typeof received}`
-      }
-    },
-  }
+	return {
+		pass,
+		message: () => {
+			if (pass) {
+				return `Expected ${received} not to be a BigInt`
+			}
+			return `Expected ${received} to be a BigInt, but received ${typeof received}`
+		},
+	}
 }

--- a/extensions/test-matchers/src/matchers/toBeBigInt.ts
+++ b/extensions/test-matchers/src/matchers/toBeBigInt.ts
@@ -1,0 +1,19 @@
+/**
+ * Custom Vitest matcher to assert that a value is a BigInt
+ * @param received - The value to test
+ * @returns Object with pass boolean and message function
+ */
+export function toBeBigInt(received: unknown) {
+  const pass = typeof received === 'bigint'
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return `Expected ${received} not to be a BigInt`
+      } else {
+        return `Expected ${received} to be a BigInt, but received ${typeof received}`
+      }
+    },
+  }
+}

--- a/extensions/test-matchers/src/matchers/toBeHex.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeHex.spec.ts
@@ -2,234 +2,225 @@ import { describe, expect, it } from 'vitest'
 import '../index.js' // Import to extend expect with our matchers
 
 describe('toBeHex', () => {
-  const validHexStrings = [
-    '0x1234abcd',
-    '0x',
-    '0x00',
-    '0xFFFFFFFF',
-    '0xabcdef123456789',
-    '0xABCDEF123456789',
-    '0x0',
-    '0xf',
-    '0xF',
-    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', // 64 chars (32 bytes)
-  ]
+	const validHexStrings = [
+		'0x1234abcd',
+		'0x',
+		'0x00',
+		'0xFFFFFFFF',
+		'0xabcdef123456789',
+		'0xABCDEF123456789',
+		'0x0',
+		'0xf',
+		'0xF',
+		'0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', // 64 chars (32 bytes)
+	]
 
-  const validHexStringsWithSize = [
-    { hex: '0x1234', size: 2 }, // 2 bytes
-    { hex: '0xabcd', size: 2 }, // 2 bytes
-    { hex: '0xABCD', size: 2 }, // 2 bytes
-    { hex: '0x00', size: 1 }, // 1 byte
-    { hex: '0x', size: 0 }, // 0 bytes
-    { hex: '0x123456789abcdef0', size: 8 }, // 8 bytes
-    { hex: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', size: 32 }, // 32 bytes (tx hash)
-  ]
+	const validHexStringsWithSize = [
+		{ hex: '0x1234', size: 2 }, // 2 bytes
+		{ hex: '0xabcd', size: 2 }, // 2 bytes
+		{ hex: '0xABCD', size: 2 }, // 2 bytes
+		{ hex: '0x00', size: 1 }, // 1 byte
+		{ hex: '0x', size: 0 }, // 0 bytes
+		{ hex: '0x123456789abcdef0', size: 8 }, // 8 bytes
+		{ hex: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', size: 32 }, // 32 bytes (tx hash)
+	]
 
-  const invalidHexStrings = [
-    // Missing 0x prefix
-    '1234',
-    'abcdef',
-    'FFFFFF',
-    'ghij',
-    'x1234',
-    '0X1234', // wrong case for X
-  ]
+	const invalidHexStrings = [
+		// Missing 0x prefix
+		'1234',
+		'abcdef',
+		'FFFFFF',
+		'ghij',
+		'x1234',
+		'0X1234', // wrong case for X
+	]
 
-  const invalidHexStringsStart0x = [
-    // Invalid hex characters
-    '0xghij',
-    '0x123G',
-    '0xZZZZ',
-    '0x123!',
-    '0x@#$%',
-    '0xhello',
+	const invalidHexStringsStart0x = [
+		// Invalid hex characters
+		'0xghij',
+		'0x123G',
+		'0xZZZZ',
+		'0x123!',
+		'0x@#$%',
+		'0xhello',
 
-    // Invalid format
-    '0x 1234', // space
-    '0x12 34', // space in middle
-  ]
+		// Invalid format
+		'0x 1234', // space
+		'0x12 34', // space in middle
+	]
 
-  const nonStringTypes = [
-    123,
-    null,
-    undefined,
-    {},
-    [],
-    BigInt(123),
-    true,
-    Symbol('test'),
-  ]
+	const nonStringTypes = [123, null, undefined, {}, [], BigInt(123), true, Symbol('test')]
 
-  const invalidSizeCases = [
-    { hex: '0x123', expectedSize: 2 }, // odd number of chars after 0x
-    { hex: '0x12345', expectedSize: 2 }, // too long
-    { hex: '0x1234', expectedSize: 1 }, // expecting 1 byte but got 2
-    { hex: '0x1234', expectedSize: 4 }, // expecting 4 bytes but got 2
-    { hex: '0x', expectedSize: 1 }, // expecting 1 byte but got 0
-  ]
+	const invalidSizeCases = [
+		{ hex: '0x123', expectedSize: 2 }, // odd number of chars after 0x
+		{ hex: '0x12345', expectedSize: 2 }, // too long
+		{ hex: '0x1234', expectedSize: 1 }, // expecting 1 byte but got 2
+		{ hex: '0x1234', expectedSize: 4 }, // expecting 4 bytes but got 2
+		{ hex: '0x', expectedSize: 1 }, // expecting 1 byte but got 0
+	]
 
-  describe('default behavior (strict: true)', () => {
-    it('should pass for valid hex strings', () => {
-      validHexStrings.forEach(hex => {
-        expect(hex).toBeHex()
-        expect(hex).toBeHex({ strict: true })
-      })
-    })
+	describe('default behavior (strict: true)', () => {
+		it('should pass for valid hex strings', () => {
+			validHexStrings.forEach((hex) => {
+				expect(hex).toBeHex()
+				expect(hex).toBeHex({ strict: true })
+			})
+		})
 
-    it('should fail for invalid hex strings or non-string types', () => {
-      [...invalidHexStrings, ...invalidHexStringsStart0x, ...nonStringTypes].forEach(hex => {
-        expect(() => expect(hex).toBeHex()).toThrow()
-        expect(() => expect(hex).toBeHex({ strict: true })).toThrow()
-      })
-    })
-  })
+		it('should fail for invalid hex strings or non-string types', () => {
+			;[...invalidHexStrings, ...invalidHexStringsStart0x, ...nonStringTypes].forEach((hex) => {
+				expect(() => expect(hex).toBeHex()).toThrow()
+				expect(() => expect(hex).toBeHex({ strict: true })).toThrow()
+			})
+		})
+	})
 
-  describe('non-strict mode (strict: false)', () => {
-    it('should pass for valid hex strings when strict: false', () => {
-      [...validHexStrings, ...invalidHexStringsStart0x].forEach(hex => {
-        expect(hex).toBeHex({ strict: false })
-      })
-    })
+	describe('non-strict mode (strict: false)', () => {
+		it('should pass for valid hex strings when strict: false', () => {
+			;[...validHexStrings, ...invalidHexStringsStart0x].forEach((hex) => {
+				expect(hex).toBeHex({ strict: false })
+			})
+		})
 
-    it('should still fail for completely invalid format when strict: false', () => {
-      [...invalidHexStrings, ...nonStringTypes].forEach(hex => {
-        expect(() => expect(hex).toBeHex({ strict: false })).toThrow()
-      })
-    })
-  })
+		it('should still fail for completely invalid format when strict: false', () => {
+			;[...invalidHexStrings, ...nonStringTypes].forEach((hex) => {
+				expect(() => expect(hex).toBeHex({ strict: false })).toThrow()
+			})
+		})
+	})
 
-  describe('size validation', () => {
-    it('should pass for hex strings with correct size', () => {
-      validHexStringsWithSize.forEach(({ hex, size }) => {
-        expect(hex).toBeHex({ size })
-        expect(hex).toBeHex({ size, strict: true })
-        expect(hex).toBeHex({ size, strict: false })
-      })
-    })
+	describe('size validation', () => {
+		it('should pass for hex strings with correct size', () => {
+			validHexStringsWithSize.forEach(({ hex, size }) => {
+				expect(hex).toBeHex({ size })
+				expect(hex).toBeHex({ size, strict: true })
+				expect(hex).toBeHex({ size, strict: false })
+			})
+		})
 
-    it('should fail for hex strings with incorrect size', () => {
-      invalidSizeCases.forEach(({ hex, expectedSize }) => {
-        expect(() => expect(hex).toBeHex({ size: expectedSize })).toThrow()
-        expect(() => expect(hex).toBeHex({ size: expectedSize, strict: true })).toThrow()
-        expect(() => expect(hex).toBeHex({ size: expectedSize, strict: false })).toThrow()
-      })
-    })
+		it('should fail for hex strings with incorrect size', () => {
+			invalidSizeCases.forEach(({ hex, expectedSize }) => {
+				expect(() => expect(hex).toBeHex({ size: expectedSize })).toThrow()
+				expect(() => expect(hex).toBeHex({ size: expectedSize, strict: true })).toThrow()
+				expect(() => expect(hex).toBeHex({ size: expectedSize, strict: false })).toThrow()
+			})
+		})
 
-    it('should fail for invalid hex even with correct size specification', () => {
-      expect(() => expect('0xGHIJ').toBeHex({ size: 2 })).toThrow()
-      expect(() => expect('1234').toBeHex({ size: 2 })).toThrow() // missing 0x
-      expect(() => expect('0x123!').toBeHex({ size: 2 })).toThrow() // invalid char
-    })
-  })
+		it('should fail for invalid hex even with correct size specification', () => {
+			expect(() => expect('0xGHIJ').toBeHex({ size: 2 })).toThrow()
+			expect(() => expect('1234').toBeHex({ size: 2 })).toThrow() // missing 0x
+			expect(() => expect('0x123!').toBeHex({ size: 2 })).toThrow() // invalid char
+		})
+	})
 
-  describe('combined options', () => {
-    it('should work with both strict and size options', () => {
-      expect('0x1234').toBeHex({ strict: true, size: 2 })
-      expect('0x1234').toBeHex({ strict: false, size: 2 })
+	describe('combined options', () => {
+		it('should work with both strict and size options', () => {
+			expect('0x1234').toBeHex({ strict: true, size: 2 })
+			expect('0x1234').toBeHex({ strict: false, size: 2 })
 
-      expect(() => expect('0x123G').toBeHex({ strict: true, size: 2 })).toThrow()
-      expect(() => expect('0x123G').toBeHex({ strict: false, size: 3 })).toThrow()
-      expect('0x123G').toBeHex({ strict: false, size: 2 })
-    })
-  })
+			expect(() => expect('0x123G').toBeHex({ strict: true, size: 2 })).toThrow()
+			expect(() => expect('0x123G').toBeHex({ strict: false, size: 3 })).toThrow()
+			expect('0x123G').toBeHex({ strict: false, size: 2 })
+		})
+	})
 
-  describe('.not modifier', () => {
-    it('should work with .not for invalid hex strings', () => {
-      [...invalidHexStrings, ...nonStringTypes].forEach(hex => {
-        expect(hex).not.toBeHex()
-      })
-    })
+	describe('.not modifier', () => {
+		it('should work with .not for invalid hex strings', () => {
+			;[...invalidHexStrings, ...nonStringTypes].forEach((hex) => {
+				expect(hex).not.toBeHex()
+			})
+		})
 
-    it('should work with .not for size mismatches', () => {
-      invalidSizeCases.forEach(({ hex, expectedSize }) => {
-        expect(hex).not.toBeHex({ size: expectedSize })
-      })
-    })
+		it('should work with .not for size mismatches', () => {
+			invalidSizeCases.forEach(({ hex, expectedSize }) => {
+				expect(hex).not.toBeHex({ size: expectedSize })
+			})
+		})
 
-    it('should fail with .not for valid hex strings', () => {
-      validHexStrings.forEach(hex => {
-        expect(() => expect(hex).not.toBeHex()).toThrow()
-      })
-    })
+		it('should fail with .not for valid hex strings', () => {
+			validHexStrings.forEach((hex) => {
+				expect(() => expect(hex).not.toBeHex()).toThrow()
+			})
+		})
 
-    it('should fail with .not for valid hex strings with correct size', () => {
-      validHexStringsWithSize.forEach(({ hex, size }) => {
-        expect(() => expect(hex).not.toBeHex({ size })).toThrow()
-      })
-    })
-  })
+		it('should fail with .not for valid hex strings with correct size', () => {
+			validHexStringsWithSize.forEach(({ hex, size }) => {
+				expect(() => expect(hex).not.toBeHex({ size })).toThrow()
+			})
+		})
+	})
 
-  describe('error messages', () => {
-    it('should provide helpful error messages for missing 0x prefix', () => {
-      try {
-        expect('1234').toBeHex()
-      } catch (error) {
-        expect(error.message).toContain('Expected "1234" to start with "0x"')
-      }
-    })
+	describe('error messages', () => {
+		it('should provide helpful error messages for missing 0x prefix', () => {
+			try {
+				expect('1234').toBeHex()
+			} catch (error) {
+				expect(error.message).toContain('Expected "1234" to start with "0x"')
+			}
+		})
 
-    it('should provide helpful error messages for invalid hex characters', () => {
-      try {
-        expect('0xghij').toBeHex()
-      } catch (error) {
-        expect(error.message).toContain('contain only hex characters')
-      }
-    })
+		it('should provide helpful error messages for invalid hex characters', () => {
+			try {
+				expect('0xghij').toBeHex()
+			} catch (error) {
+				expect(error.message).toContain('contain only hex characters')
+			}
+		})
 
-    it('should provide helpful error messages for wrong size', () => {
-      try {
-        expect('0x123').toBeHex({ size: 2 })
-      } catch (error) {
-        expect(error.message).toContain('Expected "0x123" to have 2 bytes after "0x", but got')
-      }
-    })
+		it('should provide helpful error messages for wrong size', () => {
+			try {
+				expect('0x123').toBeHex({ size: 2 })
+			} catch (error) {
+				expect(error.message).toContain('Expected "0x123" to have 2 bytes after "0x", but got')
+			}
+		})
 
-    it('should provide different messages for different error types', () => {
-      const testCases = [
-        { input: 'hello', expectedMessage: 'start with "0x"' },
-        { input: '0xGHIJ', expectedMessage: 'contain only hex characters' },
-        { input: '0x123', options: { size: 2 }, expectedMessage: 'have 2 bytes' },
-      ]
+		it('should provide different messages for different error types', () => {
+			const testCases = [
+				{ input: 'hello', expectedMessage: 'start with "0x"' },
+				{ input: '0xGHIJ', expectedMessage: 'contain only hex characters' },
+				{ input: '0x123', options: { size: 2 }, expectedMessage: 'have 2 bytes' },
+			]
 
-      testCases.forEach(({ input, options, expectedMessage }) => {
-        try {
-          expect(input).toBeHex(options)
-        } catch (error) {
-          expect(error.message).toContain(expectedMessage)
-        }
-      })
-    })
-  })
+			testCases.forEach(({ input, options, expectedMessage }) => {
+				try {
+					expect(input).toBeHex(options)
+				} catch (error) {
+					expect(error.message).toContain(expectedMessage)
+				}
+			})
+		})
+	})
 
-  describe('real-world usage patterns', () => {
-    it('should validate transaction hashes (32 bytes)', () => {
-      const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-      expect(txHash).toBeHex({ size: 32 })
-    })
+	describe('real-world usage patterns', () => {
+		it('should validate transaction hashes (32 bytes)', () => {
+			const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+			expect(txHash).toBeHex({ size: 32 })
+		})
 
-    it('should validate block hashes (32 bytes)', () => {
-      const blockHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
-      expect(blockHash).toBeHex({ size: 32 })
-    })
+		it('should validate block hashes (32 bytes)', () => {
+			const blockHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+			expect(blockHash).toBeHex({ size: 32 })
+		})
 
-    it('should validate addresses as hex (20 bytes)', () => {
-      const address = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
-      expect(address).toBeHex({ size: 20 })
-    })
+		it('should validate addresses as hex (20 bytes)', () => {
+			const address = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
+			expect(address).toBeHex({ size: 20 })
+		})
 
-    it('should validate short identifiers', () => {
-      expect('0x1234').toBeHex({ size: 2 })
-      expect('0xabcd').toBeHex({ size: 2 })
-    })
+		it('should validate short identifiers', () => {
+			expect('0x1234').toBeHex({ size: 2 })
+			expect('0xabcd').toBeHex({ size: 2 })
+		})
 
-    it('should validate function selectors (4 bytes)', () => {
-      expect('0xa9059cbb').toBeHex({ size: 4 }) // transfer function selector
-      expect('0x095ea7b3').toBeHex({ size: 4 }) // approve function selector
-    })
+		it('should validate function selectors (4 bytes)', () => {
+			expect('0xa9059cbb').toBeHex({ size: 4 }) // transfer function selector
+			expect('0x095ea7b3').toBeHex({ size: 4 }) // approve function selector
+		})
 
-    it('should validate empty hex', () => {
-      expect('0x').toBeHex({ size: 0 })
-      expect('0x').toBeHex() // should pass without size requirement
-    })
-  })
+		it('should validate empty hex', () => {
+			expect('0x').toBeHex({ size: 0 })
+			expect('0x').toBeHex() // should pass without size requirement
+		})
+	})
 })

--- a/extensions/test-matchers/src/matchers/toBeHex.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeHex.spec.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest'
+import '../index.js' // Import to extend expect with our matchers
+
+describe('toBeHex', () => {
+  const validHexStrings = [
+    '0x1234abcd',
+    '0x',
+    '0x00',
+    '0xFFFFFFFF',
+    '0xabcdef123456789',
+    '0xABCDEF123456789',
+    '0x0',
+    '0xf',
+    '0xF',
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', // 64 chars (32 bytes)
+  ]
+
+  const validHexStringsWithLength = [
+    { hex: '0x1234', length: 2 }, // 2 bytes
+    { hex: '0xabcd', length: 2 }, // 2 bytes
+    { hex: '0xABCD', length: 2 }, // 2 bytes
+    { hex: '0x00', length: 1 }, // 1 byte
+    { hex: '0x', length: 0 }, // 0 bytes
+    { hex: '0x123456789abcdef0', length: 8 }, // 8 bytes
+    { hex: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', length: 32 }, // 32 bytes (tx hash)
+  ]
+
+  const invalidHexStrings = [
+    // Missing 0x prefix
+    '1234',
+    'abcdef',
+    'FFFFFF',
+    'ghij',
+    'x1234',
+    '0X1234', // wrong case for X
+  ]
+
+  const invalidHexStringsStart0x = [
+    // Invalid hex characters
+    '0xghij',
+    '0x123G',
+    '0xZZZZ',
+    '0x123!',
+    '0x@#$%',
+    '0xhello',
+
+    // Invalid format
+    '0x 1234', // space
+    '0x12 34', // space in middle
+  ]
+
+  const nonStringTypes = [
+    123,
+    null,
+    undefined,
+    {},
+    [],
+    BigInt(123),
+    true,
+    Symbol('test'),
+  ]
+
+  const invalidLengthCases = [
+    { hex: '0x123', expectedLength: 2 }, // odd number of chars after 0x
+    { hex: '0x12345', expectedLength: 2 }, // too long
+    { hex: '0x1234', expectedLength: 1 }, // expecting 1 byte but got 2
+    { hex: '0x1234', expectedLength: 4 }, // expecting 4 bytes but got 2
+    { hex: '0x', expectedLength: 1 }, // expecting 1 byte but got 0
+  ]
+
+  describe('default behavior (strict: true)', () => {
+    it('should pass for valid hex strings', () => {
+      validHexStrings.forEach(hex => {
+        expect(hex).toBeHex()
+        expect(hex).toBeHex({ strict: true })
+      })
+    })
+
+    it('should fail for invalid hex strings or non-string types', () => {
+      [...invalidHexStrings, ...invalidHexStringsStart0x, ...nonStringTypes].forEach(hex => {
+        expect(() => expect(hex).toBeHex()).toThrow()
+        expect(() => expect(hex).toBeHex({ strict: true })).toThrow()
+      })
+    })
+  })
+
+  describe('non-strict mode (strict: false)', () => {
+    it('should pass for valid hex strings when strict: false', () => {
+      [...validHexStrings, ...invalidHexStringsStart0x].forEach(hex => {
+        expect(hex).toBeHex({ strict: false })
+      })
+    })
+
+    it('should still fail for completely invalid format when strict: false', () => {
+      [...invalidHexStrings, ...nonStringTypes].forEach(hex => {
+        expect(() => expect(hex).toBeHex({ strict: false })).toThrow()
+      })
+    })
+  })
+
+  describe('length validation', () => {
+    it('should pass for hex strings with correct length', () => {
+      validHexStringsWithLength.forEach(({ hex, length }) => {
+        expect(hex).toBeHex({ length })
+        expect(hex).toBeHex({ length, strict: true })
+        expect(hex).toBeHex({ length, strict: false })
+      })
+    })
+
+    it('should fail for hex strings with incorrect length', () => {
+      invalidLengthCases.forEach(({ hex, expectedLength }) => {
+        expect(() => expect(hex).toBeHex({ length: expectedLength })).toThrow()
+        expect(() => expect(hex).toBeHex({ length: expectedLength, strict: true })).toThrow()
+        expect(() => expect(hex).toBeHex({ length: expectedLength, strict: false })).toThrow()
+      })
+    })
+
+    it('should fail for invalid hex even with correct length specification', () => {
+      expect(() => expect('0xGHIJ').toBeHex({ length: 2 })).toThrow()
+      expect(() => expect('1234').toBeHex({ length: 2 })).toThrow() // missing 0x
+      expect(() => expect('0x123!').toBeHex({ length: 2 })).toThrow() // invalid char
+    })
+  })
+
+  describe('combined options', () => {
+    it('should work with both strict and length options', () => {
+      expect('0x1234').toBeHex({ strict: true, length: 2 })
+      expect('0x1234').toBeHex({ strict: false, length: 2 })
+
+      expect(() => expect('0x123G').toBeHex({ strict: true, length: 2 })).toThrow()
+      expect(() => expect('0x123G').toBeHex({ strict: false, length: 3 })).toThrow()
+      expect('0x123G').toBeHex({ strict: false, length: 2 })
+    })
+  })
+
+  describe('.not modifier', () => {
+    it('should work with .not for invalid hex strings', () => {
+      [...invalidHexStrings, ...nonStringTypes].forEach(hex => {
+        expect(hex).not.toBeHex()
+      })
+    })
+
+    it('should work with .not for length mismatches', () => {
+      invalidLengthCases.forEach(({ hex, expectedLength }) => {
+        expect(hex).not.toBeHex({ length: expectedLength })
+      })
+    })
+
+    it('should fail with .not for valid hex strings', () => {
+      validHexStrings.forEach(hex => {
+        expect(() => expect(hex).not.toBeHex()).toThrow()
+      })
+    })
+
+    it('should fail with .not for valid hex strings with correct length', () => {
+      validHexStringsWithLength.forEach(({ hex, length }) => {
+        expect(() => expect(hex).not.toBeHex({ length })).toThrow()
+      })
+    })
+  })
+
+  describe('error messages', () => {
+    it('should provide helpful error messages for missing 0x prefix', () => {
+      try {
+        expect('1234').toBeHex()
+      } catch (error) {
+        expect(error.message).toContain('Expected "1234" to start with "0x"')
+      }
+    })
+
+    it('should provide helpful error messages for invalid hex characters', () => {
+      try {
+        expect('0xghij').toBeHex()
+      } catch (error) {
+        expect(error.message).toContain('contain only hex characters')
+      }
+    })
+
+    it('should provide helpful error messages for wrong length', () => {
+      try {
+        expect('0x123').toBeHex({ length: 2 })
+      } catch (error) {
+        expect(error.message).toContain('Expected "0x123" to have 2 hex characters after "0x", but got')
+      }
+    })
+
+    it('should provide different messages for different error types', () => {
+      const testCases = [
+        { input: 'hello', expectedMessage: 'start with "0x"' },
+        { input: '0xGHIJ', expectedMessage: 'contain only hex characters' },
+        { input: '0x123', options: { length: 2 }, expectedMessage: 'have 2 hex characters' },
+      ]
+
+      testCases.forEach(({ input, options, expectedMessage }) => {
+        try {
+          expect(input).toBeHex(options)
+        } catch (error) {
+          expect(error.message).toContain(expectedMessage)
+        }
+      })
+    })
+  })
+
+  describe('real-world usage patterns', () => {
+    it('should validate transaction hashes (32 bytes)', () => {
+      const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      expect(txHash).toBeHex({ length: 32 })
+    })
+
+    it('should validate block hashes (32 bytes)', () => {
+      const blockHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+      expect(blockHash).toBeHex({ length: 32 })
+    })
+
+    it('should validate addresses as hex (20 bytes)', () => {
+      const address = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
+      expect(address).toBeHex({ length: 20 })
+    })
+
+    it('should validate short identifiers', () => {
+      expect('0x1234').toBeHex({ length: 2 })
+      expect('0xabcd').toBeHex({ length: 2 })
+    })
+
+    it('should validate function selectors (4 bytes)', () => {
+      expect('0xa9059cbb').toBeHex({ length: 4 }) // transfer function selector
+      expect('0x095ea7b3').toBeHex({ length: 4 }) // approve function selector
+    })
+
+    it('should validate empty hex', () => {
+      expect('0x').toBeHex({ length: 0 })
+      expect('0x').toBeHex() // should pass without length requirement
+    })
+  })
+})

--- a/extensions/test-matchers/src/matchers/toBeHex.spec.ts
+++ b/extensions/test-matchers/src/matchers/toBeHex.spec.ts
@@ -15,14 +15,14 @@ describe('toBeHex', () => {
     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', // 64 chars (32 bytes)
   ]
 
-  const validHexStringsWithLength = [
-    { hex: '0x1234', length: 2 }, // 2 bytes
-    { hex: '0xabcd', length: 2 }, // 2 bytes
-    { hex: '0xABCD', length: 2 }, // 2 bytes
-    { hex: '0x00', length: 1 }, // 1 byte
-    { hex: '0x', length: 0 }, // 0 bytes
-    { hex: '0x123456789abcdef0', length: 8 }, // 8 bytes
-    { hex: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', length: 32 }, // 32 bytes (tx hash)
+  const validHexStringsWithSize = [
+    { hex: '0x1234', size: 2 }, // 2 bytes
+    { hex: '0xabcd', size: 2 }, // 2 bytes
+    { hex: '0xABCD', size: 2 }, // 2 bytes
+    { hex: '0x00', size: 1 }, // 1 byte
+    { hex: '0x', size: 0 }, // 0 bytes
+    { hex: '0x123456789abcdef0', size: 8 }, // 8 bytes
+    { hex: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', size: 32 }, // 32 bytes (tx hash)
   ]
 
   const invalidHexStrings = [
@@ -60,12 +60,12 @@ describe('toBeHex', () => {
     Symbol('test'),
   ]
 
-  const invalidLengthCases = [
-    { hex: '0x123', expectedLength: 2 }, // odd number of chars after 0x
-    { hex: '0x12345', expectedLength: 2 }, // too long
-    { hex: '0x1234', expectedLength: 1 }, // expecting 1 byte but got 2
-    { hex: '0x1234', expectedLength: 4 }, // expecting 4 bytes but got 2
-    { hex: '0x', expectedLength: 1 }, // expecting 1 byte but got 0
+  const invalidSizeCases = [
+    { hex: '0x123', expectedSize: 2 }, // odd number of chars after 0x
+    { hex: '0x12345', expectedSize: 2 }, // too long
+    { hex: '0x1234', expectedSize: 1 }, // expecting 1 byte but got 2
+    { hex: '0x1234', expectedSize: 4 }, // expecting 4 bytes but got 2
+    { hex: '0x', expectedSize: 1 }, // expecting 1 byte but got 0
   ]
 
   describe('default behavior (strict: true)', () => {
@@ -98,38 +98,38 @@ describe('toBeHex', () => {
     })
   })
 
-  describe('length validation', () => {
-    it('should pass for hex strings with correct length', () => {
-      validHexStringsWithLength.forEach(({ hex, length }) => {
-        expect(hex).toBeHex({ length })
-        expect(hex).toBeHex({ length, strict: true })
-        expect(hex).toBeHex({ length, strict: false })
+  describe('size validation', () => {
+    it('should pass for hex strings with correct size', () => {
+      validHexStringsWithSize.forEach(({ hex, size }) => {
+        expect(hex).toBeHex({ size })
+        expect(hex).toBeHex({ size, strict: true })
+        expect(hex).toBeHex({ size, strict: false })
       })
     })
 
-    it('should fail for hex strings with incorrect length', () => {
-      invalidLengthCases.forEach(({ hex, expectedLength }) => {
-        expect(() => expect(hex).toBeHex({ length: expectedLength })).toThrow()
-        expect(() => expect(hex).toBeHex({ length: expectedLength, strict: true })).toThrow()
-        expect(() => expect(hex).toBeHex({ length: expectedLength, strict: false })).toThrow()
+    it('should fail for hex strings with incorrect size', () => {
+      invalidSizeCases.forEach(({ hex, expectedSize }) => {
+        expect(() => expect(hex).toBeHex({ size: expectedSize })).toThrow()
+        expect(() => expect(hex).toBeHex({ size: expectedSize, strict: true })).toThrow()
+        expect(() => expect(hex).toBeHex({ size: expectedSize, strict: false })).toThrow()
       })
     })
 
-    it('should fail for invalid hex even with correct length specification', () => {
-      expect(() => expect('0xGHIJ').toBeHex({ length: 2 })).toThrow()
-      expect(() => expect('1234').toBeHex({ length: 2 })).toThrow() // missing 0x
-      expect(() => expect('0x123!').toBeHex({ length: 2 })).toThrow() // invalid char
+    it('should fail for invalid hex even with correct size specification', () => {
+      expect(() => expect('0xGHIJ').toBeHex({ size: 2 })).toThrow()
+      expect(() => expect('1234').toBeHex({ size: 2 })).toThrow() // missing 0x
+      expect(() => expect('0x123!').toBeHex({ size: 2 })).toThrow() // invalid char
     })
   })
 
   describe('combined options', () => {
-    it('should work with both strict and length options', () => {
-      expect('0x1234').toBeHex({ strict: true, length: 2 })
-      expect('0x1234').toBeHex({ strict: false, length: 2 })
+    it('should work with both strict and size options', () => {
+      expect('0x1234').toBeHex({ strict: true, size: 2 })
+      expect('0x1234').toBeHex({ strict: false, size: 2 })
 
-      expect(() => expect('0x123G').toBeHex({ strict: true, length: 2 })).toThrow()
-      expect(() => expect('0x123G').toBeHex({ strict: false, length: 3 })).toThrow()
-      expect('0x123G').toBeHex({ strict: false, length: 2 })
+      expect(() => expect('0x123G').toBeHex({ strict: true, size: 2 })).toThrow()
+      expect(() => expect('0x123G').toBeHex({ strict: false, size: 3 })).toThrow()
+      expect('0x123G').toBeHex({ strict: false, size: 2 })
     })
   })
 
@@ -140,9 +140,9 @@ describe('toBeHex', () => {
       })
     })
 
-    it('should work with .not for length mismatches', () => {
-      invalidLengthCases.forEach(({ hex, expectedLength }) => {
-        expect(hex).not.toBeHex({ length: expectedLength })
+    it('should work with .not for size mismatches', () => {
+      invalidSizeCases.forEach(({ hex, expectedSize }) => {
+        expect(hex).not.toBeHex({ size: expectedSize })
       })
     })
 
@@ -152,9 +152,9 @@ describe('toBeHex', () => {
       })
     })
 
-    it('should fail with .not for valid hex strings with correct length', () => {
-      validHexStringsWithLength.forEach(({ hex, length }) => {
-        expect(() => expect(hex).not.toBeHex({ length })).toThrow()
+    it('should fail with .not for valid hex strings with correct size', () => {
+      validHexStringsWithSize.forEach(({ hex, size }) => {
+        expect(() => expect(hex).not.toBeHex({ size })).toThrow()
       })
     })
   })
@@ -176,11 +176,11 @@ describe('toBeHex', () => {
       }
     })
 
-    it('should provide helpful error messages for wrong length', () => {
+    it('should provide helpful error messages for wrong size', () => {
       try {
-        expect('0x123').toBeHex({ length: 2 })
+        expect('0x123').toBeHex({ size: 2 })
       } catch (error) {
-        expect(error.message).toContain('Expected "0x123" to have 2 hex characters after "0x", but got')
+        expect(error.message).toContain('Expected "0x123" to have 2 bytes after "0x", but got')
       }
     })
 
@@ -188,7 +188,7 @@ describe('toBeHex', () => {
       const testCases = [
         { input: 'hello', expectedMessage: 'start with "0x"' },
         { input: '0xGHIJ', expectedMessage: 'contain only hex characters' },
-        { input: '0x123', options: { length: 2 }, expectedMessage: 'have 2 hex characters' },
+        { input: '0x123', options: { size: 2 }, expectedMessage: 'have 2 bytes' },
       ]
 
       testCases.forEach(({ input, options, expectedMessage }) => {
@@ -204,32 +204,32 @@ describe('toBeHex', () => {
   describe('real-world usage patterns', () => {
     it('should validate transaction hashes (32 bytes)', () => {
       const txHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-      expect(txHash).toBeHex({ length: 32 })
+      expect(txHash).toBeHex({ size: 32 })
     })
 
     it('should validate block hashes (32 bytes)', () => {
       const blockHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
-      expect(blockHash).toBeHex({ length: 32 })
+      expect(blockHash).toBeHex({ size: 32 })
     })
 
     it('should validate addresses as hex (20 bytes)', () => {
       const address = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
-      expect(address).toBeHex({ length: 20 })
+      expect(address).toBeHex({ size: 20 })
     })
 
     it('should validate short identifiers', () => {
-      expect('0x1234').toBeHex({ length: 2 })
-      expect('0xabcd').toBeHex({ length: 2 })
+      expect('0x1234').toBeHex({ size: 2 })
+      expect('0xabcd').toBeHex({ size: 2 })
     })
 
     it('should validate function selectors (4 bytes)', () => {
-      expect('0xa9059cbb').toBeHex({ length: 4 }) // transfer function selector
-      expect('0x095ea7b3').toBeHex({ length: 4 }) // approve function selector
+      expect('0xa9059cbb').toBeHex({ size: 4 }) // transfer function selector
+      expect('0x095ea7b3').toBeHex({ size: 4 }) // approve function selector
     })
 
     it('should validate empty hex', () => {
-      expect('0x').toBeHex({ length: 0 })
-      expect('0x').toBeHex() // should pass without length requirement
+      expect('0x').toBeHex({ size: 0 })
+      expect('0x').toBeHex() // should pass without size requirement
     })
   })
 })

--- a/extensions/test-matchers/src/matchers/toBeHex.ts
+++ b/extensions/test-matchers/src/matchers/toBeHex.ts
@@ -1,15 +1,15 @@
-import { isHex } from "viem"
+import { isHex } from 'viem'
 
 export type IsHexOptions = {
-  /**
-   * Whether to check for strict hex format or only for 0x prefix
-   * @default true
-   */
-  strict?: boolean
-  /**
-   * Optional expected size in bytes
-   */
-  size?: number
+	/**
+	 * Whether to check for strict hex format or only for 0x prefix
+	 * @default true
+	 */
+	strict?: boolean
+	/**
+	 * Optional expected size in bytes
+	 */
+	size?: number
 }
 
 /**
@@ -19,23 +19,22 @@ export type IsHexOptions = {
  * @returns Object with pass boolean and message function
  */
 export function toBeHex(received: string, opts?: IsHexOptions) {
-  const isValidHex = isHex(received, opts)
-  const receivedSize = typeof received === 'string' ? (received.length - 2) / 2 : 0
-  const isValidSize = opts?.size === undefined || receivedSize === opts.size
-  const startsWithHex = typeof received === 'string' && received.startsWith('0x')
-  const pass = isValidHex && isValidSize
+	const isValidHex = isHex(received, opts)
+	const receivedSize = typeof received === 'string' ? (received.length - 2) / 2 : 0
+	const isValidSize = opts?.size === undefined || receivedSize === opts.size
+	const startsWithHex = typeof received === 'string' && received.startsWith('0x')
+	const pass = isValidHex && isValidSize
 
-  return {
-    pass,
-    message: () => {
-      if (pass) {
-        return `Expected "${received}" not to be valid hex${opts?.size ? ` with size ${opts.size}` : ''}`
-      } else {
-        if (!startsWithHex) return `Expected "${received}" to start with "0x"`
-        if (!isValidHex) return `Expected "${received}" to contain only hex characters (0-9, a-f, A-F) after "0x"`
-        if (!isValidSize) return `Expected "${received}" to have ${opts?.size} bytes after "0x", but got ${receivedSize}`
-        return `Expected "${received}" to be valid hex${opts?.size ? ` with size ${opts.size}` : ''}`
-      }
-    },
-  }
+	return {
+		pass,
+		message: () => {
+			if (pass) {
+				return `Expected "${received}" not to be valid hex${opts?.size ? ` with size ${opts.size}` : ''}`
+			}
+			if (!startsWithHex) return `Expected "${received}" to start with "0x"`
+			if (!isValidHex) return `Expected "${received}" to contain only hex characters (0-9, a-f, A-F) after "0x"`
+			if (!isValidSize) return `Expected "${received}" to have ${opts?.size} bytes after "0x", but got ${receivedSize}`
+			return `Expected "${received}" to be valid hex${opts?.size ? ` with size ${opts.size}` : ''}`
+		},
+	}
 }

--- a/extensions/test-matchers/src/matchers/toBeHex.ts
+++ b/extensions/test-matchers/src/matchers/toBeHex.ts
@@ -7,33 +7,34 @@ export type IsHexOptions = {
    */
   strict?: boolean
   /**
-   * Optional expected length in bytes
+   * Optional expected size in bytes
    */
-  length?: number
+  size?: number
 }
 
 /**
  * Custom Vitest matcher to assert that a value is valid hex
  * @param received - The value to test
- * @param expectedLength - Optional expected length of hex characters (without 0x prefix)
+ * @param expectedSize - Optional expected size of hex characters (without 0x prefix)
  * @returns Object with pass boolean and message function
  */
 export function toBeHex(received: string, opts?: IsHexOptions) {
   const isValidHex = isHex(received, opts)
-  const isValidLength = opts?.length === undefined || (received.length % 2 === 0 && received.length === opts.length * 2 + 2)
+  const receivedSize = typeof received === 'string' ? (received.length - 2) / 2 : 0
+  const isValidSize = opts?.size === undefined || receivedSize === opts.size
   const startsWithHex = typeof received === 'string' && received.startsWith('0x')
-  const pass = isValidHex && isValidLength
+  const pass = isValidHex && isValidSize
 
   return {
     pass,
     message: () => {
       if (pass) {
-        return `Expected "${received}" not to be valid hex${opts?.length ? ` with length ${opts.length}` : ''}`
+        return `Expected "${received}" not to be valid hex${opts?.size ? ` with size ${opts.size}` : ''}`
       } else {
         if (!startsWithHex) return `Expected "${received}" to start with "0x"`
         if (!isValidHex) return `Expected "${received}" to contain only hex characters (0-9, a-f, A-F) after "0x"`
-        if (!isValidLength) return `Expected "${received}" to have ${opts?.length} hex characters after "0x", but got ${received.length}`
-        return `Expected "${received}" to be valid hex${opts?.length ? ` with length ${opts.length}` : ''}`
+        if (!isValidSize) return `Expected "${received}" to have ${opts?.size} bytes after "0x", but got ${receivedSize}`
+        return `Expected "${received}" to be valid hex${opts?.size ? ` with size ${opts.size}` : ''}`
       }
     },
   }

--- a/extensions/test-matchers/src/matchers/toBeHex.ts
+++ b/extensions/test-matchers/src/matchers/toBeHex.ts
@@ -1,0 +1,40 @@
+import { isHex } from "viem"
+
+export type IsHexOptions = {
+  /**
+   * Whether to check for strict hex format or only for 0x prefix
+   * @default true
+   */
+  strict?: boolean
+  /**
+   * Optional expected length in bytes
+   */
+  length?: number
+}
+
+/**
+ * Custom Vitest matcher to assert that a value is valid hex
+ * @param received - The value to test
+ * @param expectedLength - Optional expected length of hex characters (without 0x prefix)
+ * @returns Object with pass boolean and message function
+ */
+export function toBeHex(received: string, opts?: IsHexOptions) {
+  const isValidHex = isHex(received, opts)
+  const isValidLength = opts?.length === undefined || (received.length % 2 === 0 && received.length === opts.length * 2 + 2)
+  const startsWithHex = typeof received === 'string' && received.startsWith('0x')
+  const pass = isValidHex && isValidLength
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return `Expected "${received}" not to be valid hex${opts?.length ? ` with length ${opts.length}` : ''}`
+      } else {
+        if (!startsWithHex) return `Expected "${received}" to start with "0x"`
+        if (!isValidHex) return `Expected "${received}" to contain only hex characters (0-9, a-f, A-F) after "0x"`
+        if (!isValidLength) return `Expected "${received}" to have ${opts?.length} hex characters after "0x", but got ${received.length}`
+        return `Expected "${received}" to be valid hex${opts?.length ? ` with length ${opts.length}` : ''}`
+      }
+    },
+  }
+}

--- a/extensions/test-matchers/src/matchers/toEqualAddress.spec.ts
+++ b/extensions/test-matchers/src/matchers/toEqualAddress.spec.ts
@@ -2,68 +2,60 @@ import { describe, expect, it } from 'vitest'
 import '../index.js' // Import to extend expect with our matchers
 
 describe('toEqualAddress', () => {
-  const validAddressPairs = [
-    // Same address - different cases
-    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
-    ['0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', '0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED'],
-    ['0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'],
-    // Zero address
-    ['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000'],
-    // Max address
-    ['0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF', '0xffffffffffffffffffffffffffffffffffffffff'],
-  ]
+	const validAddressPairs = [
+		// Same address - different cases
+		['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+		['0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', '0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED'],
+		['0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'],
+		// Zero address
+		['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000'],
+		// Max address
+		['0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF', '0xffffffffffffffffffffffffffffffffffffffff'],
+	]
 
-  const differentAddressPairs = [
-    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'],
-    ['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001'],
-    ['0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35A'],
-  ]
+	const differentAddressPairs = [
+		['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'],
+		['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001'],
+		['0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35A'],
+	]
 
-  const invalidAddressPairs = [
-    ['0x123', '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
-    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0x123'],
-    ['invalid', '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
-    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 'invalid'],
-  ]
+	const invalidAddressPairs = [
+		['0x123', '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+		['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0x123'],
+		['invalid', '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+		['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 'invalid'],
+	]
 
-  it('should pass when comparing equal addresses', () => {
-  validAddressPairs.forEach(([addr1, addr2]) =>
-      expect(addr1).toEqualAddress(addr2)
-    )
-  })
+	it('should pass when comparing equal addresses', () => {
+		validAddressPairs.forEach(([addr1, addr2]) => expect(addr1).toEqualAddress(addr2))
+	})
 
-  it('should fail when comparing different addresses', () => {
-    differentAddressPairs.forEach(([addr1, addr2]) =>
-      expect(() => expect(addr1).toEqualAddress(addr2)).toThrow()
-    )
-  })
+	it('should fail when comparing different addresses', () => {
+		differentAddressPairs.forEach(([addr1, addr2]) => expect(() => expect(addr1).toEqualAddress(addr2)).toThrow())
+	})
 
-  it('should fail when comparing invalid addresses', () => {
-    invalidAddressPairs.forEach(([addr1, addr2]) =>
-      expect(() => expect(addr1).toEqualAddress(addr2)).toThrow()
-    )
-  })
+	it('should fail when comparing invalid addresses', () => {
+		invalidAddressPairs.forEach(([addr1, addr2]) => expect(() => expect(addr1).toEqualAddress(addr2)).toThrow())
+	})
 
-  it('should work with .not', () => {
-    differentAddressPairs.forEach(([addr1, addr2]) =>
-      expect(addr1).not.toEqualAddress(addr2)
-    )
-    validAddressPairs.forEach(([addr1, addr2]) =>
-      expect(() => expect(addr1).not.toEqualAddress(addr2)).toThrow()
-    )
-  })
+	it('should work with .not', () => {
+		differentAddressPairs.forEach(([addr1, addr2]) => expect(addr1).not.toEqualAddress(addr2))
+		validAddressPairs.forEach(([addr1, addr2]) => expect(() => expect(addr1).not.toEqualAddress(addr2)).toThrow())
+	})
 
-  it('should provide helpful error messages', () => {
-    try {
-      expect('0x123').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
-    } catch (error) {
-      expect(error.message).toContain('Expected "0x123" to be a valid address')
-    }
+	it('should provide helpful error messages', () => {
+		try {
+			expect('0x123').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
+		} catch (error) {
+			expect(error.message).toContain('Expected "0x123" to be a valid address')
+		}
 
-    try {
-      expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
-    } catch (error) {
-      expect(error.message).toContain('Expected "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC" to equal address "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"')
-    }
-  })
+		try {
+			expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
+		} catch (error) {
+			expect(error.message).toContain(
+				'Expected "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC" to equal address "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"',
+			)
+		}
+	})
 })

--- a/extensions/test-matchers/src/matchers/toEqualAddress.spec.ts
+++ b/extensions/test-matchers/src/matchers/toEqualAddress.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import '../index.js' // Import to extend expect with our matchers
+
+describe('toEqualAddress', () => {
+  const validAddressPairs = [
+    // Same address - different cases
+    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+    ['0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed', '0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED'],
+    ['0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'],
+    // Zero address
+    ['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000'],
+    // Max address
+    ['0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF', '0xffffffffffffffffffffffffffffffffffffffff'],
+  ]
+
+  const differentAddressPairs = [
+    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'],
+    ['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001'],
+    ['0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359', '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d35A'],
+  ]
+
+  const invalidAddressPairs = [
+    ['0x123', '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0x123'],
+    ['invalid', '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 'invalid'],
+  ]
+
+  it('should pass when comparing equal addresses', () => {
+  validAddressPairs.forEach(([addr1, addr2]) =>
+      expect(addr1).toEqualAddress(addr2)
+    )
+  })
+
+  it('should fail when comparing different addresses', () => {
+    differentAddressPairs.forEach(([addr1, addr2]) =>
+      expect(() => expect(addr1).toEqualAddress(addr2)).toThrow()
+    )
+  })
+
+  it('should fail when comparing invalid addresses', () => {
+    invalidAddressPairs.forEach(([addr1, addr2]) =>
+      expect(() => expect(addr1).toEqualAddress(addr2)).toThrow()
+    )
+  })
+
+  it('should work with .not', () => {
+    differentAddressPairs.forEach(([addr1, addr2]) =>
+      expect(addr1).not.toEqualAddress(addr2)
+    )
+    validAddressPairs.forEach(([addr1, addr2]) =>
+      expect(() => expect(addr1).not.toEqualAddress(addr2)).toThrow()
+    )
+  })
+
+  it('should provide helpful error messages', () => {
+    try {
+      expect('0x123').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
+    } catch (error) {
+      expect(error.message).toContain('Expected "0x123" to be a valid address')
+    }
+
+    try {
+      expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toEqualAddress('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
+    } catch (error) {
+      expect(error.message).toContain('Expected "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC" to equal address "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"')
+    }
+  })
+})

--- a/extensions/test-matchers/src/matchers/toEqualAddress.ts
+++ b/extensions/test-matchers/src/matchers/toEqualAddress.ts
@@ -1,4 +1,4 @@
-import { isAddress, isAddressEqual } from "viem"
+import { isAddress, isAddressEqual } from 'viem'
 
 /**
  * Custom Vitest matcher to assert that two addresses are equal
@@ -7,20 +7,19 @@ import { isAddress, isAddressEqual } from "viem"
  * @returns Object with pass boolean and message function
  */
 export function toEqualAddress(received: string, expected: string) {
-  const isAddressReceived = isAddress(received, { strict: false })
-  const isAddressExpected = isAddress(expected, { strict: false })
-  const pass = isAddressReceived && isAddressExpected && isAddressEqual(received, expected)
+	const isAddressReceived = isAddress(received, { strict: false })
+	const isAddressExpected = isAddress(expected, { strict: false })
+	const pass = isAddressReceived && isAddressExpected && isAddressEqual(received, expected)
 
-  return {
-    pass,
-    message: () => {
-      if (pass) {
-        return `Expected "${received}" not to equal address "${expected}"`
-      } else {
-        if (!isAddressReceived) return `Expected "${received}" to be a valid address`
-        if (!isAddressExpected) return `Expected "${expected}" to be a valid address`
-        return `Expected "${received}" to equal address "${expected}"`
-      }
-    },
-  }
+	return {
+		pass,
+		message: () => {
+			if (pass) {
+				return `Expected "${received}" not to equal address "${expected}"`
+			}
+			if (!isAddressReceived) return `Expected "${received}" to be a valid address`
+			if (!isAddressExpected) return `Expected "${expected}" to be a valid address`
+			return `Expected "${received}" to equal address "${expected}"`
+		},
+	}
 }

--- a/extensions/test-matchers/src/matchers/toEqualAddress.ts
+++ b/extensions/test-matchers/src/matchers/toEqualAddress.ts
@@ -1,0 +1,26 @@
+import { isAddress, isAddressEqual } from "viem"
+
+/**
+ * Custom Vitest matcher to assert that two addresses are equal
+ * @param received - The first address to compare
+ * @param expected - The second address to compare
+ * @returns Object with pass boolean and message function
+ */
+export function toEqualAddress(received: string, expected: string) {
+  const isAddressReceived = isAddress(received, { strict: false })
+  const isAddressExpected = isAddress(expected, { strict: false })
+  const pass = isAddressReceived && isAddressExpected && isAddressEqual(received, expected)
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return `Expected "${received}" not to equal address "${expected}"`
+      } else {
+        if (!isAddressReceived) return `Expected "${received}" to be a valid address`
+        if (!isAddressExpected) return `Expected "${expected}" to be a valid address`
+        return `Expected "${received}" to equal address "${expected}"`
+      }
+    },
+  }
+}

--- a/extensions/test-matchers/src/matchers/toEqualHex.spec.ts
+++ b/extensions/test-matchers/src/matchers/toEqualHex.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import '../index.js' // Import to extend expect with our matchers
+
+describe('toEqualHex', () => {
+  const validHexPairs = [
+    // Same hex - different cases
+    ['0x1234abcd', '0x1234ABCD'],
+    ['0xdeadbeef', '0xDEADBEEF'],
+    ['0x0', '0x00'],
+    ['0x', '0x'],
+    // Transaction hashes (same value, different case)
+    ['0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', '0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF'],
+    // Function selectors
+    ['0xa9059cbb', '0xA9059CBB'], // transfer(address,uint256)
+    // Addresses (should work too since they're just hex)
+    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+    // Leading zeros (normalized by default)
+    ['0x000123', '0x123'],
+    ['0x0000000000000001', '0x1'],
+  ]
+
+  const differentHexPairs = [
+    ['0x1234abcd', '0x1234abce'],
+    ['0xdeadbeef', '0xdeadbeee'],
+    ['0x0', '0x1'],
+    ['0x123', '0x124'],
+    ['0x1234567890abcdef', '0x1234567890abcdee'],
+  ]
+
+  const invalidHexPairs = [
+    ['0x123g', '0x1234'], // invalid hex char
+    ['0x1234', '0x123g'], // invalid hex char
+    ['invalid', '0x1234'], // completely invalid
+    ['0x1234', 'invalid'], // completely invalid
+    ['123', '0x1234'], // missing 0x prefix
+    ['0x1234', '123'], // missing 0x prefix
+  ]
+
+  const normalizedPairs = [
+    // These should be equal with default (normalized) comparison
+    ['0x0', '0x00'],
+    ['0x000123', '0x123'],
+    ['0x0000000000000001', '0x1'],
+    ['0x00000000', '0x0'],
+    ['0x000abc', '0xabc'],
+    ['0x000000000000000000000000000000000000000000000000000000000000001a', '0x1a'],
+  ]
+
+  const exactMismatchPairs = [
+    // These should NOT be equal with exact comparison but ARE equal with normalized
+    ['0x0', '0x00'],
+    ['0x000123', '0x123'],
+    ['0x0000000000000001', '0x1'],
+    ['0x00000000', '0x0'],
+    ['0x000abc', '0xabc'],
+  ]
+
+  it('should pass when comparing equal hex (default normalized mode)', () => {
+    validHexPairs.forEach(([hex1, hex2]) =>
+      expect(hex1).toEqualHex(hex2)
+    )
+  })
+
+  it('should fail when comparing different hex', () => {
+    differentHexPairs.forEach(([hex1, hex2]) =>
+      expect(() => expect(hex1).toEqualHex(hex2)).toThrow()
+    )
+  })
+
+  it('should fail when comparing invalid hex', () => {
+    invalidHexPairs.forEach(([hex1, hex2]) =>
+      expect(() => expect(hex1).toEqualHex(hex2)).toThrow()
+    )
+  })
+
+  describe('normalized comparison (default behavior)', () => {
+    it('should normalize leading zeros by default', () => {
+      normalizedPairs.forEach(([hex1, hex2]) => {
+        expect(hex1).toEqualHex(hex2)
+        expect(hex2).toEqualHex(hex1)
+      })
+    })
+
+    it('should normalize leading zeros with explicit exact: false', () => {
+      normalizedPairs.forEach(([hex1, hex2]) => {
+        expect(hex1).toEqualHex(hex2, { exact: false })
+        expect(hex2).toEqualHex(hex1, { exact: false })
+      })
+    })
+  })
+
+  describe('exact comparison mode', () => {
+    it('should require exact match including leading zeros when exact: true', () => {
+      exactMismatchPairs.forEach(([hex1, hex2]) => {
+        expect(() => expect(hex1).toEqualHex(hex2, { exact: true })).toThrow()
+        expect(() => expect(hex2).toEqualHex(hex1, { exact: true })).toThrow()
+      })
+    })
+
+    it('should pass when hex strings are exactly the same', () => {
+      const exactMatchPairs = [
+        ['0x1234abcd', '0x1234abcd'],
+        ['0x000123', '0x000123'],
+        ['0x0', '0x0'],
+        ['0x00', '0x00'],
+        ['0x', '0x'],
+        ['0x1234ABCD', '0x1234ABCD'], // same case
+      ]
+
+      exactMatchPairs.forEach(([hex1, hex2]) => {
+        expect(hex1).toEqualHex(hex2, { exact: true })
+      })
+    })
+
+    it('should still handle case differences in exact mode', () => {
+      const caseDifferentPairs = [
+        ['0x1234abcd', '0x1234ABCD'],
+        ['0xdeadbeef', '0xDEADBEEF'],
+        ['0x000abc', '0x000ABC'],
+      ]
+
+      caseDifferentPairs.forEach(([hex1, hex2]) => {
+        expect(hex1).toEqualHex(hex2, { exact: true })
+      })
+    })
+  })
+
+  it('should work with .not', () => {
+    differentHexPairs.forEach(([hex1, hex2]) =>
+      expect(hex1).not.toEqualHex(hex2)
+    )
+    validHexPairs.forEach(([hex1, hex2]) =>
+      expect(() => expect(hex1).not.toEqualHex(hex2)).toThrow()
+    )
+
+    // Test .not with exact mode
+    exactMismatchPairs.forEach(([hex1, hex2]) => {
+      expect(hex1).not.toEqualHex(hex2, { exact: true })
+    })
+  })
+
+  it('should provide helpful error messages', () => {
+    try {
+      expect('0x1234abcd').toEqualHex('0x1234abce')
+    } catch (error) {
+      expect(error.message).toContain('Expected "0x1234abcd" to equal hex "0x1234abce"')
+    }
+
+    try {
+      expect('0x123g').toEqualHex('0x1234')
+    } catch (error) {
+      expect(error.message).toContain('Expected "0x123g" to be a valid hex string')
+    }
+
+    try {
+      expect('0x000123').toEqualHex('0x123', { exact: true })
+    } catch (error) {
+      expect(error.message).toContain('Expected "0x000123" to equal hex "0x123"')
+    }
+  })
+
+  it('should work with real-world examples', () => {
+    // Transaction hash comparison
+    const txHash1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+    const txHash2 = '0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF'
+    expect(txHash1).toEqualHex(txHash2)
+    expect(txHash1).toEqualHex(txHash2, { exact: true }) // same length, just case difference
+
+    // Function selector comparison
+    const selector1 = '0xa9059cbb' // transfer(address,uint256)
+    const selector2 = '0xA9059CBB'
+    expect(selector1).toEqualHex(selector2)
+    expect(selector1).toEqualHex(selector2, { exact: true })
+
+    // Contract address comparison
+    const addr1 = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
+    const addr2 = '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'
+    expect(addr1).toEqualHex(addr2)
+    expect(addr1).toEqualHex(addr2, { exact: true })
+
+    // Leading zero scenarios
+    const paddedValue = '0x0000000000000000000000000000000000000000000000000000000000000001'
+    const trimmedValue = '0x1'
+    expect(paddedValue).toEqualHex(trimmedValue) // normalized (default)
+    expect(() => expect(paddedValue).toEqualHex(trimmedValue, { exact: true })).toThrow() // exact mode fails
+  })
+
+  it('should handle edge cases', () => {
+    // Empty hex
+    expect('0x').toEqualHex('0x')
+    expect('0x').toEqualHex('0x', { exact: true })
+
+    // Single byte
+    expect('0x12').toEqualHex('0x12')
+    expect('0x12').toEqualHex('0x12', { exact: true })
+
+    // Zero values with different representations
+    expect('0x0').toEqualHex('0x00') // normalized
+    expect('0x0000').toEqualHex('0x00') // normalized
+    expect(() => expect('0x0').toEqualHex('0x00', { exact: true })).toThrow() // exact fails
+    expect(() => expect('0x0000').toEqualHex('0x00', { exact: true })).toThrow() // exact fails
+  })
+})

--- a/extensions/test-matchers/src/matchers/toEqualHex.spec.ts
+++ b/extensions/test-matchers/src/matchers/toEqualHex.spec.ts
@@ -2,202 +2,195 @@ import { describe, expect, it } from 'vitest'
 import '../index.js' // Import to extend expect with our matchers
 
 describe('toEqualHex', () => {
-  const validHexPairs = [
-    // Same hex - different cases
-    ['0x1234abcd', '0x1234ABCD'],
-    ['0xdeadbeef', '0xDEADBEEF'],
-    ['0x0', '0x00'],
-    ['0x', '0x'],
-    // Transaction hashes (same value, different case)
-    ['0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', '0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF'],
-    // Function selectors
-    ['0xa9059cbb', '0xA9059CBB'], // transfer(address,uint256)
-    // Addresses (should work too since they're just hex)
-    ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
-    // Leading zeros (normalized by default)
-    ['0x000123', '0x123'],
-    ['0x0000000000000001', '0x1'],
-  ]
+	const validHexPairs = [
+		// Same hex - different cases
+		['0x1234abcd', '0x1234ABCD'],
+		['0xdeadbeef', '0xDEADBEEF'],
+		['0x0', '0x00'],
+		['0x', '0x'],
+		// Transaction hashes (same value, different case)
+		[
+			'0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+			'0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF',
+		],
+		// Function selectors
+		['0xa9059cbb', '0xA9059CBB'], // transfer(address,uint256)
+		// Addresses (should work too since they're just hex)
+		['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+		// Leading zeros (normalized by default)
+		['0x000123', '0x123'],
+		['0x0000000000000001', '0x1'],
+	]
 
-  const differentHexPairs = [
-    ['0x1234abcd', '0x1234abce'],
-    ['0xdeadbeef', '0xdeadbeee'],
-    ['0x0', '0x1'],
-    ['0x123', '0x124'],
-    ['0x1234567890abcdef', '0x1234567890abcdee'],
-  ]
+	const differentHexPairs = [
+		['0x1234abcd', '0x1234abce'],
+		['0xdeadbeef', '0xdeadbeee'],
+		['0x0', '0x1'],
+		['0x123', '0x124'],
+		['0x1234567890abcdef', '0x1234567890abcdee'],
+	]
 
-  const invalidHexPairs = [
-    ['0x123g', '0x1234'], // invalid hex char
-    ['0x1234', '0x123g'], // invalid hex char
-    ['invalid', '0x1234'], // completely invalid
-    ['0x1234', 'invalid'], // completely invalid
-    ['123', '0x1234'], // missing 0x prefix
-    ['0x1234', '123'], // missing 0x prefix
-  ]
+	const invalidHexPairs = [
+		['0x123g', '0x1234'], // invalid hex char
+		['0x1234', '0x123g'], // invalid hex char
+		['invalid', '0x1234'], // completely invalid
+		['0x1234', 'invalid'], // completely invalid
+		['123', '0x1234'], // missing 0x prefix
+		['0x1234', '123'], // missing 0x prefix
+	]
 
-  const normalizedPairs = [
-    // These should be equal with default (normalized) comparison
-    ['0x0', '0x00'],
-    ['0x000123', '0x123'],
-    ['0x0000000000000001', '0x1'],
-    ['0x00000000', '0x0'],
-    ['0x000abc', '0xabc'],
-    ['0x000000000000000000000000000000000000000000000000000000000000001a', '0x1a'],
-  ]
+	const normalizedPairs = [
+		// These should be equal with default (normalized) comparison
+		['0x0', '0x00'],
+		['0x000123', '0x123'],
+		['0x0000000000000001', '0x1'],
+		['0x00000000', '0x0'],
+		['0x000abc', '0xabc'],
+		['0x000000000000000000000000000000000000000000000000000000000000001a', '0x1a'],
+	]
 
-  const exactMismatchPairs = [
-    // These should NOT be equal with exact comparison but ARE equal with normalized
-    ['0x0', '0x00'],
-    ['0x000123', '0x123'],
-    ['0x0000000000000001', '0x1'],
-    ['0x00000000', '0x0'],
-    ['0x000abc', '0xabc'],
-  ]
+	const exactMismatchPairs = [
+		// These should NOT be equal with exact comparison but ARE equal with normalized
+		['0x0', '0x00'],
+		['0x000123', '0x123'],
+		['0x0000000000000001', '0x1'],
+		['0x00000000', '0x0'],
+		['0x000abc', '0xabc'],
+	]
 
-  it('should pass when comparing equal hex (default normalized mode)', () => {
-    validHexPairs.forEach(([hex1, hex2]) =>
-      expect(hex1).toEqualHex(hex2)
-    )
-  })
+	it('should pass when comparing equal hex (default normalized mode)', () => {
+		validHexPairs.forEach(([hex1, hex2]) => expect(hex1).toEqualHex(hex2))
+	})
 
-  it('should fail when comparing different hex', () => {
-    differentHexPairs.forEach(([hex1, hex2]) =>
-      expect(() => expect(hex1).toEqualHex(hex2)).toThrow()
-    )
-  })
+	it('should fail when comparing different hex', () => {
+		differentHexPairs.forEach(([hex1, hex2]) => expect(() => expect(hex1).toEqualHex(hex2)).toThrow())
+	})
 
-  it('should fail when comparing invalid hex', () => {
-    invalidHexPairs.forEach(([hex1, hex2]) =>
-      expect(() => expect(hex1).toEqualHex(hex2)).toThrow()
-    )
-  })
+	it('should fail when comparing invalid hex', () => {
+		invalidHexPairs.forEach(([hex1, hex2]) => expect(() => expect(hex1).toEqualHex(hex2)).toThrow())
+	})
 
-  describe('normalized comparison (default behavior)', () => {
-    it('should normalize leading zeros by default', () => {
-      normalizedPairs.forEach(([hex1, hex2]) => {
-        expect(hex1).toEqualHex(hex2)
-        expect(hex2).toEqualHex(hex1)
-      })
-    })
+	describe('normalized comparison (default behavior)', () => {
+		it('should normalize leading zeros by default', () => {
+			normalizedPairs.forEach(([hex1, hex2]) => {
+				expect(hex1).toEqualHex(hex2)
+				expect(hex2).toEqualHex(hex1)
+			})
+		})
 
-    it('should normalize leading zeros with explicit exact: false', () => {
-      normalizedPairs.forEach(([hex1, hex2]) => {
-        expect(hex1).toEqualHex(hex2, { exact: false })
-        expect(hex2).toEqualHex(hex1, { exact: false })
-      })
-    })
-  })
+		it('should normalize leading zeros with explicit exact: false', () => {
+			normalizedPairs.forEach(([hex1, hex2]) => {
+				expect(hex1).toEqualHex(hex2, { exact: false })
+				expect(hex2).toEqualHex(hex1, { exact: false })
+			})
+		})
+	})
 
-  describe('exact comparison mode', () => {
-    it('should require exact match including leading zeros when exact: true', () => {
-      exactMismatchPairs.forEach(([hex1, hex2]) => {
-        expect(() => expect(hex1).toEqualHex(hex2, { exact: true })).toThrow()
-        expect(() => expect(hex2).toEqualHex(hex1, { exact: true })).toThrow()
-      })
-    })
+	describe('exact comparison mode', () => {
+		it('should require exact match including leading zeros when exact: true', () => {
+			exactMismatchPairs.forEach(([hex1, hex2]) => {
+				expect(() => expect(hex1).toEqualHex(hex2, { exact: true })).toThrow()
+				expect(() => expect(hex2).toEqualHex(hex1, { exact: true })).toThrow()
+			})
+		})
 
-    it('should pass when hex strings are exactly the same', () => {
-      const exactMatchPairs = [
-        ['0x1234abcd', '0x1234abcd'],
-        ['0x000123', '0x000123'],
-        ['0x0', '0x0'],
-        ['0x00', '0x00'],
-        ['0x', '0x'],
-        ['0x1234ABCD', '0x1234ABCD'], // same case
-      ]
+		it('should pass when hex strings are exactly the same', () => {
+			const exactMatchPairs = [
+				['0x1234abcd', '0x1234abcd'],
+				['0x000123', '0x000123'],
+				['0x0', '0x0'],
+				['0x00', '0x00'],
+				['0x', '0x'],
+				['0x1234ABCD', '0x1234ABCD'], // same case
+			]
 
-      exactMatchPairs.forEach(([hex1, hex2]) => {
-        expect(hex1).toEqualHex(hex2, { exact: true })
-      })
-    })
+			exactMatchPairs.forEach(([hex1, hex2]) => {
+				expect(hex1).toEqualHex(hex2, { exact: true })
+			})
+		})
 
-    it('should still handle case differences in exact mode', () => {
-      const caseDifferentPairs = [
-        ['0x1234abcd', '0x1234ABCD'],
-        ['0xdeadbeef', '0xDEADBEEF'],
-        ['0x000abc', '0x000ABC'],
-      ]
+		it('should still handle case differences in exact mode', () => {
+			const caseDifferentPairs = [
+				['0x1234abcd', '0x1234ABCD'],
+				['0xdeadbeef', '0xDEADBEEF'],
+				['0x000abc', '0x000ABC'],
+			]
 
-      caseDifferentPairs.forEach(([hex1, hex2]) => {
-        expect(hex1).toEqualHex(hex2, { exact: true })
-      })
-    })
-  })
+			caseDifferentPairs.forEach(([hex1, hex2]) => {
+				expect(hex1).toEqualHex(hex2, { exact: true })
+			})
+		})
+	})
 
-  it('should work with .not', () => {
-    differentHexPairs.forEach(([hex1, hex2]) =>
-      expect(hex1).not.toEqualHex(hex2)
-    )
-    validHexPairs.forEach(([hex1, hex2]) =>
-      expect(() => expect(hex1).not.toEqualHex(hex2)).toThrow()
-    )
+	it('should work with .not', () => {
+		differentHexPairs.forEach(([hex1, hex2]) => expect(hex1).not.toEqualHex(hex2))
+		validHexPairs.forEach(([hex1, hex2]) => expect(() => expect(hex1).not.toEqualHex(hex2)).toThrow())
 
-    // Test .not with exact mode
-    exactMismatchPairs.forEach(([hex1, hex2]) => {
-      expect(hex1).not.toEqualHex(hex2, { exact: true })
-    })
-  })
+		// Test .not with exact mode
+		exactMismatchPairs.forEach(([hex1, hex2]) => {
+			expect(hex1).not.toEqualHex(hex2, { exact: true })
+		})
+	})
 
-  it('should provide helpful error messages', () => {
-    try {
-      expect('0x1234abcd').toEqualHex('0x1234abce')
-    } catch (error) {
-      expect(error.message).toContain('Expected "0x1234abcd" to equal hex "0x1234abce"')
-    }
+	it('should provide helpful error messages', () => {
+		try {
+			expect('0x1234abcd').toEqualHex('0x1234abce')
+		} catch (error) {
+			expect(error.message).toContain('Expected "0x1234abcd" to equal hex "0x1234abce"')
+		}
 
-    try {
-      expect('0x123g').toEqualHex('0x1234')
-    } catch (error) {
-      expect(error.message).toContain('Expected "0x123g" to be a valid hex string')
-    }
+		try {
+			expect('0x123g').toEqualHex('0x1234')
+		} catch (error) {
+			expect(error.message).toContain('Expected "0x123g" to be a valid hex string')
+		}
 
-    try {
-      expect('0x000123').toEqualHex('0x123', { exact: true })
-    } catch (error) {
-      expect(error.message).toContain('Expected "0x000123" to equal hex "0x123"')
-    }
-  })
+		try {
+			expect('0x000123').toEqualHex('0x123', { exact: true })
+		} catch (error) {
+			expect(error.message).toContain('Expected "0x000123" to equal hex "0x123"')
+		}
+	})
 
-  it('should work with real-world examples', () => {
-    // Transaction hash comparison
-    const txHash1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-    const txHash2 = '0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF'
-    expect(txHash1).toEqualHex(txHash2)
-    expect(txHash1).toEqualHex(txHash2, { exact: true }) // same length, just case difference
+	it('should work with real-world examples', () => {
+		// Transaction hash comparison
+		const txHash1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+		const txHash2 = '0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF'
+		expect(txHash1).toEqualHex(txHash2)
+		expect(txHash1).toEqualHex(txHash2, { exact: true }) // same length, just case difference
 
-    // Function selector comparison
-    const selector1 = '0xa9059cbb' // transfer(address,uint256)
-    const selector2 = '0xA9059CBB'
-    expect(selector1).toEqualHex(selector2)
-    expect(selector1).toEqualHex(selector2, { exact: true })
+		// Function selector comparison
+		const selector1 = '0xa9059cbb' // transfer(address,uint256)
+		const selector2 = '0xA9059CBB'
+		expect(selector1).toEqualHex(selector2)
+		expect(selector1).toEqualHex(selector2, { exact: true })
 
-    // Contract address comparison
-    const addr1 = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
-    const addr2 = '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'
-    expect(addr1).toEqualHex(addr2)
-    expect(addr1).toEqualHex(addr2, { exact: true })
+		// Contract address comparison
+		const addr1 = '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
+		const addr2 = '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'
+		expect(addr1).toEqualHex(addr2)
+		expect(addr1).toEqualHex(addr2, { exact: true })
 
-    // Leading zero scenarios
-    const paddedValue = '0x0000000000000000000000000000000000000000000000000000000000000001'
-    const trimmedValue = '0x1'
-    expect(paddedValue).toEqualHex(trimmedValue) // normalized (default)
-    expect(() => expect(paddedValue).toEqualHex(trimmedValue, { exact: true })).toThrow() // exact mode fails
-  })
+		// Leading zero scenarios
+		const paddedValue = '0x0000000000000000000000000000000000000000000000000000000000000001'
+		const trimmedValue = '0x1'
+		expect(paddedValue).toEqualHex(trimmedValue) // normalized (default)
+		expect(() => expect(paddedValue).toEqualHex(trimmedValue, { exact: true })).toThrow() // exact mode fails
+	})
 
-  it('should handle edge cases', () => {
-    // Empty hex
-    expect('0x').toEqualHex('0x')
-    expect('0x').toEqualHex('0x', { exact: true })
+	it('should handle edge cases', () => {
+		// Empty hex
+		expect('0x').toEqualHex('0x')
+		expect('0x').toEqualHex('0x', { exact: true })
 
-    // Single byte
-    expect('0x12').toEqualHex('0x12')
-    expect('0x12').toEqualHex('0x12', { exact: true })
+		// Single byte
+		expect('0x12').toEqualHex('0x12')
+		expect('0x12').toEqualHex('0x12', { exact: true })
 
-    // Zero values with different representations
-    expect('0x0').toEqualHex('0x00') // normalized
-    expect('0x0000').toEqualHex('0x00') // normalized
-    expect(() => expect('0x0').toEqualHex('0x00', { exact: true })).toThrow() // exact fails
-    expect(() => expect('0x0000').toEqualHex('0x00', { exact: true })).toThrow() // exact fails
-  })
+		// Zero values with different representations
+		expect('0x0').toEqualHex('0x00') // normalized
+		expect('0x0000').toEqualHex('0x00') // normalized
+		expect(() => expect('0x0').toEqualHex('0x00', { exact: true })).toThrow() // exact fails
+		expect(() => expect('0x0000').toEqualHex('0x00', { exact: true })).toThrow() // exact fails
+	})
 })

--- a/extensions/test-matchers/src/matchers/toEqualHex.ts
+++ b/extensions/test-matchers/src/matchers/toEqualHex.ts
@@ -1,0 +1,59 @@
+import { isHex, hexToBytes, trim } from "viem"
+import { equalsBytes } from "@tevm/utils"
+
+export type EqualHexOptions = {
+  /**
+   * Whether to compare hex strings exactly as written or normalize them first.
+   * When false (default), leading zeros are trimmed before byte comparison (e.g., "0x00123" equals "0x123").
+   * When true, hex strings must match exactly including leading zeros.
+   * @default false
+   */
+  exact?: boolean
+}
+
+/**
+ * Custom Vitest matcher to assert that two hex strings are equal (after converting to bytes)
+ * @param received - The first hex string to compare
+ * @param expected - The second hex string to compare
+ * @param opts - Options for comparison behavior
+ * @returns Object with pass boolean and message function
+ */
+export function toEqualHex(received: string, expected: string, opts?: EqualHexOptions) {
+  // First validate both are valid hex strings
+  const isHexReceived = isHex(received, { strict: true })
+  const isHexExpected = isHex(expected, { strict: true })
+
+  if (!isHexReceived || !isHexExpected) {
+    return {
+      pass: false,
+      message: () => {
+        if (!isHexReceived) return `Expected "${received}" to be a valid hex string`
+        if (!isHexExpected) return `Expected "${expected}" to be a valid hex string`
+        return `Expected "${received}" to equal hex "${expected}"`
+      },
+    }
+  }
+
+  let pass: boolean
+
+  if (opts?.exact) {
+    // For exact comparison, compare strings directly (case-insensitive)
+    pass = received.toLowerCase() === expected.toLowerCase()
+  } else {
+    // For normalized comparison, trim leading zeros and compare bytes
+    const receivedBytes = hexToBytes(trim(received))
+    const expectedBytes = hexToBytes(trim(expected))
+    pass = equalsBytes(receivedBytes, expectedBytes)
+  }
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return `Expected "${received}" not to equal hex "${expected}"`
+      } else {
+        return `Expected "${received}" to equal hex "${expected}"`
+      }
+    },
+  }
+}

--- a/extensions/test-matchers/src/matchers/toEqualHex.ts
+++ b/extensions/test-matchers/src/matchers/toEqualHex.ts
@@ -1,14 +1,14 @@
-import { isHex, hexToBytes, trim } from "viem"
-import { equalsBytes } from "@tevm/utils"
+import { equalsBytes } from '@tevm/utils'
+import { hexToBytes, isHex, trim } from 'viem'
 
 export type EqualHexOptions = {
-  /**
-   * Whether to compare hex strings exactly as written or normalize them first.
-   * When false (default), leading zeros are trimmed before byte comparison (e.g., "0x00123" equals "0x123").
-   * When true, hex strings must match exactly including leading zeros.
-   * @default false
-   */
-  exact?: boolean
+	/**
+	 * Whether to compare hex strings exactly as written or normalize them first.
+	 * When false (default), leading zeros are trimmed before byte comparison (e.g., "0x00123" equals "0x123").
+	 * When true, hex strings must match exactly including leading zeros.
+	 * @default false
+	 */
+	exact?: boolean
 }
 
 /**
@@ -19,41 +19,40 @@ export type EqualHexOptions = {
  * @returns Object with pass boolean and message function
  */
 export function toEqualHex(received: string, expected: string, opts?: EqualHexOptions) {
-  // First validate both are valid hex strings
-  const isHexReceived = isHex(received, { strict: true })
-  const isHexExpected = isHex(expected, { strict: true })
+	// First validate both are valid hex strings
+	const isHexReceived = isHex(received, { strict: true })
+	const isHexExpected = isHex(expected, { strict: true })
 
-  if (!isHexReceived || !isHexExpected) {
-    return {
-      pass: false,
-      message: () => {
-        if (!isHexReceived) return `Expected "${received}" to be a valid hex string`
-        if (!isHexExpected) return `Expected "${expected}" to be a valid hex string`
-        return `Expected "${received}" to equal hex "${expected}"`
-      },
-    }
-  }
+	if (!isHexReceived || !isHexExpected) {
+		return {
+			pass: false,
+			message: () => {
+				if (!isHexReceived) return `Expected "${received}" to be a valid hex string`
+				if (!isHexExpected) return `Expected "${expected}" to be a valid hex string`
+				return `Expected "${received}" to equal hex "${expected}"`
+			},
+		}
+	}
 
-  let pass: boolean
+	let pass: boolean
 
-  if (opts?.exact) {
-    // For exact comparison, compare strings directly (case-insensitive)
-    pass = received.toLowerCase() === expected.toLowerCase()
-  } else {
-    // For normalized comparison, trim leading zeros and compare bytes
-    const receivedBytes = hexToBytes(trim(received))
-    const expectedBytes = hexToBytes(trim(expected))
-    pass = equalsBytes(receivedBytes, expectedBytes)
-  }
+	if (opts?.exact) {
+		// For exact comparison, compare strings directly (case-insensitive)
+		pass = received.toLowerCase() === expected.toLowerCase()
+	} else {
+		// For normalized comparison, trim leading zeros and compare bytes
+		const receivedBytes = hexToBytes(trim(received))
+		const expectedBytes = hexToBytes(trim(expected))
+		pass = equalsBytes(receivedBytes, expectedBytes)
+	}
 
-  return {
-    pass,
-    message: () => {
-      if (pass) {
-        return `Expected "${received}" not to equal hex "${expected}"`
-      } else {
-        return `Expected "${received}" to equal hex "${expected}"`
-      }
-    },
-  }
+	return {
+		pass,
+		message: () => {
+			if (pass) {
+				return `Expected "${received}" not to equal hex "${expected}"`
+			}
+			return `Expected "${received}" to equal hex "${expected}"`
+		},
+	}
 }

--- a/extensions/test-matchers/vitest.config.ts
+++ b/extensions/test-matchers/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
 		environment: 'node',
 		globals: true,
 		setupFiles: [],
+		include: ['**/*.spec.ts'],
 	},
 })


### PR DESCRIPTION
See #1747 for full package overview and plan.

## Description

Add basic matchers and tests:
- `expect().toBeBigInt()`
- `expect().toBeHex()`
- `expect().toBeAddress()`
- `expect().toEqualHex()`
- `expect().toEqualAddress()`