### PR TITLE
docs: fix LSP plugin link in changelog

### DIFF
--- a/bundler-packages/solc/CHANGELOG.md
+++ b/bundler-packages/solc/CHANGELOG.md
@@ -461,7 +461,7 @@
 
   ![image](https://github.com/evmts/tevm-monorepo/assets/35039927/57277b41-195c-4c54-ab70-a4e1ef3fceaa)
 
-  This will be used internally to implement go-to-definition LSP support to [@tevm/ts-plugin](https://github.com/evmts/tevm-monorepo/tree/main/ts-plugin)
+  This will be used internally to implement go-to-definition LSP support to [@tevm/ts-plugin](https://github.com/evmts/tevm-monorepo/tree/main/lsp/ts-plugin)
 
 ### Patch Changes
 


### PR DESCRIPTION
Updated outdated link to the ts-plugin in CHANGELOG.md to point to the correct lsp/ts-plugin path inside the monorepo.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to correct the URL path for internal usage notes related to go-to-definition LSP support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->