### PR TITLE
ensure fetching legcacy tx receipt do not error out

### DIFF
--- a/packages/actions/src/eth/ethGetBlockReceiptsHandler.js
+++ b/packages/actions/src/eth/ethGetBlockReceiptsHandler.js
@@ -200,12 +200,12 @@ export const ethGetBlockReceiptsHandler = (client) => async (params) => {
 		// Calculate effective gas price
 		/** @type {any} */
 		const txAny = tx
-		const effectiveGasPrice =
-			txAny.maxPriorityFeePerGas !== undefined && txAny.maxFeePerGas !== undefined
+		const effectiveGasPrice = txAny.maxFeePerGas ?
+			(txAny.maxPriorityFeePerGas !== undefined && txAny.maxFeePerGas !== undefined
 				? txAny.maxPriorityFeePerGas < txAny.maxFeePerGas - (block.header.baseFeePerGas ?? 0n)
 					? txAny.maxPriorityFeePerGas + (block.header.baseFeePerGas ?? 0n)
 					: txAny.maxFeePerGas
-				: (txAny?.gasPrice ?? 0n)
+				: (txAny?.gasPrice ?? 0n)) : txAny.gasPrice;
 
 		/** @type {import('./EthResult.js').EthGetTransactionReceiptResult} */
 		const receiptResult = {


### PR DESCRIPTION
## Description

This is a small tweak to ensure getTransactionReceipt do not error out on legacy tx.

## Testing

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to the block receipts handler logic for computing effective gas price. No changes to user-facing functionality or API behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->