### PR TITLE
test: add test case to reproduce eth_getBlockByNumber Promise serialization bug

### DIFF
--- a/packages/server/src/createHttpHandler.spec.ts
+++ b/packages/server/src/createHttpHandler.spec.ts
@@ -206,12 +206,12 @@ describe('createHttpHandler', () => {
 
 		expect(res.body.error).toBeUndefined()
 		expect(res.body.result).toBeDefined()
-		
+
 		// The bug was that result contained a Promise object which serializes to {}
 		expect(res.body.result).not.toEqual({})
 		expect(typeof res.body.result).toBe('object')
 		expect(res.body.result).not.toBeInstanceOf(Promise)
-		
+
 		// Verify the response has the expected block properties
 		expect(res.body.result).toHaveProperty('number')
 		expect(res.body.result).toHaveProperty('hash')
@@ -219,10 +219,10 @@ describe('createHttpHandler', () => {
 		expect(res.body.result).toHaveProperty('transactions')
 		expect(res.body.result.number).toMatch(/^0x/)
 		expect(res.body.result.hash).toMatch(/^0x/)
-		
+
 		// Verify basic response structure
 		expect(res.body.method).toBe('eth_getBlockByNumber')
 		expect(res.body.id).toBe(2)
 		expect(res.body.jsonrpc).toBe('2.0')
-	})
+	}, { timeout: 10_000 })
 })


### PR DESCRIPTION
Reproduces issue #1972 where Promise objects in JSON-RPC response results get serialized to empty objects when using createServer with createMemoryClient and forking.

The test verifies that eth_getBlockByNumber returns proper block data instead of serialized Promise objects.

Closes #1972

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added an integration test ensuring eth_getBlockByNumber returns a fully populated block object (standard fields and formats), conforms to JSON-RPC response shape, and is not an unresolved Promise or empty object.
  - Validates flow by fetching the latest block number then retrieving that block’s details.
  - No changes to runtime behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->