### PR TITLE
fix: getBalanceHandler with block hash

### DIFF
--- a/packages/actions/src/eth/getBalanceHandler.js
+++ b/packages/actions/src/eth/getBalanceHandler.js
@@ -1,7 +1,7 @@
 import { createAddress } from '@tevm/address'
 import { NoForkUrlSetError } from '@tevm/errors'
 import { createJsonRpcFetcher } from '@tevm/jsonrpc'
-import { bytesToHex, hexToBigInt, hexToBytes } from '@tevm/utils'
+import { bytesToHex, hexToBigInt } from '@tevm/utils'
 import { getPendingClient } from '../internal/getPendingClient.js'
 
 /**
@@ -25,13 +25,7 @@ export const getBalanceHandler =
 			return getBalanceHandler(mineResult.pendingClient)({ address, blockTag: 'latest' })
 		}
 		const block =
-			vm.blockchain.blocks.get(
-				/** @type any*/ (
-					typeof blockTag === 'string' && blockTag.startsWith('0x')
-						? hexToBytes(/** @type {import('@tevm/utils').Hex}*/ (blockTag))
-						: blockTag
-				),
-			) ??
+			vm.blockchain.blocks.get(/** @type any*/ (blockTag)) ??
 			vm.blockchain.blocksByTag.get(/** @type any*/ (blockTag)) ??
 			vm.blockchain.blocksByNumber.get(/** @type any*/ (blockTag))
 		const hasStateRoot = block && (await vm.stateManager.hasStateRoot(block.header.stateRoot))


### PR DESCRIPTION
## Description

Fixed the `getBalanceHandler` to properly handle block hash lookups by removing incorrect conversion of block tag from hex to bytes (`vm.blockchain.blocks.get()` expects a hex string, not a bytes array).

## Testing

Added a new test case that verifies the ability to fetch account balances using block hashes. The test confirms that the handler correctly retrieves balances from different blocks when referenced by their hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when fetching account balances by block hash, ensuring correct results when specifying a block hash as the block tag.

- **Tests**
  - Added tests to verify balance retrieval using block hashes, confirming correct balance values are returned for specific blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->