### PR TITLE
Fix broken link in Usage section of README

### DIFF
--- a/bundler-packages/base-bundler/README.md
+++ b/bundler-packages/base-bundler/README.md
@@ -39,7 +39,7 @@ And all bundlers
 
 ## Usage
 
-See [docs](./docs/functions/bundler.md)
+See [docs](./docs/bundler/functions/bundler.md)
 
 ## License 📄
 


### PR DESCRIPTION
This commit updates the documentation link in the Usage section of the bundler-packages/base-bundler/README.md file. The previous link pointed to a non-existent or outdated path. The link now correctly points to ./docs/bundler/functions/bundler.md, ensuring users can access the relevant documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link in the "Usage" section of the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->