### PR TITLE
prompt: devtools scaffolding

### DIFF
--- a/extensions/devtools/prompts/scaffolding.context.md
+++ b/extensions/devtools/prompts/scaffolding.context.md
@@ -28,6 +28,15 @@
     </feature>
   </coreBehavior>
 
+  <devFlow>
+    <text>Adopt an example-first, incremental development flow:</text>
+    <item>Start by scaffolding the React example so we can demonstrate working functionality immediately.</item>
+    <item>Add the package build skeleton early to produce artifacts, but keep runtime logic minimal.</item>
+    <item>Introduce the core event bus and a minimal `DevtoolsWidget` that expands and lists records.</item>
+    <item>Implement EIP‑1193 wrapper, `installWindowEthereumDevtools`, and `withTevmDevtools` v1; wire them into the example to show value end-to-end.</item>
+    <item>Iterate with additional providers (viem, wagmi, ethers) and strengthen idempotency/dedupe, keeping examples runnable at each step.</item>
+  </devFlow>
+
   <directoryStructure>
     <directory name="extensions/devtools/">
       <directory name="src/">
@@ -415,7 +424,7 @@ export { DevtoolsWidget } from './DevtoolsWidget';
 
   <examples>
     <intro>Examples (React; plain files under `extensions/devtools/examples/react`)</intro>
-    <note>They demonstrate wrapping only; UI comes from the in‑package widget:</note>
+    <note>They demonstrate wrapping incrementally; UI comes from the in‑package widget:</note>
     <example>viem: `withTevmDevtools(http(...))` → `createPublicClient`; render `<DevtoolsWidget />`.</example>
     <example>wagmi: `withTevmDevtools(createConfig(...))` → render `<WagmiConfig>` and `<DevtoolsWidget />`.</example>
     <example>ethers injected: wrap `window.ethereum` then `new BrowserProvider`; render widget.</example>

--- a/extensions/devtools/prompts/scaffolding.progress.md
+++ b/extensions/devtools/prompts/scaffolding.progress.md
@@ -2,17 +2,15 @@
   <title>Tevm Devtools – Integration Progress</title>
   <intro>The following is a high-level checklist to track integration progress across the planned PRs.</intro>
   <tasks>
-    <task index="1" done="false">1. Package skeleton (build/lint/exports) in `extensions/devtools`</task>
-    <task index="2" done="false">2. Common layer: `types`, `constants`, `ids`, `eventBus`, `guards`</task>
-    <task index="3" done="false">3. Common `decorateRequestEip1193` helper (Proxy/Reflect) and base `decorateEip1193` delegator</task>
+    <task index="1" done="false">1. React example scaffold under `extensions/devtools/examples/react`</task>
+    <task index="2" done="false">2. Package skeleton (build/lint/exports) in `extensions/devtools`</task>
+    <task index="3" done="false">3. Common layer: `types`, `constants`, `ids`, `eventBus`, `guards`</task>
     <task index="4" done="false">4. React UI inside package: `@tevm/devtools/react` → `DevtoolsWidget`</task>
-    <task index="5" done="false">5. `installWindowEthereumDevtools` (optional injected override)</task>
-    <task index="6" done="false">6. Orchestrator `withTevmDevtools` v1 (EIP‑1193 only)</task>
-    <task index="7" done="false">7. React examples scaffold: import and render `DevtoolsWidget` + injected demo</task>
-    <task index="8" done="false">8. viem: transport + client decoration + example (uses in‑package widget)</task>
-    <task index="9" done="false">9. wagmi: config decoration (transports/connectors) + example (uses widget)</task>
-    <task index="10" done="false">10. ethers: injected + JsonRpcProvider decoration + examples (use widget)</task>
-    <task index="11" done="false">11. Idempotency/dedupe hardening + overlap tests</task>
-    <task index="12" done="false">12. Docs/tests, and repo integration</task>
+    <task index="5" done="false">5. EIP‑1193 foundation: wrapper + installer + orchestrator v1 + example wiring</task>
+    <task index="6" done="false">6. viem: transport + client decoration + example (uses in‑package widget)</task>
+    <task index="7" done="false">7. wagmi: config decoration (transports/connectors) + example (uses widget)</task>
+    <task index="8" done="false">8. ethers: injected + JsonRpcProvider decoration + examples (use widget)</task>
+    <task index="9" done="false">9. Idempotency/dedupe hardening + overlap tests</task>
+    <task index="10" done="false">10. Docs/tests, and repo integration</task>
   </tasks>
 </devtoolsScaffoldingProgress>


### PR DESCRIPTION
## Description

Added scaffolding documentation for the devtools extension in the `extensions/devtools/prompts` directory. This includes:

1. A comprehensive context document (`scaffolding.context.md`) that outlines the architecture, directory structure, and implementation details for the devtools extension.
2. A step-by-step plan (`scaffolding.plan.md`) breaking down the implementation into 10 incremental PRs with clear scopes, files, and acceptance criteria.
3. A progress tracking document (`scaffolding.progress.md`) to monitor implementation status across the planned PRs.

These documents provide a complete roadmap for building a devtools extension that instruments viem, wagmi, ethers, and raw EIP-1193 providers without mutating originals, while publishing to a global event bus that the included React widget can subscribe to.