### PR TITLE
feat: @tevm/test-matchers - Chainable vitest matchers

### DIFF
--- a/extensions/test-matchers/src/chainable/chainable.spec.ts
+++ b/extensions/test-matchers/src/chainable/chainable.spec.ts
@@ -1,0 +1,236 @@
+import { assert, describe, expect, it } from 'vitest'
+import { toBeAddress, toBeHex } from '../matchers/utils/index.js'
+import { createChainableFromVitest, registerChainableMatchers } from './chainable.js'
+import type { ChainState, ChainableAssertion } from './types.js'
+
+/* ---------------------------------- TYPES --------------------------------- */
+export interface CustomMatchers {
+	/**
+	 * Assert that a value is a bigint
+	 */
+	toBeBigIntChainable(): ChainableAssertion
+
+	/**
+	 * Assert that a value is a hex string
+	 */
+	toBeHexChainable(): ChainableAssertion
+
+	/**
+	 * Assert that a value is an address
+	 */
+	toBeAddressChainable(): ChainableAssertion
+
+	/**
+	 * Assert and return state
+	 */
+	toPassDownStateChainable(a: unknown, b: unknown): ChainableAssertion
+
+	/**
+	 * Assert that previous state was passed correctly
+	 */
+	toUsePreviousStateAndBigIntChainable(): ChainableAssertion
+
+	/**
+	 * Assert that a promise resolves to a string (async)
+	 */
+	toResolveToStringChainable(): ChainableAssertion
+}
+
+// Augment vitest's Assertion - this preserves ALL existing functionality including 'not'
+declare module 'vitest' {
+	interface Assertion<T = any> extends CustomMatchers {}
+}
+
+/* ----------------------------- VITEST MATCHERS ---------------------------- */
+type ToPassDownStateState = {
+	a: unknown
+	b: unknown
+	originalValue: unknown
+}
+
+// State-aware vitest matcher for testing
+const toPassDownState = (received: unknown, a: unknown, b: unknown) => {
+	const pass = true
+	return {
+		pass,
+		actual: received,
+		expected: 'anything',
+		message: () => '',
+		state: { a, b, originalValue: received } satisfies ToPassDownStateState,
+	}
+}
+
+// Chained matcher that uses previous state - simplified ChainState signature
+const toUsePreviousStateAndBigInt = (received: unknown, chainState?: ChainState<unknown, ToPassDownStateState>) => {
+	const { previousState, previousArgs } = chainState ?? {}
+	// We want the state to be preserved regardless of pass or not (it should pass even with a not. modifier)
+	assert(
+		received !== undefined &&
+			previousState?.a !== undefined &&
+			previousState.b !== undefined &&
+			previousArgs !== undefined &&
+			received === previousState?.originalValue,
+		'State was not correctly preserved',
+	)
+	const pass = typeof received === 'bigint'
+	return {
+		pass,
+		actual: received,
+		expected: pass ? 'a bigint' : 'not a bigint',
+		message: () =>
+			pass
+				? "State and args properly passed but didn't receive a bigint"
+				: 'State and args properly passed but received a bigint',
+	}
+}
+
+// Add this async vitest matcher
+const toResolveToString = async (received: Promise<unknown>) => {
+	try {
+		const resolved = await received
+		const pass = typeof resolved === 'string'
+		return {
+			pass,
+			actual: resolved,
+			expected: 'a string',
+			message: () =>
+				pass
+					? `Expected promise not to resolve to a string but got: ${resolved}`
+					: `Expected promise to resolve to a string but got: ${typeof resolved}`,
+			state: { resolved, wasAsync: true },
+		}
+	} catch (error) {
+		return {
+			pass: false,
+			actual: error,
+			expected: 'a resolved promise',
+			message: () => `Expected promise to resolve but it rejected with: ${error}`,
+		}
+	}
+}
+
+/* ----------------------------- CHAINABLE MATCHERS ---------------------------- */
+// Create a vitest matcher and convert it inline
+const toBeBigIntChainable = createChainableFromVitest({
+	name: 'toBeBigIntChainable' as const,
+	vitestMatcher: (received: unknown) => {
+		const pass = typeof received === 'bigint'
+		return {
+			pass,
+			actual: received,
+			expected: 'a bigint',
+			message: () => (pass ? `Expected ${received} not to be a BigInt` : `Expected ${received} to be a BigInt`),
+		}
+	},
+})
+
+// Convert existing util matchers to chainable
+const toBeHexChainable = createChainableFromVitest({
+	name: 'toBeHexChainable' as const,
+	vitestMatcher: toBeHex,
+})
+
+const toBeAddressChainable = createChainableFromVitest({
+	name: 'toBeAddressChainable' as const,
+	vitestMatcher: toBeAddress,
+})
+
+// State-testing matchers - no more chainFrom needed
+const toPassDownStateChainable = createChainableFromVitest({
+	name: 'toPassDownStateChainable' as const,
+	vitestMatcher: toPassDownState,
+})
+
+const toUsePreviousStateAndBigIntChainable = createChainableFromVitest({
+	name: 'toUsePreviousStateAndBigIntChainable' as const,
+	vitestMatcher: toUsePreviousStateAndBigInt,
+})
+
+// Create the async chainable matcher
+const toResolveToStringChainable = createChainableFromVitest({
+	name: 'toResolveToStringChainable' as const,
+	vitestMatcher: toResolveToString,
+})
+
+// Register all test matchers
+export const testMatchers = {
+	toBeBigIntChainable,
+	toBeHexChainable,
+	toBeAddressChainable,
+	toPassDownStateChainable,
+	toUsePreviousStateAndBigIntChainable,
+	toResolveToStringChainable,
+}
+
+registerChainableMatchers(testMatchers)
+
+/* ----------------------------- TESTING ----------------------------- */
+describe('chainable matchers', () => {
+	it('work standalone', () => {
+		expect(123n).toBeBigIntChainable()
+		expect('0x123').toBeHexChainable()
+		expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toBeAddressChainable()
+	})
+
+	it('chaining and negation work seamlessly', () => {
+		// Chain multiple matchers
+		expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toBeHexChainable().toBeAddressChainable()
+
+		// Use 'not' with chaining
+		expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toBeAddressChainable().not.toBeBigIntChainable()
+		expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC')
+			.not.toBeBigIntChainable()
+			// negation gets reset after each chainable call
+			.toBeAddressChainable()
+			.toBeHexChainable()
+		expect('not a bigint').not.toBeBigIntChainable().not.toBeHexChainable()
+	})
+
+	it('state passing between vitest matchers', () => {
+		expect(5n)
+			.toPassDownStateChainable(1n, 2n)
+			.toUsePreviousStateAndBigIntChainable()
+			.toBeBigIntChainable()
+			.not.toBeHexChainable()
+		expect(5).toPassDownStateChainable(1n, 2n).not.toUsePreviousStateAndBigIntChainable()
+	})
+
+	it('error handling', () => {
+		expect(() => expect(5).toBeBigIntChainable()).toThrow('Expected 5 to be a BigInt')
+		expect(() => expect(5n).not.toBeBigIntChainable()).toThrow('Expected 5 not to be a BigInt')
+		expect(() => expect('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC').toBeHexChainable().toBeBigIntChainable()).toThrow(
+			'Expected 0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC to be a BigInt',
+		)
+		expect(() => expect('invalid address').not.toBeBigIntChainable().toBeAddressChainable()).toThrow(
+			'Expected invalid address to be a valid Ethereum address (checksummed)',
+		)
+		expect(() =>
+			expect(5n).toPassDownStateChainable(1n, 2n).toUsePreviousStateAndBigIntChainable().not.toBeBigIntChainable(),
+		).toThrow('Expected 5 not to be a BigInt')
+	})
+
+	it('async matchers work correctly', async () => {
+		// Test async matcher standalone
+		await expect(Promise.resolve('hello')).toResolveToStringChainable()
+
+		// Test async with negation
+		await expect(Promise.resolve(123)).not.toResolveToStringChainable()
+
+		// Test async with chaining
+		await expect(Promise.resolve('0x123')).toResolveToStringChainable().toBeHexChainable()
+	})
+
+	it('async error handling', async () => {
+		await expect(() => expect(Promise.resolve(123)).toResolveToStringChainable()).rejects.toThrow(
+			'Expected promise to resolve to a string but got: number',
+		)
+
+		await expect(() => expect(Promise.resolve('hello')).not.toResolveToStringChainable()).rejects.toThrow(
+			'Expected promise not to resolve to a string but got: hello',
+		)
+
+		await expect(() =>
+			expect(Promise.resolve('hello')).toResolveToStringChainable().toBeHexChainable(),
+		).rejects.toThrow('Expected hello to start with "0x"')
+	})
+})

--- a/extensions/test-matchers/src/chainable/chainable.ts
+++ b/extensions/test-matchers/src/chainable/chainable.ts
@@ -1,0 +1,290 @@
+import { assert, type Assertion, chai, expect } from 'vitest'
+import type {
+	ChaiContext,
+	ChaiStatic,
+	ChaiUtils,
+	ChainState,
+	ChainableAssertion,
+	ExtractVitestArgs,
+	InferredVitestChainableResult,
+	IsAsync,
+	MatcherResult,
+	VitestMatcherConfig,
+	VitestMatcherFunction,
+} from './types.js'
+
+let chaiUtils: ChaiUtils | undefined = undefined
+export const getChaiUtils = () => chaiUtils
+
+// Promise setup helper (waffle-chai pattern)
+const setupPromise = (assertion: Assertion, utils: ChaiUtils): void => {
+	const existingPromise = utils.flag(assertion, 'callPromise')
+	if (existingPromise) return
+
+	const obj = utils.flag(assertion, 'object')
+	if (obj && typeof obj.then === 'function') {
+		utils.flag(assertion, 'callPromise', obj)
+	} else {
+		utils.flag(assertion, 'callPromise', Promise.resolve())
+	}
+}
+
+const isAsyncMatcher = <TReceived, TState>(
+	matcher: VitestMatcherFunction<TReceived, boolean, TState>,
+): matcher is VitestMatcherFunction<TReceived, true, TState> => {
+	return matcher.constructor.name === 'AsyncFunction'
+}
+
+// Build chain state from flags - automatically detect any previous matcher
+const buildChainState = (assertion: Assertion, utils: ChaiUtils): ChainState => {
+	// Get the chain history from a dedicated flag
+	const chainHistory: string[] = utils.flag(assertion, 'chainHistory') || []
+
+	if (chainHistory.length === 0) {
+		return {
+			chainedFrom: undefined,
+			previousPassed: undefined,
+			previousValue: undefined,
+			previousState: undefined,
+			previousArgs: undefined,
+		}
+	}
+
+	// Use the most recent chained matcher
+	const matcherName = chainHistory[chainHistory.length - 1]
+
+	// For async matchers, use the current object (which gets updated)
+	// rather than the stored value (which might be a Promise)
+	let previousValue = utils.flag(assertion, `${matcherName}.value`)
+	const currentObj = utils.flag(assertion, 'object')
+	// If the stored value is a Promise but current object is resolved, use current object
+	if (previousValue && typeof previousValue.then === 'function' && currentObj !== previousValue)
+		previousValue = currentObj
+
+	const state = {
+		chainedFrom: matcherName,
+		previousPassed: utils.flag(assertion, `${matcherName}.passed`),
+		previousValue,
+		previousState: utils.flag(assertion, `${matcherName}.state`),
+		previousArgs: utils.flag(assertion, `${matcherName}.args`),
+	}
+
+	return state
+}
+
+// Used to fail an assertion in chai with vitest highlighting and trace
+const createInternalResultHandler = () => {
+	return {
+		__expectResult: function (this: any, result: MatcherResult, isNegated: boolean) {
+			assert(chaiUtils !== undefined, 'ChaiUtils not initialized')
+			const shouldFail = isNegated ? result.pass : !result.pass
+
+			if (shouldFail) {
+				return {
+					pass: false,
+					message: () => result.message(),
+					actual: result.actual,
+					expected: result.expected,
+				}
+			}
+
+			return { pass: true, message: () => result.message() }
+		},
+	}
+}
+
+const expectResult = (result: MatcherResult, isNegated: boolean) => {
+	;(
+		expect(result) as unknown as {
+			__expectResult: (isNegated: boolean) => MatcherResult
+		}
+	).__expectResult(isNegated)
+}
+
+// Only extract truly common parts
+const storeChainState = <TName extends string, TAsync extends boolean = false>(
+	assertion: ChaiContext<TAsync>,
+	utils: ChaiUtils,
+	name: TName,
+	obj: unknown,
+	args: readonly unknown[],
+	result: MatcherResult,
+) => {
+	utils.flag(assertion, `${name}.passed`, result.pass)
+	utils.flag(assertion, `${name}.value`, obj)
+	utils.flag(assertion, `${name}.state`, result.state)
+	utils.flag(assertion, `${name}.args`, args)
+
+	// Track chain history
+	const chainHistory: string[] = utils.flag(assertion, 'chainHistory') ?? []
+	chainHistory.push(name)
+	utils.flag(assertion, 'chainHistory', chainHistory)
+}
+
+export const parseChainArgs = <TData = unknown, TState = unknown>(args: readonly unknown[]) => {
+	const argsWithoutChainState = args.slice(0, -1)
+	const chainState = args[args.length - 1]
+	assert(
+		chainState && typeof chainState === 'object' && 'chainedFrom' in chainState,
+		'Internal error: no chain state found',
+	)
+	return { args: argsWithoutChainState, chainState: chainState as ChainState<TData, TState> }
+}
+
+// Vitest matcher wrapper for sync matchers
+function makeVitestSyncChainable<
+	TName extends string,
+	TArgs extends readonly unknown[],
+	TReceived,
+	TAsync extends boolean,
+	TState,
+>(
+	this: ChaiContext<false>,
+	name: TName,
+	vitestMatcher: VitestMatcherFunction<TReceived, TAsync, TState>,
+	args: TArgs,
+): Assertion {
+	assert(chaiUtils !== undefined, 'ChaiUtils not initialized')
+
+	// Check if we're in an async chain
+	const callPromise = chaiUtils.flag(this, 'callPromise')
+	if (callPromise && typeof callPromise.then === 'function') {
+		// We're chaining after an async matcher - join the promise chain
+		return makeVitestAsyncChainable.call(this, name, vitestMatcher as VitestMatcherFunction, args)
+	}
+
+	const obj = chaiUtils.flag(this, 'object')
+	const chainState = buildChainState(this, chaiUtils)
+
+	// Capture and reset negation flag (sync pattern)
+	const isNegated = chaiUtils.flag(this, 'negate') === true
+	chaiUtils.flag(this, 'negate', false)
+
+	const result = vitestMatcher(obj as TReceived, ...args, chainState) as MatcherResult<TState>
+	expectResult(result, isNegated)
+
+	storeChainState(this, chaiUtils, name, obj, args, result)
+	return this
+}
+
+// Vitest matcher wrapper for async matchers
+function makeVitestAsyncChainable<
+	TName extends string,
+	TArgs extends readonly unknown[],
+	TReceived,
+	TAsync extends boolean,
+	TState,
+>(
+	this: ChaiContext<true>,
+	name: TName,
+	vitestMatcher: VitestMatcherFunction<TReceived, TAsync, TState>,
+	args: TArgs,
+): ChainableAssertion {
+	assert(chaiUtils !== undefined, 'ChaiUtils not initialized')
+
+	setupPromise(this, chaiUtils)
+	const isNegated = chaiUtils.flag(this, 'negate') === true
+
+	// Get the current object (might be a Promise)
+	const obj = chaiUtils.flag(this, 'object')
+
+	const callPromiseValue = chaiUtils.flag(this, 'callPromise')
+	const derivedPromise = callPromiseValue.then(async () => {
+		assert(chaiUtils !== undefined, 'ChaiUtils not initialized')
+		const actualObj = await obj
+
+		// Update object with resolved value for further chaining
+		chaiUtils.flag(this, 'object', actualObj)
+
+		// Build chain state AFTER promise resolves, but BEFORE updating history
+		// This ensures we get the fully populated state from previous matchers
+		const chainState = buildChainState(this, chaiUtils)
+
+		// Store and restore negation flag properly (async pattern)
+		const currentNegated = chaiUtils.flag(this, 'negate') === true
+		chaiUtils.flag(this, 'negate', isNegated)
+
+		const result = await (vitestMatcher(actualObj as TReceived, ...args, chainState) as Promise<MatcherResult<TState>>)
+
+		expectResult(result, isNegated)
+
+		// Restore negation flag
+		chaiUtils.flag(this, 'negate', currentNegated)
+
+		// Store the results for future chained matchers
+		storeChainState(this, chaiUtils, name, actualObj, args, result)
+	})
+
+	// Make thenable (waffle-chai pattern)
+	this.then = derivedPromise.then.bind(derivedPromise)
+	this.catch = derivedPromise.catch.bind(derivedPromise)
+	chaiUtils.flag(this, 'callPromise', derivedPromise)
+
+	return this as unknown as ChainableAssertion
+}
+
+// Convert existing vitest matcher to chainable with perfect type inference
+export const createChainableFromVitest = <
+	TName extends string,
+	TReceived = any,
+	TState = unknown,
+	TMatcher extends VitestMatcherFunction<TReceived, boolean, TState> = VitestMatcherFunction<
+		TReceived,
+		boolean,
+		TState
+	>,
+>(config: {
+	name: TName
+	vitestMatcher: TMatcher
+}) => {
+	const { name, vitestMatcher } = config
+	const isAsync = isAsyncMatcher(vitestMatcher)
+
+	return {
+		name,
+		isAsync,
+		methodFunction: function (this: ChaiContext, ...args: ExtractVitestArgs<typeof vitestMatcher>) {
+			if (isAsync) {
+				return (makeVitestAsyncChainable<TName, ExtractVitestArgs<typeof vitestMatcher>, TReceived, true, TState>).call(
+					this,
+					name,
+					vitestMatcher as VitestMatcherFunction<TReceived, true, TState>,
+					args,
+				)
+			}
+			return (makeVitestSyncChainable<TName, ExtractVitestArgs<typeof vitestMatcher>, TReceived, false, TState>).call(
+				this as ChaiContext<false>,
+				name,
+				vitestMatcher as VitestMatcherFunction<TReceived, false, TState>,
+				args as ExtractVitestArgs<typeof vitestMatcher>,
+			)
+		},
+		chainFunction: function (this: ChaiContext): Assertion {
+			assert(chaiUtils !== undefined, 'ChaiUtils not initialized')
+			chaiUtils.flag(this, `${name}.chained`, true)
+			return this
+		},
+	} as InferredVitestChainableResult<VitestMatcherConfig<TName, TReceived, IsAsync<TMatcher>, TState>>
+}
+
+// Plugin creator with context-aware registration
+export const createChainablePlugin = (
+	matchers: Record<string, InferredVitestChainableResult<VitestMatcherConfig<string, any, boolean, any>>>,
+) => {
+	return (_chai: ChaiStatic, utils: ChaiUtils) => {
+		// Store utils reference
+		chaiUtils = utils
+
+		Object.entries(matchers).forEach(([_, matcher]) => {
+			utils.addChainableMethod(_chai.Assertion.prototype, matcher.name, matcher.methodFunction, matcher.chainFunction)
+		})
+	}
+}
+
+// Convenience function to register chainable matchers
+export const registerChainableMatchers = (
+	matchers: Record<string, InferredVitestChainableResult<VitestMatcherConfig<string, any, boolean, any>>>,
+): void => {
+	expect.extend(createInternalResultHandler())
+	chai.use(createChainablePlugin(matchers))
+}

--- a/extensions/test-matchers/src/chainable/chainable.type-spec.ts
+++ b/extensions/test-matchers/src/chainable/chainable.type-spec.ts
@@ -1,0 +1,247 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { Assertion } from 'vitest'
+import { toBeAddress, toBeHex } from '../matchers/utils/index.js'
+import { createChainableFromVitest } from './chainable.js'
+import { type CustomMatchers, testMatchers } from './chainable.spec.js'
+import type {
+	ChainState,
+	ChainableAssertion,
+	InferredVitestChainableResult,
+	MatcherResult,
+	VitestMatcherConfig,
+	VitestMatcherFunction,
+} from './types.js'
+
+// Import existing chainable matchers from spec
+const {
+	toBeBigIntChainable,
+	toBeHexChainable,
+	toBeAddressChainable,
+	toPassDownStateChainable,
+	toUsePreviousStateAndBigIntChainable,
+	toResolveToStringChainable,
+} = testMatchers
+
+// Remove the separate asyncMatcher and asyncChainable - use the shared one
+
+describe('chainable type system (exhaustive)', () => {
+	it('type: basic configuration inference', () => {
+		// Test real matcher config inference
+		expectTypeOf<typeof toBeBigIntChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toBeBigIntChainable', unknown, false, unknown>>
+		>()
+
+		expectTypeOf<typeof toBeHexChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toBeHexChainable', unknown, false, unknown>>
+		>()
+
+		expectTypeOf<typeof toBeAddressChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toBeAddressChainable', unknown, false, unknown>>
+		>()
+
+		expectTypeOf<typeof toResolveToStringChainable>().toExtend<
+			InferredVitestChainableResult<
+				VitestMatcherConfig<'toResolveToStringChainable', Promise<string>, true, { resolved: boolean }>
+			>
+		>()
+
+		// Name should be inferred correctly
+		expectTypeOf<typeof toBeBigIntChainable.name>().toEqualTypeOf<'toBeBigIntChainable'>()
+		expectTypeOf<typeof toBeHexChainable.name>().toEqualTypeOf<'toBeHexChainable'>()
+		expectTypeOf<typeof toBeAddressChainable.name>().toEqualTypeOf<'toBeAddressChainable'>()
+		expectTypeOf<typeof toResolveToStringChainable.name>().toEqualTypeOf<'toResolveToStringChainable'>()
+	})
+
+	it('type: isAsync flag inference', () => {
+		// Sync matchers should have isAsync: false
+		expectTypeOf<typeof toBeBigIntChainable.isAsync>().toEqualTypeOf<false>()
+		expectTypeOf<typeof toBeHexChainable.isAsync>().toEqualTypeOf<false>()
+		expectTypeOf<typeof toBeAddressChainable.isAsync>().toEqualTypeOf<false>()
+
+		// Async matcher should have isAsync: true
+		expectTypeOf<typeof toResolveToStringChainable.isAsync>().toEqualTypeOf<true>()
+	})
+
+	it('type: method function parameter inference', () => {
+		// Test that method functions exist and are functions
+		expectTypeOf<typeof toBeBigIntChainable.methodFunction>().toBeFunction()
+		expectTypeOf<typeof toBeHexChainable.methodFunction>().toBeFunction()
+		expectTypeOf<typeof toPassDownStateChainable.methodFunction>().toBeFunction()
+		expectTypeOf<typeof toResolveToStringChainable.methodFunction>().toBeFunction()
+	})
+
+	it('type: return type inference (sync vs async)', () => {
+		// Sync matchers return Assertion
+		expectTypeOf<ReturnType<typeof toBeBigIntChainable.methodFunction>>().toEqualTypeOf<Assertion>()
+		expectTypeOf<ReturnType<typeof toBeHexChainable.methodFunction>>().toEqualTypeOf<Assertion>()
+		expectTypeOf<ReturnType<typeof toPassDownStateChainable.methodFunction>>().toEqualTypeOf<Assertion>()
+
+		// Async matchers return ChainableAssertion
+		expectTypeOf<ReturnType<typeof toResolveToStringChainable.methodFunction>>().toExtend<ChainableAssertion>()
+	})
+
+	it('type: chain function consistency', () => {
+		// All chain functions should have the same signature
+		expectTypeOf<typeof toBeBigIntChainable.chainFunction>().toBeFunction()
+		expectTypeOf<typeof toBeHexChainable.chainFunction>().toBeFunction()
+		expectTypeOf<typeof toPassDownStateChainable.chainFunction>().toBeFunction()
+		expectTypeOf<typeof toResolveToStringChainable.chainFunction>().toBeFunction()
+	})
+
+	it('type: vitest matcher function types', () => {
+		// Test that vitest matcher types are properly structured
+		expectTypeOf<VitestMatcherFunction<unknown, false, unknown>>().toBeFunction()
+		expectTypeOf<VitestMatcherFunction<Promise<string>, true, { resolved: boolean }>>().toBeFunction()
+
+		// Test specific return type structure
+		expectTypeOf<MatcherResult<{ resolved: boolean }>>().toEqualTypeOf<{
+			pass: boolean
+			message: () => string
+			actual?: unknown
+			expected?: unknown
+			state?: { resolved: boolean }
+		}>()
+	})
+
+	it('type: chain state structure', () => {
+		// Test ChainState type structure with real state types
+		type TestState = { a: unknown; b: unknown; originalValue: unknown }
+
+		expectTypeOf<ChainState<bigint, TestState>>().toEqualTypeOf<{
+			chainedFrom: string | undefined
+			previousPassed: boolean | undefined
+			previousValue: bigint | undefined
+			previousState: TestState | undefined
+			previousArgs: readonly unknown[] | undefined
+		}>()
+
+		// Test that ChainState can be used with different types
+		expectTypeOf<ChainState<string, { resolved: boolean }>>().toEqualTypeOf<{
+			chainedFrom: string | undefined
+			previousPassed: boolean | undefined
+			previousValue: string | undefined
+			previousState: { resolved: boolean } | undefined
+			previousArgs: readonly unknown[] | undefined
+		}>()
+	})
+
+	it('type: real world matcher inference', () => {
+		// Test that real matchers are properly typed
+		expectTypeOf<typeof toBeBigIntChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toBeBigIntChainable', unknown, false, unknown>>
+		>()
+
+		expectTypeOf<typeof toBeHexChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toBeHexChainable', unknown, false, unknown>>
+		>()
+
+		expectTypeOf<typeof toBeAddressChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toBeAddressChainable', unknown, false, unknown>>
+		>()
+
+		expectTypeOf<typeof toResolveToStringChainable>().toExtend<
+			InferredVitestChainableResult<
+				VitestMatcherConfig<'toResolveToStringChainable', Promise<string>, true, { resolved: boolean }>
+			>
+		>()
+	})
+
+	it('type: state-aware matchers', () => {
+		// Test state passing matchers from spec
+		expectTypeOf<typeof toPassDownStateChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toPassDownStateChainable', unknown, false, any>>
+		>()
+
+		expectTypeOf<typeof toUsePreviousStateAndBigIntChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'toUsePreviousStateAndBigIntChainable', unknown, false, any>>
+		>()
+	})
+
+	it('type: utility types exist and work', () => {
+		// Test that ChainState is properly generic and has the right properties
+		expectTypeOf<ChainState<string, { resolved: boolean }>>().toHaveProperty('previousValue')
+		expectTypeOf<ChainState<string, { resolved: boolean }>>().toHaveProperty('previousState')
+		expectTypeOf<ChainState<string, { resolved: boolean }>>().toHaveProperty('chainedFrom')
+	})
+
+	it('type: custom matchers interface', () => {
+		// Test that CustomMatchers interface is properly defined
+		expectTypeOf<CustomMatchers>().toHaveProperty('toBeBigIntChainable')
+		expectTypeOf<CustomMatchers>().toHaveProperty('toBeHexChainable')
+		expectTypeOf<CustomMatchers>().toHaveProperty('toBeAddressChainable')
+		expectTypeOf<CustomMatchers>().toHaveProperty('toPassDownStateChainable')
+		expectTypeOf<CustomMatchers>().toHaveProperty('toUsePreviousStateAndBigIntChainable')
+		expectTypeOf<CustomMatchers>().toHaveProperty('toResolveToStringChainable')
+	})
+
+	it('type: negative test cases (should not compile)', () => {
+		// These test cases document what should NOT work
+
+		// @ts-expect-error - cannot use wrong received type
+		const wrongReceived: VitestMatcherFunction<number, false> = (received: string) => ({
+			pass: true,
+			message: () => '',
+		})
+
+		// @ts-expect-error - cannot use wrong async flag
+		const wrongAsync: VitestMatcherFunction<number, false> = async (received: number) => ({
+			pass: true,
+			message: () => '',
+		})
+
+		// @ts-expect-error - async matcher must return Promise
+		const asyncWithoutPromise: VitestMatcherFunction<number, true> = (received: number) => ({
+			pass: true,
+			message: () => '',
+		})
+
+		// Suppress unused variable warnings
+		void wrongReceived
+		void wrongAsync
+		void asyncWithoutPromise
+	})
+
+	it('type: conditional return types based on TAsync', () => {
+		// Test that conditional types work correctly
+		type SyncResult = VitestMatcherFunction<unknown, false, unknown> extends VitestMatcherFunction<any, true, any>
+			? ChainableAssertion
+			: Assertion
+		type AsyncResult = VitestMatcherFunction<
+			Promise<string>,
+			true,
+			{ resolved: boolean }
+		> extends VitestMatcherFunction<any, true, any>
+			? ChainableAssertion
+			: Assertion
+
+		expectTypeOf<SyncResult>().toEqualTypeOf<Assertion>()
+		expectTypeOf<AsyncResult>().toEqualTypeOf<ChainableAssertion>()
+	})
+
+	it('type: createChainableFromVitest function signature', () => {
+		// Test that the creation function itself is properly typed
+		expectTypeOf<typeof createChainableFromVitest>().toBeFunction()
+
+		// Test that it can accept proper configs with real matchers
+		expectTypeOf<VitestMatcherConfig<'toBeBigInt', unknown, false, unknown>>().toEqualTypeOf<{
+			readonly name: 'toBeBigInt'
+			readonly vitestMatcher: VitestMatcherFunction<unknown, false, unknown>
+		}>()
+	})
+
+	it('type: real matcher functions from utils', () => {
+		// Test that the original vitest matchers are properly typed
+		expectTypeOf<typeof toBeHex>().toBeFunction()
+		expectTypeOf<typeof toBeAddress>().toBeFunction()
+
+		// Test that they can be used to create chainable matchers
+		const testChainable = createChainableFromVitest({
+			name: 'testMatcher' as const,
+			vitestMatcher: toBeHex,
+		})
+
+		expectTypeOf<typeof testChainable>().toEqualTypeOf<
+			InferredVitestChainableResult<VitestMatcherConfig<'testMatcher', unknown, false, unknown>>
+		>()
+	})
+})

--- a/extensions/test-matchers/src/chainable/types.ts
+++ b/extensions/test-matchers/src/chainable/types.ts
@@ -1,0 +1,66 @@
+import { type Assertion, chai } from 'vitest'
+
+export type ChaiStatic = ReturnType<(typeof chai)['use']>
+export type ChaiUtils = typeof chai.util
+export type ChaiAssert = typeof chai.assert
+export type ChaiContext<TAsync extends boolean = boolean, T = unknown> = Assertion<T> & {
+	__flags: any
+	__methods: any
+	_obj: any
+	assert: ChaiAssert
+	then: TAsync extends true ? (onfulfilled: (value: T) => void, onrejected?: (reason: any) => void) => void : never
+	catch: TAsync extends true ? (onrejected: (reason: any) => void) => void : never
+}
+
+export type MatcherResult<TState = unknown> = {
+	pass: boolean
+	message: () => string
+	actual?: unknown
+	expected?: unknown
+	state?: TState
+}
+
+// Vitest-style matcher function (returns MatcherResult)
+export type VitestMatcherFunction<TReceived = any, TAsync extends boolean = boolean, TState = unknown> = (
+	received: TReceived,
+	...args: any[]
+) => TAsync extends true ? Promise<MatcherResult<TState>> : MatcherResult<TState>
+
+// Chain state interface for tracking previous matcher results
+export interface ChainState<TData = unknown, TState = unknown> {
+	chainedFrom: string | undefined
+	previousPassed: boolean | undefined
+	previousValue: TData | undefined
+	previousState: TState | undefined
+	previousArgs: readonly unknown[] | undefined
+}
+
+// Extract function parameter types for VitestMatcherFunction (excluding received)
+export type ExtractVitestArgs<T> = T extends (received: unknown, ...args: infer Args) => any ? Args : never
+
+// Helper types for assertion return types
+export type ChainableAssertion<T = unknown> = Promise<Assertion<T>> & Assertion<T>
+
+export type IsAsync<T> = T extends (...args: any[]) => Promise<any> ? true : false
+
+// Configuration for converting vitest matchers to chainable
+export interface VitestMatcherConfig<
+	TName extends string,
+	TReceived = unknown,
+	TAsync extends boolean = boolean,
+	TState = unknown,
+> {
+	readonly name: TName
+	readonly vitestMatcher: VitestMatcherFunction<TReceived, TAsync, TState>
+}
+
+// Properly inferred result type from VitestMatcherConfig
+export interface InferredVitestChainableResult<TConfig extends VitestMatcherConfig<string, any, boolean, any>> {
+	readonly name: TConfig['name']
+	readonly isAsync: TConfig['vitestMatcher'] extends VitestMatcherFunction<any, infer TAsync, any> ? TAsync : false
+	readonly methodFunction: (
+		this: ChaiContext,
+		...args: ExtractVitestArgs<TConfig['vitestMatcher']>
+	) => TConfig['vitestMatcher'] extends VitestMatcherFunction<any, true, any> ? ChainableAssertion : Assertion
+	readonly chainFunction: (this: ChaiContext) => Assertion
+}

--- a/extensions/test-matchers/src/index.ts
+++ b/extensions/test-matchers/src/index.ts
@@ -9,38 +9,21 @@ import {
 	toEqualHex,
 } from './matchers/utils/index.js'
 
-// Define all matchers
-const matchers = {
+expect.extend({
 	toBeAddress,
 	toBeHex,
 	toEqualAddress,
 	toEqualHex,
+})
+
+interface CustomMatchers {
+	toBeAddress(opts?: IsAddressOptions): void
+	toBeHex(opts?: IsHexOptions): void
+	toEqualAddress(expected: unknown): void
+	toEqualHex(expected: unknown, opts?: EqualHexOptions): void
 }
 
-// Extend expect with all matchers
-expect.extend(matchers)
-
-// Export matchers for manual usage if needed
-export { matchers }
-
-// Export individual matchers
-export { toBeAddress } from './matchers/utils/toBeAddress.js'
-export { toBeHex } from './matchers/utils/toBeHex.js'
-export { toEqualAddress } from './matchers/utils/toEqualAddress.js'
-export { toEqualHex } from './matchers/utils/toEqualHex.js'
-
-// Type declarations for TypeScript
 declare module 'vitest' {
-	interface Assertion<T = any> {
-		toBeAddress(opts?: IsAddressOptions): T
-		toBeHex(opts?: IsHexOptions): T
-		toEqualAddress(expected: unknown): T
-		toEqualHex(expected: unknown, opts?: EqualHexOptions): T
-	}
-	interface AsymmetricMatchersContaining {
-		toBeAddress(): any
-		toBeHex(opts?: IsHexOptions): any
-		toEqualAddress(expected: unknown): any
-		toEqualHex(expected: unknown, opts?: EqualHexOptions): any
-	}
+	interface Assertion<T = any> extends CustomMatchers {}
+	interface AsymmetricMatchersContaining extends CustomMatchers {}
 }


### PR DESCRIPTION
See #1747 for full package overview and plan.

## Description

Add internal functions to make vitest matchers chainable using chai, to reproduce waffle chainable matchers `await expect(tx).toEmit(event).withArgs(args)` or such.

Includes full tests & type tests for chainable functionality.