### PR TITLE
Fix broken link to Tevm Solidity Import Documentation

### DIFF
--- a/tevm/docs/bundler/vite-plugin/variables/vitePluginTevm.md
+++ b/tevm/docs/bundler/vite-plugin/variables/vitePluginTevm.md
@@ -76,5 +76,5 @@ application will update without a full reload if possible.
 
 ## See
 
- - [Tevm Solidity Import Documentation](https://tevm.sh/learn/solidity-imports)
+ - [Tevm Solidity Import Documentation](https://www.tevm.sh/docs/bundler/solidity-imports)
  - [Vite Plugin API](https://vitejs.dev/guide/api-plugin.html)


### PR DESCRIPTION
Replaced the outdated link to the Tevm Solidity Import Documentation in vitePluginTevm.md with the current and correct URL: https://www.tevm.sh/docs/bundler/solidity-imports. This ensures users are directed to the latest documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the link to the Tevm Solidity Import Documentation for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->