### PR TITLE
🐛 fix(actions): ensure eth_getStorageAt returns 32-byte padded values

### DIFF
--- a/packages/actions/src/eth/getStorageAtHandler.js
+++ b/packages/actions/src/eth/getStorageAtHandler.js
@@ -21,6 +21,7 @@ export const getStorageAtHandler = (client) => async (params) => {
 	if (tag === 'latest') {
 		return bytesToHex(
 			await vm.stateManager.getStorage(createAddress(params.address), hexToBytes(params.position, { size: 32 })),
+			{ size: 32 }
 		)
 	}
 	const block = await vm.blockchain.getBlockByTag(tag)

--- a/packages/actions/src/eth/getStorageAtProcedure.spec.ts
+++ b/packages/actions/src/eth/getStorageAtProcedure.spec.ts
@@ -45,7 +45,7 @@ describe('getStorageAtProcedure', () => {
 					if (req.method !== 'eth_getStorageAt') {
 						throw new Error('Invalid method')
 					}
-					return numberToHex(420, { size: 2 }) as any
+					return numberToHex(420, { size: 32 }) as any
 				},
 			},
 		} as any)(request)
@@ -54,7 +54,7 @@ describe('getStorageAtProcedure', () => {
 		expect(response.result).toBeDefined()
 		expect(response.method).toBe('eth_getStorageAt')
 		expect(response.id).toBe(request.id as any)
-		expect(response.result).toBe(numberToHex(420, { size: 2 }))
+		expect(response.result).toBe(numberToHex(420, { size: 32 }))
 	})
 
 	it('should handle requests without an id', async () => {
@@ -71,7 +71,7 @@ describe('getStorageAtProcedure', () => {
 					if (req.method !== 'eth_getStorageAt') {
 						throw new Error('Invalid method')
 					}
-					return numberToHex(420, { size: 2 }) as any
+					return numberToHex(420, { size: 32 }) as any
 				},
 			},
 		} as any)(request)
@@ -80,6 +80,6 @@ describe('getStorageAtProcedure', () => {
 		expect(response.result).toBeDefined()
 		expect(response.method).toBe('eth_getStorageAt')
 		expect(response.id).toBeUndefined()
-		expect(response.result).toBe(numberToHex(420, { size: 2 }))
+		expect(response.result).toBe(numberToHex(420, { size: 32 }))
 	})
 })


### PR DESCRIPTION
Fix eth_getStorageAt to always return properly padded 32-byte hex values by adding { size: 32 } parameter to bytesToHex() call. This resolves the issue where storage values were returned unpadded.

Fixes #2046

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed storage value encoding to ensure all returned storage data is consistently formatted as 32-byte hexadecimal representations, improving data consistency and correctness in storage retrieval operations.

**Tests**
- Updated test cases to validate the corrected 32-byte storage encoding format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->