### PR TITLE
🐛 fix(actions): handle null topics in eth_getLogs

### DIFF
--- a/packages/actions/src/eth/ethGetLogsHandler.js
+++ b/packages/actions/src/eth/ethGetLogsHandler.js
@@ -121,7 +121,10 @@ export const ethGetLogsHandler = (client) => async (params) => {
 		params.filterParams.address !== undefined ? [createAddress(params.filterParams.address).bytes] : [],
 		// params.filterParams.topics?.map((topic) => hexToBytes(topic)),
 
-		params.filterParams.topics?.map((topic) => (isArray(topic) ? topic.map(hexToBytes) : hexToBytes(topic))),
+		params.filterParams.topics?.map((topic) => {
+			if (topic === null) return null
+			return isArray(topic) ? topic.map(hexToBytes) : hexToBytes(topic)
+		}),
 	)
 	logs.push(
 		...cachedLogs.map(({ log, block, tx, txIndex, logIndex }) => ({


### PR DESCRIPTION
Fix the issue where eth_getLogs fails when null values are used in topics array.

Null values are used as wildcards to match any topic at that position.

**Changes:**
- Add null check in ethGetLogsHandler before calling hexToBytes
- Add test case to verify null topics work correctly as wildcards

Fixes #2048

**Original prompt:**
<prompt>
@claude fix bug
</prompt>

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Ethereum log filtering to gracefully handle null topic values in filter requests, preventing errors during conversion and allowing wildcard filters to work properly.

* **Tests**
  * Added test coverage for null topics functioning as wildcards in Ethereum log filtering operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->