### PR TITLE
fix: ci failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,25 +97,21 @@ jobs:
         continue-on-error: true
         run: pnpm -r build:wasm
 
-      - name: Check Results
+      - name: Check results
         if: always()
         run: |
-          echo "| Task | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-
           failed=""
-          steps_json='${{ toJson(steps) }}'
+          [[ "${{ steps.build-types.conclusion }}" != "success" ]] && failed="$failed build-types"
+          [[ "${{ steps.tests.conclusion }}" != "success" ]] && failed="$failed tests"
+          [[ "${{ steps.fixtures.conclusion }}" != "success" ]] && failed="$failed fixtures"
+          [[ "${{ steps.tests-rust.conclusion }}" != "success" ]] && failed="$failed tests-rust"
+          [[ "${{ steps.typecheck.conclusion }}" != "success" ]] && failed="$failed typecheck"
+          [[ "${{ steps.lint.conclusion }}" != "success" ]] && failed="$failed lint"
+          [[ "${{ steps.lint-deps.conclusion }}" != "success" ]] && failed="$failed lint-deps"
+          [[ "${{ steps.lint-packages.conclusion }}" != "success" ]] && failed="$failed lint-packages"
+          [[ "${{ steps.build-app.conclusion }}" != "success" ]] && failed="$failed build-app"
+          [[ "${{ steps.generate-docs.conclusion }}" != "success" ]] && failed="$failed generate-docs"
+          [[ "${{ steps.build-rust.conclusion }}" != "success" ]] && failed="$failed build-rust"
+          [[ "${{ steps.build-wasm.conclusion }}" != "success" ]] && failed="$failed build-wasm"
 
-          for step in build-types tests fixtures tests-rust typecheck lint lint-deps lint-packages build-app generate-docs build-rust build-wasm; do
-            conclusion=$(echo "$steps_json" | jq -r ".\"$step\".conclusion // \"skipped\"")
-            name=$(echo "$step" | sed 's/-/ /g' | sed 's/\b\w/\U&/g')  # Convert to Title Case
-
-            if [[ "$conclusion" == "success" ]]; then
-              echo "| $name | ✅ |" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "| $name | ❌ |" >> $GITHUB_STEP_SUMMARY
-              failed="$failed $step"
-            fi
-          done
-
-          [[ -n "$failed" ]] && { echo "❌ Failed:$failed" >> $GITHUB_STEP_SUMMARY; exit 1; } || echo "✅ All tasks passed" >> $GITHUB_STEP_SUMMARY
+          [[ -n "$failed" ]] && { echo "❌ Failed:$failed"; exit 1; } || echo "✅ All passed"


### PR DESCRIPTION
Fail CI workflow on any task failure, and log the status (success/failed) of each task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a consolidated summary step to the CI workflow, displaying a markdown table of step results and clearly indicating any failures in the GitHub Actions summary. The workflow now fails if any key steps fail, regardless of individual step error settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->