### PR TITLE
feat: add generic type parameters to TestSnapshotClient

### DIFF
--- a/extensions/test-node/src/createTestSnapshotClient.ts
+++ b/extensions/test-node/src/createTestSnapshotClient.ts
@@ -1,6 +1,8 @@
 import type { AddressInfo } from 'node:net'
-import { createMemoryClient } from '@tevm/memory-client'
+import type { Common } from '@tevm/common'
+import { type TevmRpcSchema, createMemoryClient } from '@tevm/memory-client'
 import { createServer } from '@tevm/server'
+import type { Account, Address, Chain, RpcSchema } from 'viem'
 import { SnapshotManager } from './snapshot/SnapshotManager.js'
 import { createCachedTransport } from './snapshot/createCachedTransport.js'
 import type { TestSnapshotClient, TestSnapshotClientOptions } from './types.js'
@@ -27,7 +29,13 @@ import type { TestSnapshotClient, TestSnapshotClientOptions } from './types.js'
  * await client.server.stop()
  * ```
  */
-export const createTestSnapshotClient = (options: TestSnapshotClientOptions): TestSnapshotClient => {
+export const createTestSnapshotClient = <
+	TCommon extends Common & Chain = Common & Chain,
+	TAccountOrAddress extends Account | Address | undefined = undefined,
+	TRpcSchema extends RpcSchema | undefined = TevmRpcSchema,
+>(
+	options: TestSnapshotClientOptions<TCommon, TAccountOrAddress, TRpcSchema>,
+): TestSnapshotClient<TCommon, TAccountOrAddress> => {
 	// Validate fork transport is provided
 	const forkTransport = options.fork?.transport
 	if (!forkTransport) {

--- a/extensions/test-node/src/types.ts
+++ b/extensions/test-node/src/types.ts
@@ -1,5 +1,7 @@
 import type { Server as HttpServer } from 'node:http'
-import type { MemoryClient, MemoryClientOptions } from '@tevm/memory-client'
+import type { Common } from '@tevm/common'
+import type { MemoryClient, MemoryClientOptions, TevmRpcSchema } from '@tevm/memory-client'
+import type { Account, Address, Chain, RpcSchema } from 'viem'
 
 export type SnapshotAutosaveMode = 'onStop' | 'onRequest'
 
@@ -24,11 +26,18 @@ export type TestOptions = {
 	autosave?: SnapshotAutosaveMode
 }
 
-export type TestSnapshotClientOptions = MemoryClientOptions & {
+export type TestSnapshotClientOptions<
+	TCommon extends Common & Chain = Common & Chain,
+	TAccountOrAddress extends Account | Address | undefined = undefined,
+	TRpcSchema extends RpcSchema | undefined = TevmRpcSchema,
+> = MemoryClientOptions<TCommon, TAccountOrAddress, TRpcSchema> & {
 	test?: TestOptions
 }
 
-export type TestSnapshotClient = MemoryClient & {
+export type TestSnapshotClient<
+TCommon extends Common & Chain = Common & Chain,
+TAccountOrAddress extends Account | Address | undefined = undefined,
+> = MemoryClient<TCommon, TAccountOrAddress> & {
 	server: {
 		/**
 		 * The HTTP server


### PR DESCRIPTION
## Description

Added generic type parameters to `TestSnapshotClient` and `TestSnapshotClientOptions` to improve type safety and flexibility. The changes allow for better type inference when using custom chain configurations, account types, and RPC schemas.

## Testing

The changes are type-level only and maintain backward compatibility with existing code. Existing tests should continue to pass without modification.

## Additional Information

- [ ] I read the [contributing docs](../tevm/docs/_media/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: