### PR TITLE
06 03 test matchers events

### DIFF
--- a/extensions/test-matchers/README.md
+++ b/extensions/test-matchers/README.md
@@ -148,6 +148,149 @@ expect(hex1).toEqualHex(hex2, { exact: true })  // exact string comparison
 expect('0x1234abcd').not.toEqualHex('0x1234abce')
 ```
 
+## Event Matchers
+
+### `toEmit(contract, eventName)`
+
+Asserts that a transaction emitted a specific event from a contract.
+
+```typescript
+import { expect, test } from 'vitest'
+import '@tevm/test-matchers'
+
+// Contract with typed ABI
+const contract = {
+  abi: [
+    {
+      type: 'event',
+      name: 'Transfer',
+      inputs: [
+        { name: 'from', type: 'address', indexed: true },
+        { name: 'to', type: 'address', indexed: true },
+        { name: 'value', type: 'uint256', indexed: false }
+      ]
+    }
+  ],
+  address: '0x742d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b'
+}
+
+test('contract event emission', async () => {
+  // ✅ Passes - event was emitted
+  await expect(contract.write.transfer('0x123...', 100n))
+    .toEmit(contract, 'Transfer')
+
+  // ❌ Fails - event was not emitted
+  await expect(contract.read.balanceOf('0x123...'))
+    .toEmit(contract, 'Transfer')
+
+  // Works with .not
+  await expect(contract.read.balanceOf('0x123...'))
+    .not.toEmit(contract, 'Transfer')
+})
+```
+
+### `toEmit(eventSignature)` and `toEmit(eventSelector)`
+
+Alternative ways to specify events using signature strings or hex selectors.
+
+```typescript
+test('event emission with signature', async () => {
+  // Using event signature string
+  await expect(contract.write.transfer('0x123...', 100n))
+    .toEmit('Transfer(address,address,uint256)')
+
+  // Using event selector (hex)
+  await expect(contract.write.transfer('0x123...', 100n))
+    .toEmit('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
+})
+```
+
+### `withArgs(...expectedArgs)`
+
+Chains with `toEmit` to assert specific event arguments in positional order.
+
+```typescript
+test('event with specific arguments', async () => {
+  const fromAddr = '0x742d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b'
+  const toAddr = '0x123d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b'
+  const amount = 100n
+
+  // ✅ Passes - exact argument match
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withArgs(fromAddr, toAddr, amount)
+
+  // ❌ Fails - wrong arguments
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withArgs(fromAddr, toAddr, 200n) // wrong amount
+
+  // Works with event signatures too
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit('Transfer(address,address,uint256)')
+    .withArgs(fromAddr, toAddr, amount)
+})
+```
+
+### `withNamedArgs(expectedArgs)`
+
+Chains with `toEmit` to assert specific event arguments by name. Supports partial matching.
+
+```typescript
+test('event with named arguments', async () => {
+  const toAddr = '0x123d35Cc5dB4c8E9f8D4Dc1Ef70c4c7c8E5b7A6b'
+  const amount = 100n
+
+  // ✅ Passes - partial named argument match
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withNamedArgs({
+      to: toAddr,
+      value: amount
+    })
+
+  // ✅ Passes - can check just one argument
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withNamedArgs({ value: amount })
+
+  // ✅ Passes - empty object matches any event
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withNamedArgs({})
+
+  // ❌ Fails - wrong named arguments
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withNamedArgs({ value: 200n })
+
+  // ❌ Fails - invalid argument name
+  await expect(contract.write.transfer(toAddr, amount))
+    .toEmit(contract, 'Transfer')
+    .withNamedArgs({ invalidArg: 100n })
+})
+```
+
+### Event Matcher Limitations
+
+**Important:** Due to how Chai's `.not` property works, you cannot use `.not` directly before `withArgs` or `withNamedArgs`. Meaning that you _can_ test that an event was not emitted, but you _cannot_ test that an event was emitted but not with certain arguments.
+
+```typescript
+// ❌ Does NOT work - .not breaks the chain
+await expect(transaction)
+  .toEmit(contract, 'Transfer')
+  .not.withArgs(100n) // This will fail with an error
+
+// ✅ Works - use .not before toEmit
+await expect(transaction)
+  .not.toEmit(contract, 'Transfer') // Event should not be emitted at all
+
+// ✅ Alternative - assert the positive case
+await expect(transaction)
+  .toEmit(contract, 'Transfer')
+  .withArgs(200n) // Assert it has different args instead
+```
+
 ## TypeScript Support
 
 All matchers include full TypeScript support with proper type definitions. The matchers will be available on the `expect` object after importing.
@@ -223,6 +366,29 @@ test('Address validation with different strictness', () => {
 
   // But they should be equal as addresses
   expect(checksummed).toEqualAddress(lowercase) // passes (same address)
+})
+
+test('Event testing examples', async () => {
+  const client = // ... your TEVM client
+
+  // Basic event testing
+  await expect(client.tevmContract(contract.write.transfer('0x123...', 100n)))
+    .toEmit(contract, 'Transfer')
+
+  // Event with specific arguments
+  await expect(client.tevmContract(contract.write.transfer('0x123...', 100n)))
+    .toEmit(contract, 'Transfer')
+    .withArgs('0x742d35Cc...', '0x123...', 100n)
+
+  // Event with named arguments (partial matching)
+  await expect(client.tevmContract(contract.write.transfer('0x123...', 100n)))
+    .toEmit(contract, 'Transfer')
+    .withNamedArgs({ value: 100n })
+
+  // Using event signatures instead of contracts
+  await expect(transaction)
+    .toEmit('Transfer(address,address,uint256)')
+    .withArgs(fromAddr, toAddr, amount)
 })
 ```
 

--- a/extensions/test-matchers/src/index.ts
+++ b/extensions/test-matchers/src/index.ts
@@ -1,14 +1,19 @@
-import type { IsAddressOptions } from 'viem'
 import { expect } from 'vitest'
+import { registerChainableMatchers } from './internal/chainable.js'
+import { type ContractLike, type EmitMatchers, type TransactionLike, eventMatchers } from './matchers/events/index.js'
 import {
 	type EqualHexOptions,
+	type IsAddressOptions,
 	type IsHexOptions,
+	type UtilsMatchers,
 	toBeAddress,
 	toBeBigInt,
 	toBeHex,
 	toEqualAddress,
 	toEqualHex,
 } from './matchers/utils/index.js'
+
+export type { IsAddressOptions, IsHexOptions, EqualHexOptions, ContractLike, TransactionLike }
 
 expect.extend({
 	toBeBigInt,
@@ -18,15 +23,9 @@ expect.extend({
 	toEqualHex,
 })
 
-interface CustomMatchers {
-	toBeBigInt(): void
-	toBeAddress(opts?: IsAddressOptions): void
-	toBeHex(opts?: IsHexOptions): void
-	toEqualAddress(expected: unknown): void
-	toEqualHex(expected: unknown, opts?: EqualHexOptions): void
-}
+registerChainableMatchers(eventMatchers)
 
 declare module 'vitest' {
-	interface Assertion<T = any> extends CustomMatchers {}
-	interface AsymmetricMatchersContaining extends CustomMatchers {}
+	interface Assertion<T = any> extends UtilsMatchers, EmitMatchers {}
+	interface AsymmetricMatchersContaining extends UtilsMatchers, EmitMatchers {}
 }

--- a/extensions/test-matchers/src/internal/chainable.spec.ts
+++ b/extensions/test-matchers/src/internal/chainable.spec.ts
@@ -4,6 +4,7 @@ import { createChainableFromVitest, registerChainableMatchers } from './chainabl
 import type { ChainState, ChainableAssertion } from './types.js'
 
 /* ---------------------------------- TYPES --------------------------------- */
+// biome-ignore lint/suspicious/noExportsInTest: exporting for chainable.type-spec.ts
 export interface CustomMatchers {
 	/**
 	 * Assert that a value is a BigInt
@@ -144,6 +145,7 @@ const toResolveToStringChainable = createChainableFromVitest({
 })
 
 // Register all test matchers
+// biome-ignore lint/suspicious/noExportsInTest: exporting for chainable.type-spec.ts
 export const testMatchers = {
 	toBeBigIntChainable,
 	toBeHexChainable,

--- a/extensions/test-matchers/src/internal/chainable.ts
+++ b/extensions/test-matchers/src/internal/chainable.ts
@@ -216,6 +216,7 @@ function makeVitestAsyncChainable<
 	})
 
 	// Make thenable (waffle-chai pattern)
+	// biome-ignore lint/suspicious/noThenProperty: binding the promise to replicate chai waffle pattern
 	this.then = derivedPromise.then.bind(derivedPromise)
 	this.catch = derivedPromise.catch.bind(derivedPromise)
 	chaiUtils.flag(this, 'callPromise', derivedPromise)

--- a/extensions/test-matchers/src/matchers/events/index.ts
+++ b/extensions/test-matchers/src/matchers/events/index.ts
@@ -1,0 +1,74 @@
+import type { AbiEventParameter, AbiParametersToPrimitiveTypes, ExtractAbiEvent } from 'abitype'
+import type { ContractEventName, Hex } from 'viem'
+import type { Abi } from 'viem'
+import { createChainableFromVitest } from '../../internal/chainable.js'
+import type { ChainableAssertion } from '../../internal/types.js'
+import { toEmit } from './toEmit.js'
+import type { ContractLike, TransactionLike } from './types.js'
+import { withArgs } from './withArgs.js'
+import { type EventInputsToNamedArgs, withNamedArgs } from './withNamedArgs.js'
+
+// Create chainable matchers
+export const toEmitChainable = createChainableFromVitest({
+	name: 'toEmit' as const,
+	vitestMatcher: toEmit,
+})
+
+export const withArgsChainable = createChainableFromVitest({
+	name: 'withArgs' as const,
+	vitestMatcher: withArgs,
+})
+
+export const withNamedArgsChainable = createChainableFromVitest({
+	name: 'withNamedArgs' as const,
+	vitestMatcher: withNamedArgs,
+})
+
+// Register the chainable matchers
+export const eventMatchers = {
+	toEmit: toEmitChainable,
+	withArgs: withArgsChainable,
+	withNamedArgs: withNamedArgsChainable,
+}
+
+export { toEmit, withArgs, withNamedArgs }
+export type { ContractLike, TransactionLike }
+
+// TypeScript declaration for vitest
+export interface EmitMatchers {
+	/**
+	 * Assert that an event was emitted
+	 */
+	toEmit<TAbi extends Abi, TEventName extends ContractEventName<TAbi>>(
+		contract: ContractLike<TAbi>,
+		eventName: TEventName,
+	): Promise<EmitAssertionWithContract<TAbi, TEventName>> & EmitAssertionWithContract<TAbi, TEventName>
+
+	toEmit(eventSignature: string): ChainableAssertion
+	toEmit(eventSelector: Hex): ChainableAssertion
+}
+
+// Only-after toEmit assertion type
+interface EmitAssertionWithContract<TAbi extends Abi, TEventName extends ContractEventName<TAbi>> {
+	/**
+	 * Chain with toEmit to assert event arguments (typed for specific contract)
+	 */
+	withArgs<
+		TInputs extends readonly AbiEventParameter[] = ExtractAbiEvent<TAbi, TEventName> extends {
+			inputs: infer U extends readonly AbiEventParameter[]
+		}
+			? U
+			: readonly AbiEventParameter[],
+	>(...expectedArgs: AbiParametersToPrimitiveTypes<TInputs>): ChainableAssertion
+
+	/**
+	 * Chain with toEmit to assert named event arguments (typed for specific contract)
+	 */
+	withNamedArgs<
+		TInputs extends readonly AbiEventParameter[] = ExtractAbiEvent<TAbi, TEventName> extends {
+			inputs: infer U extends readonly AbiEventParameter[]
+		}
+			? U
+			: readonly AbiEventParameter[],
+	>(expectedArgs: Partial<EventInputsToNamedArgs<TInputs>>): ChainableAssertion
+}

--- a/extensions/test-matchers/src/matchers/events/toEmit.spec.ts
+++ b/extensions/test-matchers/src/matchers/events/toEmit.spec.ts
@@ -1,0 +1,177 @@
+import { type Contract } from '@tevm/contract'
+import { createMemoryClient } from '@tevm/memory-client'
+import { SimpleContract } from '@tevm/test-utils'
+import type { Address, Hex } from 'viem'
+import { toEventSelector } from 'viem'
+import { assert, beforeEach, describe, expect, it } from 'vitest'
+
+const client = createMemoryClient()
+
+describe('toEmit', () => {
+	let contract: Contract<'SimpleContract', typeof SimpleContract.humanReadableAbi, Address, Hex, Hex>
+
+	beforeEach(async () => {
+		const { createdAddress } = await client.tevmDeploy({ ...SimpleContract.deploy(0n), addToBlockchain: true })
+		assert(createdAddress, 'createdAddress is undefined')
+		contract = SimpleContract.withAddress(createdAddress)
+	})
+
+	describe('basic event detection', () => {
+		it('should detect event with contract + event name', async () => {
+			await expect(client.tevmContract(contract.write.set(100n))).toEmit(contract, 'ValueSet')
+			await expect(client.tevmContract(contract.write.set(100n))).toEmit(contract, 'ValueSet')
+		})
+
+		it('should detect event with signature string', async () => {
+			await expect(client.tevmContract(contract.write.set(100n))).toEmit('ValueSet(uint256)')
+			await expect(client.tevmContract(contract.write.set(100n))).toEmit('ValueSet(uint256 newValue)')
+		})
+
+		it('should detect event with hex selector', async () => {
+			await expect(client.tevmContract(contract.write.set(100n))).toEmit(toEventSelector('ValueSet(uint256)'))
+			await expect(client.tevmContract(contract.write.set(100n))).toEmit(toEventSelector('ValueSet(uint256 newValue)'))
+		})
+
+		it('should fail when event not emitted', async () => {
+			// Call method that doesn't emit ValueSet
+			await expect(expect(client.tevmContract(contract.read.get())).toEmit(contract, 'ValueSet')).rejects.toThrow()
+		})
+
+		it('should fail when wrong event name', async () => {
+			await expect(expect(client.tevmContract(contract.write.set(100n))).toEmit('NonExistentEvent')).rejects.toThrow()
+		})
+	})
+
+	describe('withArgs argument matching', () => {
+		it('should pass with correct arguments', async () => {
+			await expect(client.tevmContract(contract.write.set(100n)))
+				.toEmit(contract, 'ValueSet')
+				.withArgs(100n)
+		})
+
+		it('should fail with wrong arguments', async () => {
+			await expect(
+				expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit(contract, 'ValueSet')
+					.withArgs(200n),
+			).rejects.toThrow()
+		})
+
+		it('should fail with wrong number of arguments', async () => {
+			await expect(
+				expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit(contract, 'ValueSet')
+					.withArgs(100n, 200n),
+			).rejects.toThrow()
+		})
+
+		it('should fail with both right and wrong arguments', async () => {
+			try {
+				await expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit(contract, 'ValueSet')
+					.withArgs(100n, 200n)
+			} catch (error: any) {
+				expect(error.message).toBe(
+					"Expected event ValueSet to be emitted with the specified arguments, but it wasn't found in any of the 1 emitted events",
+				)
+				expect(error.actual).toEqual([100n])
+			}
+		})
+
+		it('should fail without contract', async () => {
+			await expect(
+				expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit('ValueSet(uint256)')
+					// @ts-expect-error - 'withArgs' does not exist on type 'ChainableAssertion'.
+					.withArgs(100n),
+			).rejects.toThrow('withArgs() requires a contract with abi and event name')
+		})
+	})
+
+	describe('withNamedArgs argument matching', () => {
+		it('should pass with correct named arguments', async () => {
+			await expect(client.tevmContract(contract.write.set(100n)))
+				.toEmit(contract, 'ValueSet')
+				.withNamedArgs({ newValue: 100n })
+		})
+
+		it('should pass with partial named arguments', async () => {
+			// Even if event has multiple args, partial matching should work
+			await expect(client.tevmContract(contract.write.set(100n)))
+				.toEmit(contract, 'ValueSet')
+				.withNamedArgs({}) // Empty object should pass
+		})
+
+		it('should fail with wrong named arguments', async () => {
+			try {
+				await expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit(contract, 'ValueSet')
+					.withNamedArgs({ newValue: 200n })
+			} catch (error: any) {
+				expect(error.message).toBe(
+					"Expected event ValueSet to be emitted with the specified named arguments, but it wasn't found in any of the 1 emitted events",
+				)
+				expect(error.actual).toEqual([{ newValue: 100n }])
+			}
+		})
+
+		it('should fail with invalid argument names', async () => {
+			try {
+				await expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit(contract, 'ValueSet')
+					// @ts-expect-error - 'invalidArg' does not exist in the event inputs
+					.withNamedArgs({ invalidArg: 100n })
+			} catch (error: any) {
+				expect(error.message).toBe(
+					"Expected event ValueSet to be emitted with the specified named arguments, but it wasn't found in any of the 1 emitted events",
+				)
+				expect(error.actual).toEqual([{ newValue: 100n }])
+			}
+		})
+
+		it('should fail with both right and wrong arguments', async () => {
+			try {
+				await expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit(contract, 'ValueSet')
+					// @ts-expect-error - 'invalidArg' does not exist in the event inputs
+					.withNamedArgs({ newValue: 100n, invalidArg: 200n })
+			} catch (error: any) {
+				expect(error.message).toBe(
+					"Expected event ValueSet to be emitted with the specified named arguments, but it wasn't found in any of the 1 emitted events",
+				)
+				expect(error.actual).toEqual([{ newValue: 100n }])
+			}
+		})
+
+		it('should fail without contract', async () => {
+			await expect(
+				expect(client.tevmContract(contract.write.set(100n)))
+					.toEmit('ValueSet(uint256)')
+					// @ts-expect-error - 'withNamedArgs' does not exist on type 'ChainableAssertion'.
+					.withNamedArgs({ newValue: 100n }),
+			).rejects.toThrow('withNamedArgs() requires a contract with abi and event name')
+		})
+	})
+
+	describe('negation support', () => {
+		it('should support not.toEmit - event should not be emitted at all', async () => {
+			// Transaction that doesn't emit ValueSet
+			await expect(client.tevmContract(contract.read.get())).not.toEmit(contract, 'ValueSet')
+		})
+
+		it('should fail not.toEmit when event is actually emitted', async () => {
+			await expect(
+				expect(client.tevmContract(contract.write.set(100n))).not.toEmit(contract, 'ValueSet'),
+			).rejects.toThrow()
+		})
+
+		it('should support not.toEmit with signature string', async () => {
+			await expect(client.tevmContract(contract.read.get())).not.toEmit('ValueSet(uint256)')
+		})
+
+		it('should support not.toEmit with hex selector', async () => {
+			const selector = toEventSelector('ValueSet(uint256)')
+			await expect(client.tevmContract(contract.read.get())).not.toEmit(selector)
+		})
+	})
+})

--- a/extensions/test-matchers/src/matchers/events/toEmit.ts
+++ b/extensions/test-matchers/src/matchers/events/toEmit.ts
@@ -1,0 +1,97 @@
+import type { ContractEventName, Hex } from 'viem'
+import { decodeEventLog, encodeEventTopics, getAddress, isHex, toEventSelector } from 'viem'
+import type { Abi, AbiEvent } from 'viem'
+import type { MatcherResult } from '../../internal/types.js'
+import type { ContractLike, ToEmitState, TransactionLike } from './types.js'
+
+// Vitest-style matcher function
+export const toEmit = async <
+	TAbi extends Abi | undefined = Abi | undefined,
+	TEventName extends TAbi extends Abi ? ContractEventName<TAbi> : never = TAbi extends Abi
+		? ContractEventName<TAbi>
+		: never,
+	TContract extends TAbi extends Abi ? ContractLike<TAbi> : never = TAbi extends Abi ? ContractLike<TAbi> : never,
+>(
+	received: TransactionLike | Promise<TransactionLike>,
+	contractOrEventIdentifier: TContract | Hex | string,
+	eventName?: TEventName,
+): Promise<MatcherResult<ToEmitState>> => {
+	const logs = (await received).logs
+
+	// Handle event signature or selector
+	if (typeof contractOrEventIdentifier === 'string') {
+		const eventSelector = isHex(contractOrEventIdentifier)
+			? contractOrEventIdentifier
+			: toEventSelector(contractOrEventIdentifier)
+
+		const matchedLogs = logs.filter((log) => log.topics[0]?.startsWith(eventSelector))
+		const pass = matchedLogs.length > 0
+
+		return {
+			pass,
+			actual: logs.map((log) => log.topics[0]).filter(Boolean),
+			expected: `logs containing event selector ${eventSelector}`,
+			message: () =>
+				pass
+					? `Expected event ${contractOrEventIdentifier} not to be emitted`
+					: `Expected event ${contractOrEventIdentifier} to be emitted`,
+			state: {
+				matchedLogs,
+				eventIdentifier: contractOrEventIdentifier,
+			},
+		}
+	}
+
+	// Contract + event name case
+	if (!eventName) throw new Error('You need to provide an event name as a second argument')
+	const contract = contractOrEventIdentifier
+	const eventAbi = contract.abi.find((item): item is AbiEvent => item.type === 'event' && item.name === eventName)
+
+	if (!eventAbi)
+		throw new Error(
+			`Event ${eventName} not found in contract ABI. Please make sure you've compiled the latest version before running the test.`,
+		)
+
+	const eventTopic = encodeEventTopics({
+		abi: contract.abi,
+		eventName: eventName,
+	})[0]
+
+	const matchedLogs = logs.filter((log) => {
+		const topicMatches = log.topics[0] === eventTopic
+		const addressMatches = contract?.address ? getAddress(log.address) === getAddress(contract.address) : true
+		return topicMatches && addressMatches
+	})
+
+	const pass = matchedLogs.length > 0
+
+	// Create meaningful actual/expected values for the diff
+	const actualEvents = logs
+		.filter((log) => (contract?.address ? getAddress(log.address) === getAddress(contract.address) : true))
+		.map((log) => {
+			try {
+				const decoded = decodeEventLog({
+					abi: contract.abi,
+					data: log.data,
+					topics: log.topics,
+				})
+				return `${decoded.eventName}(${decoded.args ? Object.values(decoded.args).join(', ') : ''})`
+			} catch {
+				return `UnknownEvent(${log.topics[0]})`
+			}
+		})
+
+	return {
+		pass,
+		actual: actualEvents,
+		expected: `event "${eventName}" to be emitted`,
+		message: () =>
+			pass ? `Expected event ${eventName} not to be emitted` : `Expected event ${eventName} to be emitted`,
+		state: {
+			matchedLogs,
+			contract,
+			eventName,
+			eventAbi,
+		},
+	}
+}

--- a/extensions/test-matchers/src/matchers/events/types.ts
+++ b/extensions/test-matchers/src/matchers/events/types.ts
@@ -1,0 +1,32 @@
+import type { ExtractAbiEvent } from 'abitype'
+import type { ContractEventName, Log } from 'viem'
+import type { Abi } from 'viem'
+
+// Contract-like object with ABI
+export interface ContractLike<TAbi extends Abi = Abi> {
+	abi: TAbi
+	address?: `0x${string}`
+}
+
+// Transaction-like object that has logs
+export interface TransactionLike {
+	logs: Log[]
+}
+
+// State for toEmit matcher to pass to chained matchers
+export type ToEmitState<
+	TAbi extends Abi | undefined = Abi | undefined,
+	TEventName extends TAbi extends Abi ? ContractEventName<TAbi> : never = TAbi extends Abi
+		? ContractEventName<TAbi>
+		: never,
+> = TAbi extends Abi
+	? {
+			matchedLogs: Log[]
+			contract: ContractLike<TAbi>
+			eventName: TEventName
+			eventAbi: ExtractAbiEvent<TAbi, TEventName>
+		}
+	: {
+			matchedLogs: Log[]
+			eventIdentifier: string
+		}

--- a/extensions/test-matchers/src/matchers/events/withArgs.ts
+++ b/extensions/test-matchers/src/matchers/events/withArgs.ts
@@ -1,0 +1,67 @@
+import type { AbiEventParameter, AbiParametersToPrimitiveTypes, ExtractAbiEvent } from 'abitype'
+import { type Abi, type ContractEventName, decodeEventLog } from 'viem'
+import { parseChainArgs } from '../../internal/chainable.js'
+import type { ChainState, MatcherResult } from '../../internal/types.js'
+import type { ToEmitState } from './types.js'
+
+export const withArgs = <
+	TAbi extends Abi | undefined = Abi | undefined,
+	TEventName extends TAbi extends Abi ? ContractEventName<TAbi> : never = TAbi extends Abi
+		? ContractEventName<TAbi>
+		: never,
+	TInputs extends readonly AbiEventParameter[] = TAbi extends Abi
+		? ExtractAbiEvent<TAbi, TEventName> extends { inputs: infer U extends readonly AbiEventParameter[] }
+			? U
+			: readonly AbiEventParameter[]
+		: never,
+>(
+	// @ts-expect-error - unused variable
+	received: unknown,
+	...argsAndChainState: readonly [...AbiParametersToPrimitiveTypes<TInputs>, ChainState<unknown, ToEmitState>]
+): MatcherResult => {
+	const {
+		args,
+		chainState: { previousState },
+	} = parseChainArgs<unknown, ToEmitState>(argsAndChainState)
+
+	if (!previousState || !('contract' in previousState))
+		throw new Error('withArgs() requires a contract with abi and event name')
+
+	const { matchedLogs, contract, eventName } = previousState
+
+	// Try to decode and match arguments for each matched log
+	let argsMatched = false
+	const actualArgsFromLogs: unknown[][] = []
+
+	// At this point since we provided an abi & event name we know for sure that the matched logs correspond to the event we're looking for
+	for (const log of matchedLogs) {
+		const decodedLog = decodeEventLog({
+			abi: contract.abi,
+			data: log.data,
+			topics: log.topics,
+			eventName: eventName,
+		})
+
+		const decodedArgs = Object.values(decodedLog.args as unknown as Record<string, unknown>)
+		if (!decodedArgs.length) continue
+		actualArgsFromLogs.push(decodedArgs)
+
+		if (decodedArgs.length === args.length) {
+			const allArgsMatch = decodedArgs.every((actual, i) => actual === args[i])
+			if (allArgsMatch) {
+				argsMatched = true
+				break
+			}
+		}
+	}
+
+	return {
+		pass: argsMatched,
+		actual: actualArgsFromLogs.flat(),
+		expected: args,
+		message: () => {
+			if (argsMatched) return `Expected event ${eventName} not to be emitted with the specified arguments`
+			return `Expected event ${eventName} to be emitted with the specified arguments, but it wasn't found in any of the ${matchedLogs?.length ?? 0} emitted events`
+		},
+	}
+}

--- a/extensions/test-matchers/src/matchers/events/withNamedArgs.ts
+++ b/extensions/test-matchers/src/matchers/events/withNamedArgs.ts
@@ -1,0 +1,71 @@
+import type { AbiEventParameter, AbiParameterToPrimitiveType, ExtractAbiEvent } from 'abitype'
+import { type Abi, type ContractEventName, decodeEventLog } from 'viem'
+import { assert } from 'vitest'
+import type { ChainState, MatcherResult } from '../../internal/types.js'
+import type { ToEmitState } from './types.js'
+
+// Helper type to convert ABI event inputs to named object
+export type EventInputsToNamedArgs<TInputs extends readonly AbiEventParameter[]> = {
+	[K in TInputs[number] as K extends { name: infer TName extends string } ? TName : never]: K extends { name: string }
+		? AbiParameterToPrimitiveType<K>
+		: never
+}
+
+export const withNamedArgs = <
+	TAbi extends Abi | undefined = Abi | undefined,
+	TEventName extends TAbi extends Abi ? ContractEventName<TAbi> : never = TAbi extends Abi
+		? ContractEventName<TAbi>
+		: never,
+	TInputs extends readonly AbiEventParameter[] = TAbi extends Abi
+		? ExtractAbiEvent<TAbi, TEventName> extends { inputs: infer U extends readonly AbiEventParameter[] }
+			? U
+			: readonly AbiEventParameter[]
+		: never,
+>(
+	// @ts-expect-error - unused variable
+	received: unknown,
+	expectedArgs: Partial<EventInputsToNamedArgs<TInputs>>,
+	chainState?: ChainState<unknown, ToEmitState<TAbi, TEventName>>,
+): MatcherResult => {
+	assert(chainState, 'Internal error: no chain state found')
+	const { previousState } = chainState
+
+	if (!previousState || !('contract' in previousState))
+		throw new Error('withNamedArgs() requires a contract with abi and event name')
+
+	const { matchedLogs, contract, eventName } = previousState
+
+	let argsMatched = false
+	const actualNamedArgsFromLogs: Record<string, unknown>[] = []
+
+	for (const log of matchedLogs) {
+		const decodedLog = decodeEventLog({
+			abi: contract.abi,
+			data: log.data,
+			topics: log.topics,
+			eventName: eventName,
+		})
+
+		const decodedArgs = decodedLog.args as unknown as Record<string, unknown>
+		actualNamedArgsFromLogs.push(decodedArgs)
+
+		// Check if all expected args match
+		const allArgsMatch = Object.entries(expectedArgs).every(
+			([argName, expectedValue]) => decodedArgs[argName] === expectedValue,
+		)
+		if (allArgsMatch) {
+			argsMatched = true
+			break
+		}
+	}
+
+	return {
+		pass: argsMatched,
+		actual: actualNamedArgsFromLogs,
+		expected: expectedArgs,
+		message: () => {
+			if (argsMatched) return `Expected event ${eventName} not to be emitted with the specified named arguments`
+			return `Expected event ${eventName} to be emitted with the specified named arguments, but it wasn't found in any of the ${matchedLogs?.length ?? 0} emitted events`
+		},
+	}
+}

--- a/extensions/test-matchers/src/matchers/utils/index.ts
+++ b/extensions/test-matchers/src/matchers/utils/index.ts
@@ -1,5 +1,17 @@
-export { toBeBigInt } from './toBeBigInt.js'
-export { toBeAddress } from './toBeAddress.js'
-export { toBeHex, type IsHexOptions } from './toBeHex.js'
-export { toEqualAddress } from './toEqualAddress.js'
-export { toEqualHex, type EqualHexOptions } from './toEqualHex.js'
+import type { IsAddressOptions } from 'viem'
+import { toBeAddress } from './toBeAddress.js'
+import { toBeBigInt } from './toBeBigInt.js'
+import { type IsHexOptions, toBeHex } from './toBeHex.js'
+import { toEqualAddress } from './toEqualAddress.js'
+import { type EqualHexOptions, toEqualHex } from './toEqualHex.js'
+
+export { toBeBigInt, toBeAddress, toBeHex, toEqualAddress, toEqualHex }
+export type { IsAddressOptions, IsHexOptions, EqualHexOptions }
+
+export interface UtilsMatchers {
+	toBeBigInt(): void
+	toBeAddress(opts?: IsAddressOptions): void
+	toBeHex(opts?: IsHexOptions): void
+	toEqualAddress(expected: unknown): void
+	toEqualHex(expected: unknown, opts?: EqualHexOptions): void
+}


### PR DESCRIPTION
See #1747 for full package overview and plan.

## Description

Add `toEmit` matcher that can optionally be chained with `withArgs` or `withNamedArgs`. This mimics the waffle chai matcher.

```typescript
// Basic event testing
await expect(transaction).toEmit(contract, 'Transfer')

// With positional arguments
await expect(transaction)
  .toEmit(contract, 'Transfer')
  .withArgs(from, to, amount)

// With named arguments (partial matching)
await expect(transaction)
  .toEmit(contract, 'Transfer')
  .withNamedArgs({ value: 100n })

// Using event signatures
await expect(transaction).toEmit('Transfer(address,address,uint256)')
```