### PR TITLE
fix: add missing status field to call/tevmCall and getTransactionByHash/Receipt

### DIFF
--- a/packages/actions/src/Call/CallResult.ts
+++ b/packages/actions/src/Call/CallResult.ts
@@ -172,4 +172,9 @@ export type CallResult<ErrorType = TevmCallError> = {
 	 * The value that accrues to the miner by this transaction.
 	 */
 	minerValue?: bigint
+	/**
+	 * Status of transaction execution (1 for success, 0 for failure).
+	 * Only present for post-Byzantium transactions when the transaction is included in the blockchain.
+	 */
+	status?: Hex
 }

--- a/packages/actions/src/Call/callHandlerResult.js
+++ b/packages/actions/src/Call/callHandlerResult.js
@@ -100,5 +100,12 @@ export const callHandlerResult = (evmResult, txHash, trace, accessList) => {
 	if (/** @type {any} */ (evmResult).createdAddress) {
 		out.createdAddress = getAddress(/** @type {any} */ (evmResult).createdAddress.toString())
 	}
+
+	// Set status based on execution success/failure (1 for success, 0 for failure)
+	// Status is only meaningful when the transaction is actually executed on-chain
+	if (txHash) {
+		out.status = /** @type {any} */ (evmResult).execResult.exceptionError ? '0x0' : '0x1'
+	}
+
 	return out
 }

--- a/packages/actions/src/eth/ethGetTransactionReceipt.js
+++ b/packages/actions/src/eth/ethGetTransactionReceipt.js
@@ -150,11 +150,9 @@ export const ethGetTransactionReceiptHandler = (client) => async (params) => {
 				? bytesToHex(/** @type any*/ (receipt).stateRoot)
 				: undefined,
 		status:
-			/** @type any*/ (receipt).status instanceof Uint8Array
-				? /** @type any*/ (receipt).status
-				: typeof (/** @type any*/ (receipt).status) === 'number'
-					? numberToHex(/** @type any*/ (receipt).status)
-					: undefined,
+			typeof (/** @type any*/ (receipt).status) === 'number'
+				? numberToHex(/** @type any*/ (receipt).status)
+				: undefined,
 		logs: await Promise.all(
 			receipt.logs.map((log, i) => ({
 				address: bytesToHex(log[0]),


### PR DESCRIPTION
Fixes #1967

Adds the missing "status" field to both call/tevmCall and getTransactionByHash/Receipt functions to comply with JSON-RPC spec.

## Changes
- Fix ethGetTransactionReceipt.js to properly convert numeric status (0|1) to hex
- Add status field to CallResult type with proper JSDoc documentation
- Implement status field in callHandlerResult.js based on execution success/failure
- Status follows JSON-RPC spec: '0x1' for success, '0x0' for failure
- Only set status when transaction has txHash (executed on-chain)

Generated with [Claude Code](https://claude.ai/code)