### PR TITLE
🐛 fix: await blockToJsonRpcBlock in ethGetBlockByNumberProcedure

### DIFF
--- a/packages/actions/src/eth/ethGetBlockByNumberProcedure.js
+++ b/packages/actions/src/eth/ethGetBlockByNumberProcedure.js
@@ -53,7 +53,7 @@ export const ethGetBlockByNumberJsonRpcProcedure = (client) => {
 			}
 		}
 		const includeTransactions = request.params[1] ?? false
-		const result = blockToJsonRpcBlock(block, includeTransactions)
+		const result = await blockToJsonRpcBlock(block, includeTransactions)
 		return {
 			method: request.method,
 			result,

--- a/packages/actions/src/eth/ethGetBlockByNumberProcedure.spec.ts
+++ b/packages/actions/src/eth/ethGetBlockByNumberProcedure.spec.ts
@@ -72,4 +72,24 @@ describe('ethGetBlockByNumberJsonRpcProcedure', () => {
 		expect(response.error).toBeDefined()
 		expect(response.error).toMatchSnapshot()
 	})
+
+	it('should NOT return a Promise object in the result (reproduces bug)', async () => {
+		const request: EthGetBlockByNumberJsonRpcRequest = {
+			jsonrpc: '2.0',
+			method: 'eth_getBlockByNumber',
+			id: 1,
+			params: ['0x1', false], // Block number as hex
+		}
+
+		const response = await ethGetBlockByNumberJsonRpcProcedure(client)(request)
+		expect(response.error).toBeUndefined()
+		expect(response.result).toBeDefined()
+		
+		// This test reproduces the bug: the result should be a plain object, not a Promise
+		expect(response.result).not.toBeInstanceOf(Promise)
+		expect(typeof response.result).toBe('object')
+		expect(response.result).toHaveProperty('number')
+		expect(response.result).toHaveProperty('hash')
+		expect(response.result).toHaveProperty('parentHash')
+	})
 })


### PR DESCRIPTION
This PR fixes issue #1893 where `getBlockByNumber` was returning a Promise instead of the actual block data.

## Problem
The `ethGetBlockByNumberProcedure` was missing the `await` keyword when calling the async `blockToJsonRpcBlock()` function, causing it to return a Promise object in the JSON-RPC response.

## Solution
- Added missing `await` keyword in `ethGetBlockByNumberProcedure.js` line 56
- Added test case to verify result is not a Promise object
- Followed TDD: reproduced bug first, then fixed it
- Now consistent with `ethGetBlockByHashProcedure` which correctly uses await

## Testing
Added test case `should NOT return a Promise object in the result (reproduces bug)` that ensures the result is a proper block object with expected properties.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where block data in JSON-RPC responses could be returned as a Promise instead of a fully resolved object.

- **Tests**
  - Added a test to ensure block data in responses is a plain object and not a Promise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->