### PR TITLE
feat: EthBlobBaseFeeJsonRpcProcedure type

### DIFF
--- a/packages/actions/src/eth/EthJsonRpcRequest.ts
+++ b/packages/actions/src/eth/EthJsonRpcRequest.ts
@@ -310,6 +310,7 @@ export type EthCreateAccessListJsonRpcRequest = JsonRpcRequest<
 export type EthJsonRpcRequest =
 	| EthAccountsJsonRpcRequest
 	| EthAccountsJsonRpcRequest
+	| EthBlobBaseFeeJsonRpcRequest
 	| EthBlockNumberJsonRpcRequest
 	| EthCallJsonRpcRequest
 	| EthChainIdJsonRpcRequest

--- a/packages/actions/src/eth/EthJsonRpcRequest.ts
+++ b/packages/actions/src/eth/EthJsonRpcRequest.ts
@@ -39,6 +39,11 @@ export type JsonRpcTransaction = {
  * JSON-RPC request for `eth_accounts` procedure
  */
 export type EthAccountsJsonRpcRequest = JsonRpcRequest<'eth_accounts', readonly []>
+// eth_blobBaseFee
+/**
+ * JSON-RPC request for `eth_blobBaseFee` procedure
+ */
+export type EthBlobBaseFeeJsonRpcRequest = JsonRpcRequest<'eth_blobBaseFee', readonly []>
 // eth_blockNumber
 /**
  * JSON-RPC request for `eth_blockNumber` procedure

--- a/packages/actions/src/eth/EthJsonRpcResponse.ts
+++ b/packages/actions/src/eth/EthJsonRpcResponse.ts
@@ -13,6 +13,12 @@ import type { EthBlockNumberResult } from './EthResult.js'
  */
 export type EthAccountsJsonRpcResponse = JsonRpcResponse<'eth_accounts', Address[], string | number>
 
+// eth_blobBaseFee
+/**
+ * JSON-RPC response for `eth_blobBaseFee` procedure
+ */
+export type EthBlobBaseFeeJsonRpcResponse = JsonRpcResponse<'eth_blobBaseFee', Hex, string | number>
+
 // eth_blockNumber
 /**
  * JSON-RPC response for `eth_blockNumber` procedure

--- a/packages/actions/src/eth/EthProcedure.ts
+++ b/packages/actions/src/eth/EthProcedure.ts
@@ -1,5 +1,6 @@
 import type {
 	EthAccountsJsonRpcRequest,
+	EthBlobBaseFeeJsonRpcRequest,
 	EthBlockNumberJsonRpcRequest,
 	EthCallJsonRpcRequest,
 	EthChainIdJsonRpcRequest,
@@ -41,6 +42,7 @@ import type {
 } from './EthJsonRpcRequest.js'
 import type {
 	EthAccountsJsonRpcResponse,
+	EthBlobBaseFeeJsonRpcResponse,
 	EthBlockNumberJsonRpcResponse,
 	EthCallJsonRpcResponse,
 	EthChainIdJsonRpcResponse,
@@ -83,6 +85,10 @@ import type {
 
 // eth_accounts
 export type EthAccountsJsonRpcProcedure = (request: EthAccountsJsonRpcRequest) => Promise<EthAccountsJsonRpcResponse>
+// eth_blobBaseFee
+export type EthBlobBaseFeeJsonRpcProcedure = (
+	request: EthBlobBaseFeeJsonRpcRequest,
+) => Promise<EthBlobBaseFeeJsonRpcResponse>
 // eth_blockNumber
 export type EthBlockNumberJsonRpcProcedure = (
 	request: EthBlockNumberJsonRpcRequest,

--- a/packages/actions/src/eth/ethBlobBaseFeeProcedure.js
+++ b/packages/actions/src/eth/ethBlobBaseFeeProcedure.js
@@ -1,11 +1,9 @@
-// TODO add a  @returns {import('./EthProcedure.js').EthBlobBaseFeeJsonRpcProcedure}
-
 import { numberToHex } from '@tevm/utils'
 
 /**
  * Request handler for eth_coinbase JSON-RPC requests.
  * @param {import('@tevm/node').TevmNode} client
- * @returns {import('./EthProcedure.js').EthGasPriceJsonRpcProcedure}
+ * @returns {import('./EthProcedure.js').EthBlobBaseFeeJsonRpcProcedure}
  */
 export const ethBlobBaseFeeJsonRpcProcedure = (client) => {
 	return async (request) => {

--- a/packages/actions/src/eth/ethBlobBaseFeeProcedure.js
+++ b/packages/actions/src/eth/ethBlobBaseFeeProcedure.js
@@ -1,7 +1,7 @@
 import { numberToHex } from '@tevm/utils'
 
 /**
- * Request handler for eth_coinbase JSON-RPC requests.
+ * Request handler for eth_blobBaseFee JSON-RPC requests.
  * @param {import('@tevm/node').TevmNode} client
  * @returns {import('./EthProcedure.js').EthBlobBaseFeeJsonRpcProcedure}
  */

--- a/packages/actions/src/tevm-request-handler/EthReturnType.ts
+++ b/packages/actions/src/tevm-request-handler/EthReturnType.ts
@@ -1,5 +1,6 @@
 import type {
 	EthAccountsJsonRpcResponse,
+	EthBlobBaseFeeJsonRpcResponse,
 	EthBlockNumberJsonRpcResponse,
 	EthCallJsonRpcResponse,
 	EthChainIdJsonRpcResponse,
@@ -49,6 +50,7 @@ export type EthReturnType = {
 	eth_sign: EthSignJsonRpcResponse
 	eth_newBlockFilter: EthNewBlockFilterJsonRpcResponse
 	eth_mining: EthMiningJsonRpcResponse
+	eth_blobBaseFee: EthBlobBaseFeeJsonRpcResponse
 	eth_chainId: EthChainIdJsonRpcResponse
 	eth_getCode: EthGetCodeJsonRpcResponse
 	eth_getLogs: EthGetLogsJsonRpcResponse


### PR DESCRIPTION
## Description

Added support for the `eth_blobBaseFee` JSON-RPC procedure by:
- Creating type definitions for the request and response in `EthJsonRpcRequest.ts` and `EthJsonRpcResponse.ts`
- Adding the procedure type to `EthProcedure.ts`
- Fixing the return type annotation in `ethBlobBaseFeeProcedure.js` to correctly reference the new procedure type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Ethereum JSON-RPC method `eth_blobBaseFee`, enabling interaction and response handling for this procedure.
- **Documentation**
  - Updated annotations to accurately describe the new procedure and its return type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->