### PR TITLE
✨ refactor: replace std.debug.assert with if (\!condition) unreachable

### DIFF
--- a/src/evm/opcodes/arithmetic.zig
+++ b/src/evm/opcodes/arithmetic.zig
@@ -87,7 +87,7 @@ pub fn op_add(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -128,7 +128,7 @@ pub fn op_mul(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -168,7 +168,7 @@ pub fn op_sub(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -216,7 +216,7 @@ pub fn op_div(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -267,7 +267,7 @@ pub fn op_sdiv(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -327,7 +327,7 @@ pub fn op_mod(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -378,7 +378,7 @@ pub fn op_smod(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -437,7 +437,7 @@ pub fn op_addmod(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     const n = frame.stack.pop_unsafe();
     const b = frame.stack.pop_unsafe();
@@ -504,7 +504,7 @@ pub fn op_mulmod(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     const n = frame.stack.pop_unsafe();
     const b = frame.stack.pop_unsafe();
@@ -591,7 +591,7 @@ pub fn op_exp(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     const vm = @as(*Vm, @ptrCast(@alignCast(interpreter)));
     _ = vm;
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const exp = frame.stack.pop_unsafe();
     const base = frame.stack.peek_unsafe().*;
@@ -669,7 +669,7 @@ pub fn op_signextend(pc: usize, interpreter: *Operation.Interpreter, state: *Ope
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const byte_num = frame.stack.pop_unsafe();
     const x = frame.stack.peek_unsafe().*;

--- a/src/evm/opcodes/bitwise.zig
+++ b/src/evm/opcodes/bitwise.zig
@@ -10,7 +10,7 @@ pub fn op_and(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -28,7 +28,7 @@ pub fn op_or(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -46,7 +46,7 @@ pub fn op_xor(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -64,7 +64,7 @@ pub fn op_not(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     const value = frame.stack.peek_unsafe().*;
 
@@ -81,7 +81,7 @@ pub fn op_byte(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const i = frame.stack.pop_unsafe();
     const val = frame.stack.peek_unsafe().*;
@@ -109,7 +109,7 @@ pub fn op_shl(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const shift = frame.stack.pop_unsafe();
     const value = frame.stack.peek_unsafe().*;
@@ -133,7 +133,7 @@ pub fn op_shr(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const shift = frame.stack.pop_unsafe();
     const value = frame.stack.peek_unsafe().*;
@@ -157,7 +157,7 @@ pub fn op_sar(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const shift = frame.stack.pop_unsafe();
     const value = frame.stack.peek_unsafe().*;

--- a/src/evm/opcodes/comparison.zig
+++ b/src/evm/opcodes/comparison.zig
@@ -15,7 +15,7 @@ pub fn op_lt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -37,7 +37,7 @@ pub fn op_gt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -59,7 +59,7 @@ pub fn op_slt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -84,7 +84,7 @@ pub fn op_sgt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -109,7 +109,7 @@ pub fn op_eq(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -130,7 +130,7 @@ pub fn op_iszero(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Peek the operand unsafely
     const a = frame.stack.peek_unsafe().*;

--- a/src/evm/opcodes/control.zig
+++ b/src/evm/opcodes/control.zig
@@ -28,7 +28,7 @@ pub fn op_jump(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Use unsafe pop since bounds checking is done by jump_table
     const dest = frame.stack.pop_unsafe();
@@ -50,7 +50,7 @@ pub fn op_jumpi(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Use batch pop for performance - pop 2 values at once
     const values = frame.stack.pop2_unsafe();
@@ -75,7 +75,7 @@ pub fn op_pc(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Use unsafe push since bounds checking is done by jump_table
     frame.stack.append_unsafe(@as(u256, @intCast(pc)));
@@ -98,7 +98,7 @@ pub fn op_return(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Use batch pop for performance - pop 2 values at once
     const values = frame.stack.pop2_unsafe();
@@ -140,7 +140,7 @@ pub fn op_revert(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Use batch pop for performance - pop 2 values at once
     const values = frame.stack.pop2_unsafe();
@@ -199,7 +199,7 @@ pub fn op_selfdestruct(pc: usize, interpreter: *Operation.Interpreter, state: *O
     // Check if we're in a static call
     if (frame.is_static) return ExecutionError.Error.WriteProtection;
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Use unsafe pop since bounds checking is done by jump_table
     const beneficiary_u256 = frame.stack.pop_unsafe();

--- a/src/evm/opcodes/memory.zig
+++ b/src/evm/opcodes/memory.zig
@@ -21,7 +21,7 @@ pub fn op_mload(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Get offset from top of stack unsafely - bounds checking is done in jump_table.zig
     const offset = frame.stack.peek_unsafe().*;
@@ -55,7 +55,7 @@ pub fn op_mstore(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop two values unsafely using batch operation - bounds checking is done in jump_table.zig
     // EVM Stack: [..., value, offset] where offset is on top
@@ -89,7 +89,7 @@ pub fn op_mstore8(pc: usize, interpreter: *Operation.Interpreter, state: *Operat
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop two values unsafely using batch operation - bounds checking is done in jump_table.zig
     // EVM Stack: [..., value, offset] where offset is on top
@@ -124,7 +124,7 @@ pub fn op_msize(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // MSIZE returns the size in bytes, but memory is always expanded in 32-byte words
     // So we need to round up to the nearest word boundary
@@ -143,7 +143,7 @@ pub fn op_mcopy(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., dest, src, size] (top to bottom)
@@ -184,7 +184,7 @@ pub fn op_calldataload(pc: usize, interpreter: *Operation.Interpreter, state: *O
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Get offset from top of stack unsafely - bounds checking is done in jump_table.zig
     const offset = frame.stack.peek_unsafe().*;
@@ -220,7 +220,7 @@ pub fn op_calldatasize(pc: usize, interpreter: *Operation.Interpreter, state: *O
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Push result unsafely - bounds checking is done in jump_table.zig
     frame.stack.append_unsafe(@as(u256, @intCast(frame.input.len)));
@@ -234,7 +234,7 @@ pub fn op_calldatacopy(pc: usize, interpreter: *Operation.Interpreter, state: *O
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., size, data_offset, mem_offset] (top to bottom)
@@ -275,7 +275,7 @@ pub fn op_codesize(pc: usize, interpreter: *Operation.Interpreter, state: *Opera
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Push result unsafely - bounds checking is done in jump_table.zig
     frame.stack.append_unsafe(@as(u256, @intCast(frame.contract.code.len)));
@@ -289,7 +289,7 @@ pub fn op_codecopy(pc: usize, interpreter: *Operation.Interpreter, state: *Opera
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., size, code_offset, mem_offset] (top to bottom)
@@ -330,7 +330,7 @@ pub fn op_returndatasize(pc: usize, interpreter: *Operation.Interpreter, state: 
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Push result unsafely - bounds checking is done in jump_table.zig
     frame.stack.append_unsafe(@as(u256, @intCast(frame.return_data_buffer.len)));
@@ -344,7 +344,7 @@ pub fn op_returndatacopy(pc: usize, interpreter: *Operation.Interpreter, state: 
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., size, data_offset, mem_offset] (top to bottom)

--- a/src/evm/opcodes/stack.zig
+++ b/src/evm/opcodes/stack.zig
@@ -35,7 +35,7 @@ pub fn make_push(comptime n: u8) fn (usize, *Operation.Interpreter, *Operation.S
 
             const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-            std.debug.assert(frame.stack.size < Stack.CAPACITY);
+            if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
             var value: u256 = 0;
             const code = frame.contract.code;
@@ -68,8 +68,8 @@ pub fn make_dup(comptime n: u8) fn (usize, *Operation.Interpreter, *Operation.St
 
             const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-            std.debug.assert(frame.stack.size >= n);
-            std.debug.assert(frame.stack.size < Stack.CAPACITY);
+            if (frame.stack.size < n) unreachable;
+            if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
             frame.stack.dup_unsafe(n);
 
@@ -89,7 +89,7 @@ pub fn make_swap(comptime n: u8) fn (usize, *Operation.Interpreter, *Operation.S
 
             const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-            std.debug.assert(frame.stack.size >= n + 1);
+            if (frame.stack.size < n + 1) unreachable;
 
             frame.stack.swapUnsafe(n);
 

--- a/src/evm/opcodes/storage.zig
+++ b/src/evm/opcodes/storage.zig
@@ -42,7 +42,7 @@ pub fn op_sload(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
     const vm = @as(*Vm, @ptrCast(@alignCast(interpreter)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     const slot = frame.stack.peek_unsafe().*;
 
@@ -80,7 +80,7 @@ pub fn op_sstore(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
     // This prevents reentrancy attacks by ensuring enough gas remains for exception handling
     if (vm.chain_rules.IsIstanbul and frame.gas_remaining <= gas_constants.SstoreSentryGas) return ExecutionError.Error.OutOfGas;
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Stack order: [..., value, slot] where slot is on top
     const popped = frame.stack.pop2_unsafe();
@@ -123,7 +123,7 @@ pub fn op_tload(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     // Gas is already handled by jump table constant_gas = 100
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Get slot from top of stack unsafely - bounds checking is done in jump_table.zig
     const slot = frame.stack.peek_unsafe().*;
@@ -146,7 +146,7 @@ pub fn op_tstore(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     // Gas is already handled by jump table constant_gas = 100
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop two values unsafely using batch operation - bounds checking is done in jump_table.zig
     // Stack order: [..., value, slot] where slot is on top


### PR DESCRIPTION
## Description

Replace `std.debug.assert` with `if` statements and `unreachable` in EVM opcodes implementation. This change maintains the same runtime behavior while making the assertion logic more explicit.

The pattern `std.debug.assert(frame.stack.size >= N)` is replaced with `if (frame.stack.size < N) unreachable`, and similarly `std.debug.assert(frame.stack.size < Stack.CAPACITY)` is replaced with `if (frame.stack.size >= Stack.CAPACITY) unreachable`.

## Testing

The code changes maintain identical runtime behavior since both approaches (assert vs if+unreachable) result in the same program termination when the condition is violated. This refactoring improves code clarity by making the assertion checks more explicit.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stack size validation for all EVM opcodes by enforcing runtime checks, ensuring that operations abort immediately if stack requirements are not met, rather than only in debug builds.

- **Chores**
  - Updated internal error handling for stack operations to use unconditional runtime checks, increasing reliability and consistency in execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->