### PR TITLE
📦 perf: remove explicit inline keywords to reduce bundle size

### DIFF
--- a/src/evm/constants.zig
+++ b/src/evm/constants.zig
@@ -306,7 +306,7 @@ pub const SELFDESTRUCT: u8 = 0xFF;
 ///     // Read `data_size` bytes following the opcode
 /// }
 /// ```
-pub inline fn is_push(op: u8) bool {
+pub fn is_push(op: u8) bool {
     return op >= PUSH1 and op <= PUSH32;
 }
 
@@ -330,7 +330,7 @@ pub inline fn is_push(op: u8) bool {
 /// const size = get_push_size(PUSH20); // Returns 20
 /// const size2 = get_push_size(ADD);   // Returns 0
 /// ```
-pub inline fn get_push_size(op: u8) u8 {
+pub fn get_push_size(op: u8) u8 {
     if (!is_push(op)) return 0;
     return op - PUSH1 + 1;
 }
@@ -349,37 +349,37 @@ pub inline fn get_push_size(op: u8) u8 {
 ///
 /// ## Stack Effect
 /// DUPn: [... vn ... v1] -> [... vn ... v1 vn]
-pub inline fn is_dup(op: u8) bool {
+pub fn is_dup(op: u8) bool {
     return op >= DUP1 and op <= DUP16;
 }
 
 /// Get the stack position for a DUP opcode
 /// Returns 0 for non-DUP opcodes
-pub inline fn get_dup_position(op: u8) u8 {
+pub fn get_dup_position(op: u8) u8 {
     if (!is_dup(op)) return 0;
     return op - DUP1 + 1;
 }
 
 /// Check if an opcode is a SWAP operation
-pub inline fn is_swap(op: u8) bool {
+pub fn is_swap(op: u8) bool {
     return op >= SWAP1 and op <= SWAP16;
 }
 
 /// Get the stack position for a SWAP opcode
 /// Returns 0 for non-SWAP opcodes
-pub inline fn get_swap_position(op: u8) u8 {
+pub fn get_swap_position(op: u8) u8 {
     if (!is_swap(op)) return 0;
     return op - SWAP1 + 1;
 }
 
 /// Check if an opcode is a LOG operation
-pub inline fn is_log(op: u8) bool {
+pub fn is_log(op: u8) bool {
     return op >= LOG0 and op <= LOG4;
 }
 
 /// Get the number of topics for a LOG opcode
 /// Returns 0 for non-LOG opcodes
-pub inline fn get_log_topic_count(op: u8) u8 {
+pub fn get_log_topic_count(op: u8) u8 {
     if (!is_log(op)) return 0;
     return op - LOG0;
 }
@@ -410,18 +410,18 @@ pub inline fn get_log_topic_count(op: u8) u8 {
 ///     return;
 /// }
 /// ```
-pub inline fn is_terminating(op: u8) bool {
+pub fn is_terminating(op: u8) bool {
     return op == STOP or op == RETURN or op == REVERT or op == SELFDESTRUCT or op == INVALID;
 }
 
 /// Check if an opcode is a call operation
-pub inline fn is_call(op: u8) bool {
+pub fn is_call(op: u8) bool {
     return op == CALL or op == CALLCODE or op == DELEGATECALL or op == STATICCALL or
         op == EXTCALL or op == EXTDELEGATECALL or op == EXTSTATICCALL;
 }
 
 /// Check if an opcode is a create operation
-pub inline fn is_create(op: u8) bool {
+pub fn is_create(op: u8) bool {
     return op == CREATE or op == CREATE2;
 }
 
@@ -450,13 +450,13 @@ pub inline fn is_create(op: u8) bool {
 /// ## Static Call Protection
 /// These operations will fail with an error if executed within
 /// a STATICCALL context.
-pub inline fn modifies_state(op: u8) bool {
+pub fn modifies_state(op: u8) bool {
     return op == SSTORE or op == CREATE or op == CREATE2 or op == SELFDESTRUCT or
         op == LOG0 or op == LOG1 or op == LOG2 or op == LOG3 or op == LOG4;
 }
 
 /// Check if an opcode is valid
-pub inline fn is_valid(op: u8) bool {
+pub fn is_valid(op: u8) bool {
     return op != INVALID;
 }
 

--- a/src/evm/contract.zig
+++ b/src/evm/contract.zig
@@ -485,7 +485,7 @@ fn ensure_analysis(self: *Self, allocator: std.mem.Allocator) void {
 }
 
 /// Check if position is code (not data)
-pub inline fn is_code(self: *const Self, pos: u64) bool {
+pub fn is_code(self: *const Self, pos: u64) bool {
     if (self.analysis) |analysis| {
         // We know pos is within bounds if analysis exists, so use unchecked version
         return analysis.code_segments.is_set_unchecked(@intCast(pos));
@@ -516,30 +516,30 @@ pub inline fn is_code(self: *const Self, pos: u64) bool {
 /// ## Note
 /// This method is marked inline for performance as it's called
 /// millions of times during contract execution.
-pub inline fn use_gas(self: *Self, amount: u64) bool {
+pub fn use_gas(self: *Self, amount: u64) bool {
     if (self.gas < amount) return false;
     self.gas -= amount;
     return true;
 }
 
 /// Use gas without checking (when known safe)
-pub inline fn use_gas_unchecked(self: *Self, amount: u64) void {
+pub fn use_gas_unchecked(self: *Self, amount: u64) void {
     self.gas -= amount;
 }
 
 /// Refund gas to contract
-pub inline fn refund_gas(self: *Self, amount: u64) void {
+pub fn refund_gas(self: *Self, amount: u64) void {
     self.gas += amount;
 }
 
 /// Add to gas refund counter with clamping
-pub inline fn add_gas_refund(self: *Self, amount: u64) void {
+pub fn add_gas_refund(self: *Self, amount: u64) void {
     const max_refund = self.gas / MAX_REFUND_QUOTIENT;
     self.gas_refund = @min(self.gas_refund + amount, max_refund);
 }
 
 /// Subtract from gas refund counter with clamping
-pub inline fn sub_gas_refund(self: *Self, amount: u64) void {
+pub fn sub_gas_refund(self: *Self, amount: u64) void {
     self.gas_refund = if (self.gas_refund > amount) self.gas_refund - amount else 0;
 }
 

--- a/src/evm/jump_table.zig
+++ b/src/evm/jump_table.zig
@@ -92,7 +92,7 @@ pub fn init() Self {
 /// ```zig
 /// const op = table.get_operation(0x01); // Get ADD operation
 /// ```
-pub inline fn get_operation(self: *const Self, opcode: u8) *const Operation {
+pub fn get_operation(self: *const Self, opcode: u8) *const Operation {
     return self.table[opcode] orelse &Operation.NULL;
 }
 

--- a/src/evm/opcodes/arithmetic.zig
+++ b/src/evm/opcodes/arithmetic.zig
@@ -87,7 +87,7 @@ pub fn op_add(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -128,7 +128,7 @@ pub fn op_mul(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -168,7 +168,7 @@ pub fn op_sub(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -216,7 +216,7 @@ pub fn op_div(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -267,7 +267,7 @@ pub fn op_sdiv(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -327,7 +327,7 @@ pub fn op_mod(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -378,7 +378,7 @@ pub fn op_smod(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -437,7 +437,7 @@ pub fn op_addmod(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     const n = frame.stack.pop_unsafe();
     const b = frame.stack.pop_unsafe();
@@ -504,7 +504,7 @@ pub fn op_mulmod(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
     _ = interpreter;
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     const n = frame.stack.pop_unsafe();
     const b = frame.stack.pop_unsafe();
@@ -591,7 +591,7 @@ pub fn op_exp(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
     const vm = @as(*Vm, @ptrCast(@alignCast(interpreter)));
     _ = vm;
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const exp = frame.stack.pop_unsafe();
     const base = frame.stack.peek_unsafe().*;
@@ -669,7 +669,7 @@ pub fn op_signextend(pc: usize, interpreter: *Operation.Interpreter, state: *Ope
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const byte_num = frame.stack.pop_unsafe();
     const x = frame.stack.peek_unsafe().*;

--- a/src/evm/opcodes/bitwise.zig
+++ b/src/evm/opcodes/bitwise.zig
@@ -10,7 +10,7 @@ pub fn op_and(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -28,7 +28,7 @@ pub fn op_or(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -46,7 +46,7 @@ pub fn op_xor(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const b = frame.stack.pop_unsafe();
     const a = frame.stack.peek_unsafe().*;
@@ -64,7 +64,7 @@ pub fn op_not(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     const value = frame.stack.peek_unsafe().*;
 
@@ -81,7 +81,7 @@ pub fn op_byte(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const i = frame.stack.pop_unsafe();
     const val = frame.stack.peek_unsafe().*;
@@ -109,7 +109,7 @@ pub fn op_shl(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const shift = frame.stack.pop_unsafe();
     const value = frame.stack.peek_unsafe().*;
@@ -133,7 +133,7 @@ pub fn op_shr(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const shift = frame.stack.pop_unsafe();
     const value = frame.stack.peek_unsafe().*;
@@ -157,7 +157,7 @@ pub fn op_sar(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     const shift = frame.stack.pop_unsafe();
     const value = frame.stack.peek_unsafe().*;

--- a/src/evm/opcodes/comparison.zig
+++ b/src/evm/opcodes/comparison.zig
@@ -15,7 +15,7 @@ pub fn op_lt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -37,7 +37,7 @@ pub fn op_gt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -59,7 +59,7 @@ pub fn op_slt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -84,7 +84,7 @@ pub fn op_sgt(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -109,7 +109,7 @@ pub fn op_eq(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop the top operand (b) unsafely
     const b = frame.stack.pop_unsafe();
@@ -130,7 +130,7 @@ pub fn op_iszero(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Peek the operand unsafely
     const a = frame.stack.peek_unsafe().*;

--- a/src/evm/opcodes/control.zig
+++ b/src/evm/opcodes/control.zig
@@ -28,7 +28,7 @@ pub fn op_jump(pc: usize, interpreter: *Operation.Interpreter, state: *Operation
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Use unsafe pop since bounds checking is done by jump_table
     const dest = frame.stack.pop_unsafe();
@@ -50,7 +50,7 @@ pub fn op_jumpi(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Use batch pop for performance - pop 2 values at once
     const values = frame.stack.pop2_unsafe();
@@ -75,7 +75,7 @@ pub fn op_pc(pc: usize, interpreter: *Operation.Interpreter, state: *Operation.S
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Use unsafe push since bounds checking is done by jump_table
     frame.stack.append_unsafe(@as(u256, @intCast(pc)));
@@ -98,7 +98,7 @@ pub fn op_return(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Use batch pop for performance - pop 2 values at once
     const values = frame.stack.pop2_unsafe();
@@ -140,7 +140,7 @@ pub fn op_revert(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Use batch pop for performance - pop 2 values at once
     const values = frame.stack.pop2_unsafe();
@@ -199,7 +199,7 @@ pub fn op_selfdestruct(pc: usize, interpreter: *Operation.Interpreter, state: *O
     // Check if we're in a static call
     if (frame.is_static) return ExecutionError.Error.WriteProtection;
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Use unsafe pop since bounds checking is done by jump_table
     const beneficiary_u256 = frame.stack.pop_unsafe();

--- a/src/evm/opcodes/memory.zig
+++ b/src/evm/opcodes/memory.zig
@@ -21,7 +21,7 @@ pub fn op_mload(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Get offset from top of stack unsafely - bounds checking is done in jump_table.zig
     const offset = frame.stack.peek_unsafe().*;
@@ -55,7 +55,7 @@ pub fn op_mstore(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop two values unsafely using batch operation - bounds checking is done in jump_table.zig
     // EVM Stack: [..., value, offset] where offset is on top
@@ -89,7 +89,7 @@ pub fn op_mstore8(pc: usize, interpreter: *Operation.Interpreter, state: *Operat
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop two values unsafely using batch operation - bounds checking is done in jump_table.zig
     // EVM Stack: [..., value, offset] where offset is on top
@@ -124,7 +124,7 @@ pub fn op_msize(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // MSIZE returns the size in bytes, but memory is always expanded in 32-byte words
     // So we need to round up to the nearest word boundary
@@ -143,7 +143,7 @@ pub fn op_mcopy(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., dest, src, size] (top to bottom)
@@ -184,7 +184,7 @@ pub fn op_calldataload(pc: usize, interpreter: *Operation.Interpreter, state: *O
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Get offset from top of stack unsafely - bounds checking is done in jump_table.zig
     const offset = frame.stack.peek_unsafe().*;
@@ -220,7 +220,7 @@ pub fn op_calldatasize(pc: usize, interpreter: *Operation.Interpreter, state: *O
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Push result unsafely - bounds checking is done in jump_table.zig
     frame.stack.append_unsafe(@as(u256, @intCast(frame.input.len)));
@@ -234,7 +234,7 @@ pub fn op_calldatacopy(pc: usize, interpreter: *Operation.Interpreter, state: *O
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., size, data_offset, mem_offset] (top to bottom)
@@ -275,7 +275,7 @@ pub fn op_codesize(pc: usize, interpreter: *Operation.Interpreter, state: *Opera
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Push result unsafely - bounds checking is done in jump_table.zig
     frame.stack.append_unsafe(@as(u256, @intCast(frame.contract.code.len)));
@@ -289,7 +289,7 @@ pub fn op_codecopy(pc: usize, interpreter: *Operation.Interpreter, state: *Opera
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., size, code_offset, mem_offset] (top to bottom)
@@ -330,7 +330,7 @@ pub fn op_returndatasize(pc: usize, interpreter: *Operation.Interpreter, state: 
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size < Stack.CAPACITY);
+    if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
     // Push result unsafely - bounds checking is done in jump_table.zig
     frame.stack.append_unsafe(@as(u256, @intCast(frame.return_data_buffer.len)));
@@ -344,7 +344,7 @@ pub fn op_returndatacopy(pc: usize, interpreter: *Operation.Interpreter, state: 
 
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-    std.debug.assert(frame.stack.size >= 3);
+    if (frame.stack.size < 3) unreachable;
 
     // Pop three values unsafely - bounds checking is done in jump_table.zig
     // EVM stack order: [..., size, data_offset, mem_offset] (top to bottom)

--- a/src/evm/opcodes/memory.zig
+++ b/src/evm/opcodes/memory.zig
@@ -11,7 +11,7 @@ const error_mapping = @import("../error_mapping.zig");
 const map_memory_error = error_mapping.map_memory_error;
 
 // Helper to check if u256 fits in usize
-inline fn check_offset_bounds(value: u256) ExecutionError.Error!void {
+fn check_offset_bounds(value: u256) ExecutionError.Error!void {
     if (value > std.math.maxInt(usize)) return ExecutionError.Error.InvalidOffset;
 }
 

--- a/src/evm/opcodes/stack.zig
+++ b/src/evm/opcodes/stack.zig
@@ -35,7 +35,7 @@ pub fn make_push(comptime n: u8) fn (usize, *Operation.Interpreter, *Operation.S
 
             const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-            std.debug.assert(frame.stack.size < Stack.CAPACITY);
+            if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
             var value: u256 = 0;
             const code = frame.contract.code;
@@ -68,8 +68,8 @@ pub fn make_dup(comptime n: u8) fn (usize, *Operation.Interpreter, *Operation.St
 
             const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-            std.debug.assert(frame.stack.size >= n);
-            std.debug.assert(frame.stack.size < Stack.CAPACITY);
+            if (frame.stack.size < n) unreachable;
+            if (frame.stack.size >= Stack.CAPACITY) unreachable;
 
             frame.stack.dup_unsafe(n);
 
@@ -89,7 +89,7 @@ pub fn make_swap(comptime n: u8) fn (usize, *Operation.Interpreter, *Operation.S
 
             const frame = @as(*Frame, @ptrCast(@alignCast(state)));
 
-            std.debug.assert(frame.stack.size >= n + 1);
+            if (frame.stack.size < n + 1) unreachable;
 
             frame.stack.swapUnsafe(n);
 

--- a/src/evm/opcodes/storage.zig
+++ b/src/evm/opcodes/storage.zig
@@ -42,7 +42,7 @@ pub fn op_sload(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
     const frame = @as(*Frame, @ptrCast(@alignCast(state)));
     const vm = @as(*Vm, @ptrCast(@alignCast(interpreter)));
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     const slot = frame.stack.peek_unsafe().*;
 
@@ -80,7 +80,7 @@ pub fn op_sstore(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
     // This prevents reentrancy attacks by ensuring enough gas remains for exception handling
     if (vm.chain_rules.IsIstanbul and frame.gas_remaining <= gas_constants.SstoreSentryGas) return ExecutionError.Error.OutOfGas;
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Stack order: [..., value, slot] where slot is on top
     const popped = frame.stack.pop2_unsafe();
@@ -123,7 +123,7 @@ pub fn op_tload(pc: usize, interpreter: *Operation.Interpreter, state: *Operatio
 
     // Gas is already handled by jump table constant_gas = 100
 
-    std.debug.assert(frame.stack.size >= 1);
+    if (frame.stack.size < 1) unreachable;
 
     // Get slot from top of stack unsafely - bounds checking is done in jump_table.zig
     const slot = frame.stack.peek_unsafe().*;
@@ -146,7 +146,7 @@ pub fn op_tstore(pc: usize, interpreter: *Operation.Interpreter, state: *Operati
 
     // Gas is already handled by jump table constant_gas = 100
 
-    std.debug.assert(frame.stack.size >= 2);
+    if (frame.stack.size < 2) unreachable;
 
     // Pop two values unsafely using batch operation - bounds checking is done in jump_table.zig
     // Stack order: [..., value, slot] where slot is on top

--- a/src/evm/stack.zig
+++ b/src/evm/stack.zig
@@ -81,7 +81,7 @@ size: usize = 0,
 /// const stack = try Stack.from_slice(&values);
 /// // Stack: [10, 20, 30] with 30 on top
 /// ```
-pub inline fn from_slice(values: []const u256) Error!Self {
+pub fn from_slice(values: []const u256) Error!Self {
     var stack = Self{};
     for (values) |value| {
         try stack.append(value);
@@ -99,7 +99,7 @@ pub inline fn from_slice(values: []const u256) Error!Self {
 /// ```zig
 /// try stack.append(0x1234);
 /// ```
-pub inline fn append(self: *Self, value: u256) Error!void {
+pub fn append(self: *Self, value: u256) Error!void {
     if (self.size >= CAPACITY) return Error.Overflow;
     self.data[self.size] = value;
     self.size += 1;
@@ -112,13 +112,13 @@ pub inline fn append(self: *Self, value: u256) Error!void {
 ///
 /// @param self The stack to push onto
 /// @param value The 256-bit value to push
-pub inline fn append_unsafe(self: *Self, value: u256) void {
+pub fn append_unsafe(self: *Self, value: u256) void {
     self.data[self.size] = value;
     self.size += 1;
 }
 
 /// Alias for append_unsafe (camelCase compatibility).
-pub inline fn appendUnsafe(self: *Self, value: u256) void {
+pub fn appendUnsafe(self: *Self, value: u256) void {
     self.append_unsafe(value);
 }
 
@@ -135,7 +135,7 @@ pub inline fn appendUnsafe(self: *Self, value: u256) void {
 /// ```zig
 /// const value = try stack.pop();
 /// ```
-pub inline fn pop(self: *Self) Error!u256 {
+pub fn pop(self: *Self) Error!u256 {
     if (self.size == 0) return Error.Underflow;
     self.size -= 1;
     const value = self.data[self.size];
@@ -150,14 +150,14 @@ pub inline fn pop(self: *Self) Error!u256 {
 ///
 /// @param self The stack to pop from
 /// @return The popped value
-pub inline fn pop_unsafe(self: *Self) u256 {
+pub fn pop_unsafe(self: *Self) u256 {
     self.size -= 1;
     const value = self.data[self.size];
     self.data[self.size] = 0;
     return value;
 }
 
-pub inline fn popUnsafe(self: *Self) u256 {
+pub fn popUnsafe(self: *Self) u256 {
     return self.pop_unsafe();
 }
 
@@ -172,7 +172,7 @@ pub inline fn popUnsafe(self: *Self) u256 {
 /// const top = try stack.peek();
 /// std.debug.print("Top value: {}", .{top.*});
 /// ```
-pub inline fn peek(self: *const Self) Error!*const u256 {
+pub fn peek(self: *const Self) Error!*const u256 {
     if (self.size == 0) return Error.OutOfBounds;
     return &self.data[self.size - 1];
 }
@@ -183,11 +183,11 @@ pub inline fn peek(self: *const Self) Error!*const u256 {
 ///
 /// @param self The stack to peek at
 /// @return Pointer to the top value
-pub inline fn peek_unsafe(self: *const Self) *const u256 {
+pub fn peek_unsafe(self: *const Self) *const u256 {
     return &self.data[self.size - 1];
 }
 
-pub inline fn peekUnsafe(self: *const Self) *const u256 {
+pub fn peekUnsafe(self: *const Self) *const u256 {
     return self.peek_unsafe();
 }
 
@@ -195,11 +195,11 @@ pub inline fn peekUnsafe(self: *const Self) *const u256 {
 ///
 /// @param self The stack to check
 /// @return true if stack has no elements
-pub inline fn is_empty(self: *const Self) bool {
+pub fn is_empty(self: *const Self) bool {
     return self.size == 0;
 }
 
-pub inline fn isEmpty(self: *const Self) bool {
+pub fn isEmpty(self: *const Self) bool {
     return self.is_empty();
 }
 
@@ -207,11 +207,11 @@ pub inline fn isEmpty(self: *const Self) bool {
 ///
 /// @param self The stack to check
 /// @return true if stack has 1024 elements
-pub inline fn is_full(self: *const Self) bool {
+pub fn is_full(self: *const Self) bool {
     return self.size == CAPACITY;
 }
 
-pub inline fn isFull(self: *const Self) bool {
+pub fn isFull(self: *const Self) bool {
     return self.is_full();
 }
 
@@ -230,29 +230,29 @@ pub inline fn isFull(self: *const Self) bool {
 /// const top = try stack.back(0); // Returns 30
 /// const second = try stack.back(1); // Returns 20
 /// ```
-pub inline fn back(self: *const Self, n: usize) Error!u256 {
+pub fn back(self: *const Self, n: usize) Error!u256 {
     if (n >= self.size) return Error.OutOfBounds;
     return self.data[self.size - n - 1];
 }
 
-pub inline fn back_unsafe(self: *const Self, n: usize) u256 {
+pub fn back_unsafe(self: *const Self, n: usize) u256 {
     return self.data[self.size - n - 1];
 }
 
-pub inline fn backUnsafe(self: *const Self, n: usize) u256 {
+pub fn backUnsafe(self: *const Self, n: usize) u256 {
     return self.back_unsafe(n);
 }
 
-pub inline fn peek_n(self: *const Self, n: usize) Error!u256 {
+pub fn peek_n(self: *const Self, n: usize) Error!u256 {
     if (n >= self.size) return Error.OutOfBounds;
     return self.data[self.size - n - 1];
 }
 
-pub inline fn peekN(self: *const Self, n: usize) Error!u256 {
+pub fn peekN(self: *const Self, n: usize) Error!u256 {
     return self.peek_n(n);
 }
 
-pub inline fn peek_n_unsafe(self: *const Self, n: usize) Error!u256 {
+pub fn peek_n_unsafe(self: *const Self, n: usize) Error!u256 {
     return self.data[self.size - n - 1];
 }
 
@@ -272,21 +272,21 @@ pub inline fn peek_n_unsafe(self: *const Self, n: usize) Error!u256 {
 /// try stack.swap(2); // SWAP2
 /// // Stack: [10, 40, 30, 20] with 20 on top
 /// ```
-pub inline fn swap(self: *Self, n: usize) Error!void {
+pub fn swap(self: *Self, n: usize) Error!void {
     if (n == 0 or n > 16) return Error.InvalidPosition;
     if (self.size <= n) return Error.OutOfBounds;
     std.mem.swap(u256, &self.data[self.size - 1], &self.data[self.size - n - 1]);
 }
 
-pub inline fn swap_unsafe(self: *Self, n: usize) Error!void {
+pub fn swap_unsafe(self: *Self, n: usize) Error!void {
     std.mem.swap(u256, &self.data[self.size - 1], &self.data[self.size - n - 1]);
 }
 
-pub inline fn swapUnsafe(self: *Self, n: usize) void {
+pub fn swapUnsafe(self: *Self, n: usize) void {
     std.mem.swap(u256, &self.data[self.size - 1], &self.data[self.size - n - 1]);
 }
 
-pub inline fn swap_n(self: *Self, comptime N: usize) Error!void {
+pub fn swap_n(self: *Self, comptime N: usize) Error!void {
     if (N == 0 or N > 16) @compileError("Invalid swap position");
     if (self.size <= N) return Error.OutOfBounds;
     const top_idx = self.size - 1;
@@ -294,11 +294,11 @@ pub inline fn swap_n(self: *Self, comptime N: usize) Error!void {
     std.mem.swap(@TypeOf(self.data[0]), &self.data[top_idx], &self.data[swap_idx]);
 }
 
-pub inline fn swapN(self: *Self, n: usize) Error!void {
+pub fn swapN(self: *Self, n: usize) Error!void {
     return self.swap(n);
 }
 
-pub inline fn swap_n_unsafe(self: *Self, comptime N: usize) void {
+pub fn swap_n_unsafe(self: *Self, comptime N: usize) void {
     @setRuntimeSafety(false);
     if (N == 0 or N > 16) @compileError("Invalid swap position");
     // Unsafe: No bounds checking - caller must ensure self.size > N
@@ -309,7 +309,7 @@ pub inline fn swap_n_unsafe(self: *Self, comptime N: usize) void {
     self.data[swap_idx] = temp;
 }
 
-pub inline fn swapNUnsafe(self: *Self, n: usize) void {
+pub fn swapNUnsafe(self: *Self, n: usize) void {
     @setRuntimeSafety(false);
     const top_idx = self.size - 1;
     const swap_idx = self.size - n - 1;
@@ -333,47 +333,47 @@ pub inline fn swapNUnsafe(self: *Self, n: usize) void {
 /// try stack.dup(2); // DUP2
 /// // Stack: [10, 20, 30, 20] with 20 on top
 /// ```
-pub inline fn dup(self: *Self, n: usize) Error!void {
+pub fn dup(self: *Self, n: usize) Error!void {
     if (n == 0 or n > 16) return Error.InvalidPosition;
     if (n > self.size) return Error.OutOfBounds;
     if (self.size >= CAPACITY) return Error.Overflow;
     try self.append(self.data[self.size - n]);
 }
 
-pub inline fn dup_unsafe(self: *Self, n: usize) void {
+pub fn dup_unsafe(self: *Self, n: usize) void {
     @setRuntimeSafety(false);
     self.append_unsafe(self.data[self.size - n]);
 }
 
-pub inline fn dupUnsafe(self: *Self, n: usize) void {
+pub fn dupUnsafe(self: *Self, n: usize) void {
     @setRuntimeSafety(false);
     self.dup_unsafe(n);
 }
 
-pub inline fn dup_n(self: *Self, comptime N: usize) Error!void {
+pub fn dup_n(self: *Self, comptime N: usize) Error!void {
     if (N == 0 or N > 16) @compileError("Invalid dup position");
     if (N > self.size) return Error.OutOfBounds;
     if (self.size >= CAPACITY) return Error.Overflow;
     try self.append(self.data[self.size - N]);
 }
 
-pub inline fn dupN(self: *Self, n: usize) Error!void {
+pub fn dupN(self: *Self, n: usize) Error!void {
     return self.dup(n);
 }
 
-pub inline fn dup_n_unsafe(self: *Self, comptime N: usize) void {
+pub fn dup_n_unsafe(self: *Self, comptime N: usize) void {
     @setRuntimeSafety(false);
     if (N == 0 or N > 16) @compileError("Invalid dup position");
     // Unsafe: No bounds checking - caller must ensure N <= self.size and self.size < CAPACITY
     self.append_unsafe(self.data[self.size - N]);
 }
 
-pub inline fn dupNUnsafe(self: *Self, n: usize) void {
+pub fn dupNUnsafe(self: *Self, n: usize) void {
     @setRuntimeSafety(false);
     self.append_unsafe(self.data[self.size - n]);
 }
 
-pub inline fn pop_n(self: *Self, comptime N: usize) Error![N]u256 {
+pub fn pop_n(self: *Self, comptime N: usize) Error![N]u256 {
     if (self.size < N) return Error.OutOfBounds;
 
     self.size -= N;
@@ -388,7 +388,7 @@ pub inline fn pop_n(self: *Self, comptime N: usize) Error![N]u256 {
     return result;
 }
 
-pub inline fn popn(self: *Self, n: usize) Error![]u256 {
+pub fn popn(self: *Self, n: usize) Error![]u256 {
     if (self.size < n) return Error.OutOfBounds;
 
     self.size -= n;
@@ -398,7 +398,7 @@ pub inline fn popn(self: *Self, n: usize) Error![]u256 {
 }
 
 /// Pop N values and return reference to new top (for opcodes that pop N and push 1)
-pub inline fn pop_n_top(self: *Self, comptime N: usize) Error!struct {
+pub fn pop_n_top(self: *Self, comptime N: usize) Error!struct {
     values: [N]u256,
     top: *u256,
 } {
@@ -407,7 +407,7 @@ pub inline fn pop_n_top(self: *Self, comptime N: usize) Error!struct {
     return .{ .values = values, .top = &self.data[self.size - 1] };
 }
 
-pub inline fn popn_top(self: *Self, n: usize) Error!struct {
+pub fn popn_top(self: *Self, n: usize) Error!struct {
     values: []u256,
     top: *u256,
 } {
@@ -419,7 +419,7 @@ pub inline fn popn_top(self: *Self, n: usize) Error!struct {
 // EIP-663 operations
 
 /// DUPN - duplicate Nth element (dynamic N from bytecode)
-pub inline fn dup_n_dynamic(self: *Self, n: u8) Error!void {
+pub fn dup_n_dynamic(self: *Self, n: u8) Error!void {
     if (n == 0) return Error.InvalidPosition;
     const idx = @as(usize, n);
     if (idx > self.size) return Error.OutOfBounds;
@@ -427,12 +427,12 @@ pub inline fn dup_n_dynamic(self: *Self, n: u8) Error!void {
     try self.append(self.data[self.size - idx]);
 }
 
-pub inline fn dupn(self: *Self, n: usize) Error!void {
+pub fn dupn(self: *Self, n: usize) Error!void {
     return self.dup(n);
 }
 
 /// SWAPN - swap top with Nth element (dynamic N from bytecode)
-pub inline fn swap_n_dynamic(self: *Self, n: u8) Error!void {
+pub fn swap_n_dynamic(self: *Self, n: u8) Error!void {
     // EIP-663: swap the top element with the one at `depth + 1`
     if (n >= self.size) return Error.OutOfBounds;
     const last = self.size - 1;
@@ -443,11 +443,11 @@ pub inline fn swap_n_dynamic(self: *Self, n: u8) Error!void {
     );
 }
 
-pub inline fn swapn(self: *Self, n: usize) Error!void {
+pub fn swapn(self: *Self, n: usize) Error!void {
     return self.swap(n);
 }
 
-pub inline fn exchange(self: *Self, n: u8, m: u8) Error!void {
+pub fn exchange(self: *Self, n: u8, m: u8) Error!void {
     if (m == 0) return Error.InvalidPosition;
 
     const n_idx = @as(usize, n) + 1;
@@ -464,16 +464,16 @@ pub inline fn exchange(self: *Self, n: u8, m: u8) Error!void {
 /// The zeroing can be removed for performance if security is not a concern.
 ///
 /// @param self The stack to clear
-pub inline fn clear(self: *Self) void {
+pub fn clear(self: *Self) void {
     self.size = 0;
     @memset(&self.data, 0); // could consider removing for perf
 }
 
-pub inline fn to_slice(self: *const Self) []const u256 {
+pub fn to_slice(self: *const Self) []const u256 {
     return self.data[0..self.size];
 }
 
-pub inline fn toSlice(self: *const Self) []const u256 {
+pub fn toSlice(self: *const Self) []const u256 {
     return self.to_slice();
 }
 
@@ -494,11 +494,11 @@ pub inline fn toSlice(self: *const Self) []const u256 {
 ///     // Safe to proceed
 /// }
 /// ```
-pub inline fn check_requirements(self: *const Self, pop_count: usize, push_count: usize) bool {
+pub fn check_requirements(self: *const Self, pop_count: usize, push_count: usize) bool {
     return self.size >= pop_count and (self.size - pop_count + push_count) <= CAPACITY;
 }
 
-pub inline fn checkRequirements(self: *const Self, pop_count: usize, push_count: usize) bool {
+pub fn checkRequirements(self: *const Self, pop_count: usize, push_count: usize) bool {
     return self.check_requirements(pop_count, push_count);
 }
 
@@ -521,7 +521,7 @@ pub inline fn checkRequirements(self: *const Self, pop_count: usize, push_count:
 /// const operands = try stack.pop2_push1(a_plus_b);
 /// // operands.a and operands.b contain the popped values
 /// ```
-pub inline fn pop2_push1(self: *Self, result: u256) Error!struct { a: u256, b: u256 } {
+pub fn pop2_push1(self: *Self, result: u256) Error!struct { a: u256, b: u256 } {
     if (self.size < 2) return Error.OutOfBounds;
 
     // Pop two values
@@ -537,7 +537,7 @@ pub inline fn pop2_push1(self: *Self, result: u256) Error!struct { a: u256, b: u
 }
 
 /// Pop 2 values and push 1 result (unsafe version for hot paths)
-pub inline fn pop2_push1_unsafe(self: *Self, result: u256) struct { a: u256, b: u256 } {
+pub fn pop2_push1_unsafe(self: *Self, result: u256) struct { a: u256, b: u256 } {
     @setRuntimeSafety(false);
 
     self.size -= 2;
@@ -551,7 +551,7 @@ pub inline fn pop2_push1_unsafe(self: *Self, result: u256) struct { a: u256, b: 
 }
 
 /// Pop 3 values and push 1 result - common for ternary operations
-pub inline fn pop3_push1(self: *Self, result: u256) Error!struct { a: u256, b: u256, c: u256 } {
+pub fn pop3_push1(self: *Self, result: u256) Error!struct { a: u256, b: u256, c: u256 } {
     if (self.size < 3) return Error.OutOfBounds;
 
     self.size -= 3;
@@ -566,7 +566,7 @@ pub inline fn pop3_push1(self: *Self, result: u256) Error!struct { a: u256, b: u
 }
 
 /// Pop 3 values and push 1 result (unsafe version)
-pub inline fn pop3_push1_unsafe(self: *Self, result: u256) struct { a: u256, b: u256, c: u256 } {
+pub fn pop3_push1_unsafe(self: *Self, result: u256) struct { a: u256, b: u256, c: u256 } {
     @setRuntimeSafety(false);
 
     self.size -= 3;
@@ -581,7 +581,7 @@ pub inline fn pop3_push1_unsafe(self: *Self, result: u256) struct { a: u256, b: 
 }
 
 /// Pop 1 value and push 1 result - for unary operations
-pub inline fn pop1_push1(self: *Self, result: u256) Error!u256 {
+pub fn pop1_push1(self: *Self, result: u256) Error!u256 {
     if (self.size < 1) return Error.OutOfBounds;
 
     const value = self.data[self.size - 1];
@@ -591,7 +591,7 @@ pub inline fn pop1_push1(self: *Self, result: u256) Error!u256 {
 }
 
 /// Pop 1 value and push 1 result (unsafe version)
-pub inline fn pop1_push1_unsafe(self: *Self, result: u256) u256 {
+pub fn pop1_push1_unsafe(self: *Self, result: u256) u256 {
     @setRuntimeSafety(false);
 
     const value = self.data[self.size - 1];
@@ -601,7 +601,7 @@ pub inline fn pop1_push1_unsafe(self: *Self, result: u256) u256 {
 }
 
 /// Pop 2 values without pushing - for comparison operations
-pub inline fn pop2(self: *Self) Error!struct { a: u256, b: u256 } {
+pub fn pop2(self: *Self) Error!struct { a: u256, b: u256 } {
     if (self.size < 2) return Error.OutOfBounds;
 
     self.size -= 2;
@@ -612,7 +612,7 @@ pub inline fn pop2(self: *Self) Error!struct { a: u256, b: u256 } {
 }
 
 /// Pop 2 values without pushing (unsafe version)
-pub inline fn pop2_unsafe(self: *Self) struct { a: u256, b: u256 } {
+pub fn pop2_unsafe(self: *Self) struct { a: u256, b: u256 } {
     @setRuntimeSafety(false);
 
     self.size -= 2;
@@ -623,7 +623,7 @@ pub inline fn pop2_unsafe(self: *Self) struct { a: u256, b: u256 } {
 }
 
 /// Pop 3 values without pushing - for memory operations
-pub inline fn pop3(self: *Self) Error!struct { a: u256, b: u256, c: u256 } {
+pub fn pop3(self: *Self) Error!struct { a: u256, b: u256, c: u256 } {
     if (self.size < 3) return Error.OutOfBounds;
 
     self.size -= 3;
@@ -635,7 +635,7 @@ pub inline fn pop3(self: *Self) Error!struct { a: u256, b: u256, c: u256 } {
 }
 
 /// Pop 3 values without pushing (unsafe version)
-pub inline fn pop3_unsafe(self: *Self) struct { a: u256, b: u256, c: u256 } {
+pub fn pop3_unsafe(self: *Self) struct { a: u256, b: u256, c: u256 } {
     @setRuntimeSafety(false);
 
     self.size -= 3;
@@ -661,7 +661,7 @@ pub inline fn pop3_unsafe(self: *Self) struct { a: u256, b: u256, c: u256 } {
 /// try stack.swap1_optimized();
 /// // Stack: [20, 10] with 10 on top
 /// ```
-pub inline fn swap1_optimized(self: *Self) Error!void {
+pub fn swap1_optimized(self: *Self) Error!void {
     if (self.size < 2) return Error.OutOfBounds;
 
     const top_idx = self.size - 1;
@@ -688,7 +688,7 @@ pub inline fn swap1_optimized(self: *Self) Error!void {
 /// try stack.dup1_optimized();
 /// // Stack: [10, 20, 20] with 20 on top
 /// ```
-pub inline fn dup1_optimized(self: *Self) Error!void {
+pub fn dup1_optimized(self: *Self) Error!void {
     if (self.size == 0) return Error.OutOfBounds;
     if (self.size >= CAPACITY) return Error.Overflow;
 
@@ -697,7 +697,7 @@ pub inline fn dup1_optimized(self: *Self) Error!void {
 }
 
 /// Batch push multiple values
-pub inline fn push_batch(self: *Self, values: []const u256) Error!void {
+pub fn push_batch(self: *Self, values: []const u256) Error!void {
     if (self.size + values.len > CAPACITY) return Error.Overflow;
 
     @memcpy(self.data[self.size .. self.size + values.len], values);
@@ -705,7 +705,7 @@ pub inline fn push_batch(self: *Self, values: []const u256) Error!void {
 }
 
 /// Get multiple top values without popping (for opcodes that need to peek at multiple values)
-pub inline fn peek_multiple(self: *const Self, comptime N: usize) Error![N]u256 {
+pub fn peek_multiple(self: *const Self, comptime N: usize) Error![N]u256 {
     if (self.size < N) return Error.OutOfBounds;
 
     var result: [N]u256 = undefined;
@@ -715,14 +715,14 @@ pub inline fn peek_multiple(self: *const Self, comptime N: usize) Error![N]u256 
     return result;
 }
 
-pub inline fn set_top_unsafe(self: *Self, value: u256) void {
+pub fn set_top_unsafe(self: *Self, value: u256) void {
     // @setRuntimeSafety(false); // Removed as per user feedback
     // Assumes stack is not empty; this should be guaranteed by jump_table validation
     // for opcodes that use this pattern (e.g., after a pop and peek on a stack with >= 2 items).
     self.data[self.size - 1] = value;
 }
 
-pub inline fn set_top_two_unsafe(self: *Self, top: u256, second: u256) void {
+pub fn set_top_two_unsafe(self: *Self, top: u256, second: u256) void {
     // Assumes stack has at least 2 elements; this should be guaranteed by jump_table validation
     self.data[self.size - 1] = top;
     self.data[self.size - 2] = second;


### PR DESCRIPTION
## Description

Removed `inline` attribute from utility functions in the EVM implementation to better allow compiler reduce binary size. This change affects functions in several modules including constants, contract, jump_table, memory opcodes, and stack operations. In Fast mode compiler will usually be smart enough toinline and the official docs warn against inlining for perf reasons

## Testing

The code has been tested to ensure that removing the `inline` attribute doesn't affect functionality. Performance-critical paths have been verified to maintain their efficiency, as the compiler will still automatically inline functions where beneficial.

## Additional Information

- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)

Your ENS/address: