### PR TITLE
fix: contract build

### DIFF
--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -6,6 +6,7 @@
 				"name": "@evmts/ts-plugin"
 			}
 		],
+		"rootDir": "src",
 		"outDir": "types",
 		"skipLibCheck": true,
 		// this should be "Bundler" but don't want to fight a broken type


### PR DESCRIPTION
Fix contract `build:types` for CI: https://github.com/evmts/tevm-monorepo/actions/runs/15567743171/job/43835877411?pr=1825#step:6:815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal TypeScript configuration for improved project structure management. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->