### PR TITLE
feat: Add signature util

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -108,6 +108,14 @@ export {
 	createAddressFromString,
 	createAccount,
 } from './ethereumjs.js'
+export {
+	recoverPublicKey,
+	recoverAddress,
+	hashMessage,
+	recoverMessageAddress,
+	verifyMessage,
+	signMessage,
+} from './signature.js'
 export type {
 	WithdrawalData,
 	DB as Db,

--- a/packages/utils/src/signature.js
+++ b/packages/utils/src/signature.js
@@ -1,0 +1,195 @@
+import { ecrecover } from './ethereumjs.js'
+import { getAddress, keccak256, toBytes, toHex } from './viem.js'
+
+/**
+ * @typedef {Object} Signature
+ * @property {bigint} r - The r value of the signature
+ * @property {bigint} s - The s value of the signature  
+ * @property {number} v - The recovery id (27 or 28)
+ * @property {0 | 1} [yParity] - The y parity (0 or 1)
+ */
+
+/**
+ * Recovers the public key from a signature
+ * @param {Object} params - The parameters
+ * @param {import('./abitype.js').Hex} params.hash - The message hash
+ * @param {Signature} params.signature - The signature
+ * @returns {import('./abitype.js').Hex} The uncompressed public key (65 bytes)
+ * @throws {Error} If the signature is invalid
+ * @example
+ * ```js
+ * import { recoverPublicKey } from '@tevm/utils'
+ * 
+ * const publicKey = recoverPublicKey({
+ *   hash: '0x82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28',
+ *   signature: {
+ *     r: 0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9n,
+ *     s: 0x129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66n,
+ *     v: 27
+ *   }
+ * })
+ * ```
+ */
+export function recoverPublicKey({ hash, signature }) {
+	const v = signature.yParity !== undefined ? signature.yParity : signature.v - 27
+	
+	// Convert bigint values to proper byte arrays for ecrecover
+	const rBytes = new Uint8Array(32)
+	const sBytes = new Uint8Array(32)
+	
+	// Convert bigint to bytes (big endian)
+	const rBigInt = typeof signature.r === 'string' ? BigInt(signature.r) : signature.r
+	const sBigInt = typeof signature.s === 'string' ? BigInt(signature.s) : signature.s
+	
+	for (let i = 0; i < 32; i++) {
+		rBytes[31 - i] = Number((rBigInt >> BigInt(8 * i)) & 0xffn)
+		sBytes[31 - i] = Number((sBigInt >> BigInt(8 * i)) & 0xffn)
+	}
+	
+	const publicKey = ecrecover(toBytes(hash), BigInt(v), rBytes, sBytes)
+	
+	if (!publicKey) {
+		throw new Error('Failed to recover public key')
+	}
+	
+	// ecrecover returns a 64-byte public key, we need to add the 0x04 prefix for uncompressed format
+	return `0x04${toHex(publicKey).slice(2)}`
+}
+
+/**
+ * Recovers the address from a signature
+ * @param {Object} params - The parameters
+ * @param {import('./abitype.js').Hex} params.hash - The message hash
+ * @param {Signature} params.signature - The signature
+ * @returns {import('./abitype.js').Address} The recovered address
+ * @throws {Error} If the signature is invalid
+ * @example
+ * ```js
+ * import { recoverAddress } from '@tevm/utils'
+ * 
+ * const address = recoverAddress({
+ *   hash: '0x82ff40c0a986c6a5cfad4ddf4c3aa6996f1a7837f9c398e17e5de5cbd5a12b28',
+ *   signature: {
+ *     r: 0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9n,
+ *     s: 0x129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66n,
+ *     v: 27
+ *   }
+ * })
+ * ```
+ */
+export function recoverAddress({ hash, signature }) {
+	const publicKey = recoverPublicKey({ hash, signature })
+	// Remove 0x04 prefix from uncompressed public key
+	const publicKeyBytes = toBytes(publicKey).slice(1)
+	const addressHash = keccak256(publicKeyBytes)
+	// Take last 20 bytes of hash
+	return getAddress(`0x${addressHash.slice(-40)}`)
+}
+
+/**
+ * Hashes a message according to EIP-191
+ * @param {string} message - The message to hash
+ * @returns {import('./abitype.js').Hex} The message hash
+ * @example
+ * ```js
+ * import { hashMessage } from '@tevm/utils'
+ * 
+ * const hash = hashMessage('Hello world')
+ * // 0x8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede
+ * ```
+ */
+export function hashMessage(message) {
+	const prefix = `\x19Ethereum Signed Message:\n${message.length}`
+	return keccak256(toBytes(prefix + message))
+}
+
+/**
+ * Recovers the address from a signed message
+ * @param {Object} params - The parameters
+ * @param {string} params.message - The original message
+ * @param {Signature} params.signature - The signature
+ * @returns {import('./abitype.js').Address} The recovered address
+ * @throws {Error} If the signature is invalid
+ * @example
+ * ```js
+ * import { recoverMessageAddress } from '@tevm/utils'
+ * 
+ * const address = recoverMessageAddress({
+ *   message: 'Hello world',
+ *   signature: {
+ *     r: 0x...,
+ *     s: 0x...,
+ *     v: 27
+ *   }
+ * })
+ * ```
+ */
+export function recoverMessageAddress({ message, signature }) {
+	const hash = hashMessage(message)
+	return recoverAddress({ hash, signature })
+}
+
+/**
+ * Verifies a message signature
+ * @param {Object} params - The parameters
+ * @param {import('./abitype.js').Address} params.address - The expected signer address
+ * @param {string} params.message - The original message
+ * @param {Signature} params.signature - The signature
+ * @returns {boolean} Whether the signature is valid
+ * @example
+ * ```js
+ * import { verifyMessage } from '@tevm/utils'
+ * 
+ * const isValid = verifyMessage({
+ *   address: '0xa6fb229e9b0a4e4ef52ea6991adcfc59207c7711',
+ *   message: 'Hello world',
+ *   signature: {
+ *     r: 0x...,
+ *     s: 0x...,
+ *     v: 27
+ *   }
+ * })
+ * ```
+ */
+export function verifyMessage({ address, message, signature }) {
+	try {
+		const recoveredAddress = recoverMessageAddress({ message, signature })
+		return recoveredAddress.toLowerCase() === address.toLowerCase()
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Signs a message with a private key
+ * @param {Object} params - The parameters
+ * @param {import('./abitype.js').Hex} params.privateKey - The private key
+ * @param {string} params.message - The message to sign
+ * @returns {Promise<Signature>} The signature
+ * @example
+ * ```js
+ * import { signMessage } from '@tevm/utils'
+ * 
+ * const signature = await signMessage({
+ *   privateKey: '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1',
+ *   message: 'Hello world'
+ * })
+ * ```
+ */
+export async function signMessage({ privateKey, message }) {
+	// Import viem's signMessage function directly
+	const { signMessage: viemSignMessage } = await import('viem/accounts')
+	const signature = await viemSignMessage({ privateKey, message })
+	
+	// Convert viem signature format to our format
+	// The last byte in viem signature is already the v value (27/28)
+	const v = parseInt(signature.slice(130, 132), 16)
+	const yParity = v - 27  // Convert v to yParity (0/1)
+	
+	return {
+		r: BigInt(signature.slice(0, 66)), // First 32 bytes as hex
+		s: BigInt(`0x${signature.slice(66, 130)}`), // Next 32 bytes as hex  
+		v, // Already 27/28
+		yParity,
+	}
+}

--- a/packages/utils/src/signature.spec.ts
+++ b/packages/utils/src/signature.spec.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest'
+import { 
+	recoverPublicKey, 
+	recoverAddress, 
+	hashMessage, 
+	recoverMessageAddress, 
+	verifyMessage,
+	signMessage 
+} from './signature.js'
+import type { Hex } from './abitype.js'
+
+describe('signature', () => {
+	// Test vectors from viem signMessage for 'Hello world'
+	const testVectors = {
+		privateKey: '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1' as Hex,
+		message: 'Hello world',
+		messageHash: '0x8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede' as Hex,
+		r: 0x157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87n,
+		s: 0x28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78n,
+		v: 27,
+		expectedAddress: '0xED54a7C1d8634BB589f24Bb7F05a5554b36F9618' as Hex,
+	}
+
+	// Test vectors from ecrecover precompile tests
+	const ecrecoverTestVectors = {
+		hash: '0x852daa74cc3c31fe64542bb9b8764cfb91cc30f9acf9389071ffb44a9eefde46' as Hex,
+		v: 27,
+		r: 0xb814eaab5953337fed2cf504a5b887cddd65a54b7429d7b191ff1331ca0726b1n,
+		s: 0x264de2660d307112075c15f08ba9c25c9a0cc6f8119aff3e7efb0a942773abb0n,
+		expectedAddress: '0xCDABe213e99dC5f6Bf6ce5B7149895d2097a4ac0' as Hex,
+	}
+
+	describe('recoverPublicKey', () => {
+		it('should recover public key from signature with v value', () => {
+			const publicKey = recoverPublicKey({
+				hash: testVectors.messageHash,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: testVectors.v,
+				},
+			})
+
+			// Should return a 65-byte uncompressed public key
+			expect(publicKey).toMatch(/^0x04[0-9a-f]{128}$/i)
+		})
+
+		it('should recover public key from signature with yParity', () => {
+			const publicKey = recoverPublicKey({
+				hash: testVectors.messageHash,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					yParity: 0,
+				},
+			})
+
+			// Should return a 65-byte uncompressed public key
+			expect(publicKey).toMatch(/^0x04[0-9a-f]{128}$/i)
+		})
+
+		it('should throw for invalid signature', () => {
+			expect(() => recoverPublicKey({
+				hash: testVectors.messageHash,
+				signature: {
+					r: 0n,
+					s: 0n,
+					v: 27,
+				},
+			})).toThrow()
+		})
+	})
+
+	describe('recoverAddress', () => {
+		it('should recover address from signature', () => {
+			const address = recoverAddress({
+				hash: testVectors.messageHash,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: testVectors.v,
+				},
+			})
+
+			expect(address.toLowerCase()).toBe(testVectors.expectedAddress.toLowerCase())
+		})
+
+		it('should recover address from ecrecover test vector', () => {
+			const address = recoverAddress({
+				hash: ecrecoverTestVectors.hash,
+				signature: {
+					r: ecrecoverTestVectors.r,
+					s: ecrecoverTestVectors.s,
+					v: ecrecoverTestVectors.v,
+				},
+			})
+
+			expect(address.toLowerCase()).toBe(ecrecoverTestVectors.expectedAddress.toLowerCase())
+		})
+
+		it('should work with yParity instead of v', () => {
+			const address = recoverAddress({
+				hash: testVectors.messageHash,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					yParity: 0,
+				},
+			})
+
+			expect(address.toLowerCase()).toBe(testVectors.expectedAddress.toLowerCase())
+		})
+	})
+
+	describe('hashMessage', () => {
+		it('should hash message according to EIP-191', () => {
+			const message = 'Hello world'
+			const hash = hashMessage(message)
+			
+			// Expected hash from ethereumjs tests
+			expect(hash).toBe('0x8144a6fa26be252b86456491fbcd43c1de7e022241845ffea1c3df066f7cfede')
+		})
+
+		it('should handle empty message', () => {
+			const hash = hashMessage('')
+			expect(hash).toBe('0x5f35dce98ba4fba25530a026ed80b2cecdaa31091ba4958b99b52ea1d068adad')
+		})
+
+		it('should handle long message', () => {
+			const longMessage = 'a'.repeat(1000)
+			const hash = hashMessage(longMessage)
+			expect(hash).toMatch(/^0x[0-9a-f]{64}$/i)
+		})
+	})
+
+	describe('recoverMessageAddress', () => {
+		it('should recover address from signed message', () => {
+			const address = recoverMessageAddress({ 
+				message: testVectors.message, 
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: testVectors.v,
+				}
+			})
+			expect(address.toLowerCase()).toBe(testVectors.expectedAddress.toLowerCase())
+		})
+	})
+
+	describe('verifyMessage', () => {
+		it('should verify valid signature', () => {
+			const isValid = verifyMessage({
+				address: testVectors.expectedAddress,
+				message: testVectors.message,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: testVectors.v,
+				},
+			})
+
+			expect(isValid).toBe(true)
+		})
+
+		it('should reject invalid signature', () => {
+			const isValid = verifyMessage({
+				address: testVectors.expectedAddress,
+				message: 'Hello world',
+				signature: {
+					r: 0x123n,
+					s: 0x456n,
+					v: 27,
+				},
+			})
+
+			expect(isValid).toBe(false)
+		})
+
+		it('should reject wrong address', () => {
+			const isValid = verifyMessage({
+				address: '0x0000000000000000000000000000000000000000',
+				message: testVectors.message,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: testVectors.v,
+				},
+			})
+
+			expect(isValid).toBe(false)
+		})
+
+		it('should handle case-insensitive address comparison', () => {
+			const isValid = verifyMessage({
+				address: testVectors.expectedAddress.toUpperCase() as Hex,
+				message: testVectors.message,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: testVectors.v,
+				},
+			})
+
+			expect(isValid).toBe(true)
+		})
+	})
+
+	describe('signMessage', () => {
+		it('should sign message correctly', async () => {
+			const message = 'Hello world'
+			const signature = await signMessage({
+				privateKey: testVectors.privateKey,
+				message,
+			})
+
+			expect(signature).toHaveProperty('r')
+			expect(signature).toHaveProperty('s')
+			expect(signature).toHaveProperty('v')
+			expect(typeof signature.r).toBe('bigint')
+			expect(typeof signature.s).toBe('bigint')
+			expect([27, 28]).toContain(signature.v)
+		})
+
+		it('should produce deterministic signatures', async () => {
+			const message = 'Test message'
+			const signature1 = await signMessage({
+				privateKey: testVectors.privateKey,
+				message,
+			})
+			const signature2 = await signMessage({
+				privateKey: testVectors.privateKey,
+				message,
+			})
+
+			expect(signature1.r).toBe(signature2.r)
+			expect(signature1.s).toBe(signature2.s)
+			expect(signature1.v).toBe(signature2.v)
+		})
+	})
+
+	describe('edge cases', () => {
+		it('should handle v values 0 and 1 as yParity', () => {
+			const address1 = recoverAddress({
+				hash: testVectors.messageHash,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					yParity: 0,
+				},
+			})
+
+			const address2 = recoverAddress({
+				hash: testVectors.messageHash,
+				signature: {
+					r: testVectors.r,
+					s: testVectors.s,
+					v: 27,
+				},
+			})
+
+			expect(address1).toBe(address2)
+		})
+
+		it('should handle hex strings for r and s values', () => {
+			const address = recoverAddress({
+				hash: testVectors.messageHash,
+				signature: {
+					r: BigInt('0x157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87'),
+					s: BigInt('0x28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78'),
+					v: 27,
+				},
+			})
+
+			expect(address.toLowerCase()).toBe(testVectors.expectedAddress.toLowerCase())
+		})
+	})
+})


### PR DESCRIPTION
## Description

Added a new signature utility module to the `@tevm/utils` package that provides cryptographic functions for Ethereum message signing and verification. The module includes:

- `recoverPublicKey`: Recovers public key from a signature and message hash
- `recoverAddress`: Recovers the signer's address from a signature
- `hashMessage`: Creates an EIP-191 compliant message hash
- `recoverMessageAddress`: Recovers the address from a signed message
- `verifyMessage`: Verifies if a signature is valid for a given address and message
- `signMessage`: Signs a message with a private key

These utilities provide a complete set of tools for working with Ethereum signatures in a consistent format.

## Testing

Added comprehensive test suite that covers:
- Standard signature recovery and verification
- Edge cases with different signature formats (v vs yParity)
- Compatibility with known test vectors
- Deterministic signature generation
- Error handling for invalid signatures

## Additional Information

- [ ] I read the [contributing docs](../tevm/docs/_media/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a set of cryptographic utilities for Ethereum-style signatures, including functions to sign messages, recover public keys and addresses from signatures, hash messages, and verify message signatures.

* **Tests**
  * Added comprehensive tests to validate the new cryptographic utilities, covering various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->