### PR TITLE
🐛 fix: set cacheTime to 0 for memory client

### DIFF
--- a/packages/memory-client/src/createMemoryClient.js
+++ b/packages/memory-client/src/createMemoryClient.js
@@ -313,6 +313,7 @@ export const createMemoryClient = (options) => {
 	})()
 	const memoryClient = createClient({
 		...options,
+		cacheTime: 0,
 		transport: createTevmTransport({
 			...options,
 			...(common !== undefined ? { common } : {}),

--- a/packages/memory-client/src/test/viem/getBlockNumber.spec.ts
+++ b/packages/memory-client/src/test/viem/getBlockNumber.spec.ts
@@ -14,4 +14,31 @@ describe('getBlockNumber', () => {
 		await mc.tevmMine()
 		expect(await mc.getBlockNumber({ cacheTime: 0 })).toBe(1n)
 	})
+
+	it('should update immediately with rapid mining and fetching', async () => {
+		// Test for issue #1977 - cacheTime should be 0 for memory client
+		// Verify block number updates immediately after mining without caching delays
+		expect(await mc.getBlockNumber()).toBe(0n)
+		
+		await mc.tevmMine()
+		expect(await mc.getBlockNumber()).toBe(1n)
+		
+		await mc.tevmMine()
+		expect(await mc.getBlockNumber()).toBe(2n)
+		
+		// Rapid sequence: mine, fetch, mine, fetch
+		await mc.tevmMine()
+		const blockNumber1 = await mc.getBlockNumber()
+		expect(blockNumber1).toBe(3n)
+		
+		await mc.tevmMine()
+		const blockNumber2 = await mc.getBlockNumber()
+		expect(blockNumber2).toBe(4n)
+		
+		// Verify no caching is happening by checking consecutive calls
+		const consecutiveCall1 = await mc.getBlockNumber()
+		const consecutiveCall2 = await mc.getBlockNumber()
+		expect(consecutiveCall1).toBe(4n)
+		expect(consecutiveCall2).toBe(4n)
+	})
 })


### PR DESCRIPTION
Set cacheTime: 0 in createMemoryClient to disable viem caching since TEVM itself acts as the cache.

Closes ##1977

Generated with [Claude Code](https://claude.ai/code)