### PR TITLE
Fix link to contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Explain the quality checks that have been done on the code changes
 
 ## Additional Information
 
-- [ ] I read the [contributing docs](../docs/contributing.md) (if this is your first contribution)
+- [ ] I read the [contributing docs](../tevm/docs/_media/CONTRIBUTING.md) (if this is your first contribution)
 
 Your ENS/address:
 


### PR DESCRIPTION
What was changed
In .github/pull_request_template.md, we updated the link to the contributing guide:

Old:
../docs/contributing.md

New:
../tevm/docs/media/CONTRIBUTING.md

Why this change is needed
The previous link pointed to a non-existent or outdated location.
This update ensures that contributors are directed to the correct and current contributing documentation based on the updated folder structure.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request template to fix the link to the contributing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->