### PR TITLE
Fix contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,10 @@ npm i pnpm@9 --global && pnpm --version
 npm i bun --global && bun --version
 ```
 
-or run bun update if already installed
+or run bun upgrade if already installed
 
 ```bash
-bun update
+bun upgrade
 ```
 
 3. Install Rust if working with Rust code
@@ -161,6 +161,8 @@ bun run test
 Note `bun test` will run bun instead of [vitest](https://vitest.dev) resulting in errors
 
 ## Fixtures
+
+**Note**: Fixtures are located in individual packages such as `bundler-packages/config/src/fixtures/`, `bundler-packages/resolutions/src/fixtures/`, `bundler-packages/compiler/src/fixtures/`, and `lsp/ts-plugin/src/fixtures/`. The instructions below apply when working within those packages.
 
 Fixtures in [src/fixtures](./src/fixtures/) exist both for the vitest tests and also can be loaded in watch mode.
 

--- a/tevm/docs/_media/CONTRIBUTING.md
+++ b/tevm/docs/_media/CONTRIBUTING.md
@@ -162,6 +162,8 @@ Note `bun test` will run bun instead of [vitest](https://vitest.dev) resulting i
 
 ## Fixtures
 
+**Note**: Fixtures are located in individual packages such as `bundler-packages/config/src/fixtures/`, `bundler-packages/resolutions/src/fixtures/`, `bundler-packages/compiler/src/fixtures/`, and `lsp/ts-plugin/src/fixtures/`. The instructions below apply when working within those packages.
+
 Fixtures in [src/fixtures](./src/fixtures/) exist both for the vitest tests and also can be loaded in watch mode.
 
 The best way to debug a bug or implement a new feature is to first add a new fixture to use in test or dev server


### PR DESCRIPTION
## Description

docs says "bun update" but should be "bun upgrade "

## Testing

Not needed 
## Additional Information

- [ x] I read the [contributing docs](../tevm/docs/_media/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xA97b1379446d4d116822a8f740C70163FB1C71c3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated command guidance from "bun update" to "bun upgrade" to reflect the correct CLI subcommand.
  * Clarified fixture locations across packages and that fixture instructions apply within those packages.
  * Added note that some fixtures may be expected to error and that the development server behavior is considered successful in those cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->