### PR TITLE
🔧 fix: Add missing EVM module entrypoint and logger stub

### DIFF
--- a/src/evm/evm.zig
+++ b/src/evm/evm.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+// Import all EVM modules
+pub const CodeAnalysis = @import("CodeAnalysis.zig");
+pub const Contract = @import("Contract.zig");
+pub const ExecutionError = @import("ExecutionError.zig");
+pub const Frame = @import("Frame.zig");
+pub const Hardfork = @import("Hardfork.zig");
+pub const JumpTable = @import("JumpTable.zig");
+pub const Memory = @import("Memory.zig");
+pub const Opcode = @import("Opcode.zig");
+pub const Operation = @import("Operation.zig");
+pub const Stack = @import("Stack.zig");
+pub const StoragePool = @import("StoragePool.zig");
+pub const Vm = @import("Vm.zig");
+
+// Import utility modules
+pub const bitvec = @import("bitvec.zig");
+pub const chain_rules = @import("chain_rules.zig");
+pub const constants = @import("constants.zig");
+pub const eip_7702_bytecode = @import("eip_7702_bytecode.zig");
+pub const fee_market = @import("fee_market.zig");
+pub const gas_constants = @import("gas_constants.zig");
+
+// Tests - run all module tests
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}

--- a/src/ui/assets.zig
+++ b/src/ui/assets.zig
@@ -57,11 +57,6 @@ pub const assets = [_]Self{
         "text/css",
     ),
     Self.init(
-        "/assets/logo-BKhbptE1.svg",
-        @embedFile("dist/assets/logo-BKhbptE1.svg"),
-        "image/svg+xml",
-    ),
-    Self.init(
         "/tauri.svg",
         @embedFile("dist/tauri.svg"),
         "image/svg+xml",


### PR DESCRIPTION
## Description

Added initial EVM module structure with a stub logger implementation. The PR introduces:

1. `EvmLogger.zig` with basic logging functionality (debug, info, warn) and scoped logging
2. `evm.zig` as the main entry point that imports and exposes all EVM-related modules
3. Removed an unused logo asset from the UI assets list

## Testing

The code includes a test block in `evm.zig` that will recursively test all declarations in the module. The logger implementation is currently stubbed with TODOs for future implementation.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: