### PR TITLE
test(server): cover parseRequest options

### DIFF
--- a/packages/server/src/internal/parseRequest.spec.ts
+++ b/packages/server/src/internal/parseRequest.spec.ts
@@ -44,6 +44,41 @@ describe('parseRequest', () => {
 		expect((result as InvalidRequestError).message).toMatchSnapshot()
 	})
 
+	it('should reject empty batch requests when disabled', () => {
+		const result = parseRequest('[]', { allowEmptyBatch: false })
+		expect(result).toBeInstanceOf(InvalidRequestError)
+		expect((result as InvalidRequestError).message).toBe('Empty batch requests are invalid')
+	})
+
+	it('should reject batches that exceed the configured max size', () => {
+		const body = JSON.stringify([validJsonRpcRequest, validJsonRpcRequest])
+		const result = parseRequest(body, { maxBatchSize: 1 })
+		expect(result).toBeInstanceOf(InvalidRequestError)
+		expect((result as InvalidRequestError).message).toBe('Batch request exceeds configured max batch size of 1')
+	})
+
+	it('should require jsonrpc version for strict single requests', () => {
+		const body = JSON.stringify({ method: 'tevm_call', params: [], id: 1 })
+		const result = parseRequest(body, { requireJsonrpc: true })
+		expect(result).toBeInstanceOf(InvalidRequestError)
+		expect((result as InvalidRequestError).message).toContain('jsonrpc')
+	})
+
+	it('should mark invalid strict batch entries without rejecting the whole batch', () => {
+		const body = JSON.stringify([validJsonRpcRequest, { method: 'tevm_call', params: [], id: 2 }])
+		const result = parseRequest(body, { requireJsonrpc: true })
+		expect(Array.isArray(result)).toBe(true)
+		const batch = result as Array<any>
+		expect(batch[0]).toEqual(validJsonRpcRequest)
+		expect(batch[1]).toMatchObject({
+			__invalidJsonRpcRequest: true,
+			id: 2,
+			method: 'tevm_call',
+			jsonrpc: '2.0',
+		})
+		expect(batch[1].error.message).toContain('jsonrpc')
+	})
+
 	it('should return InvalidRequestError for invalid bulk JSON-RPC request', () => {
 		const body = JSON.stringify([validJsonRpcRequest, invalidJsonRpcRequest])
 		const result = parseRequest(body)

--- a/packages/server/src/internal/parseRequest.spec.ts
+++ b/packages/server/src/internal/parseRequest.spec.ts
@@ -4,6 +4,17 @@ import { InvalidJsonError } from '../errors/InvalidJsonError.js'
 import { parseRequest } from './parseRequest.js'
 
 describe('parseRequest', () => {
+	type InvalidBatchRequest = {
+		__invalidJsonRpcRequest: true
+		id: string | number | null
+		method: string
+		jsonrpc: '2.0'
+		error: {
+			code: number
+			message: string
+		}
+	}
+
 	const validJsonRpcRequest = {
 		jsonrpc: '2.0',
 		method: 'tevm_call',
@@ -44,31 +55,31 @@ describe('parseRequest', () => {
 		expect((result as InvalidRequestError).message).toMatchSnapshot()
 	})
 
-	it('should reject empty batch requests when disabled', () => {
+	it('should reject empty batch requests when disabled', (): void => {
 		const result = parseRequest('[]', { allowEmptyBatch: false })
 		expect(result).toBeInstanceOf(InvalidRequestError)
 		expect((result as InvalidRequestError).message).toBe('Empty batch requests are invalid')
 	})
 
-	it('should reject batches that exceed the configured max size', () => {
+	it('should reject batches that exceed the configured max size', (): void => {
 		const body = JSON.stringify([validJsonRpcRequest, validJsonRpcRequest])
 		const result = parseRequest(body, { maxBatchSize: 1 })
 		expect(result).toBeInstanceOf(InvalidRequestError)
 		expect((result as InvalidRequestError).message).toBe('Batch request exceeds configured max batch size of 1')
 	})
 
-	it('should require jsonrpc version for strict single requests', () => {
+	it('should require jsonrpc version for strict single requests', (): void => {
 		const body = JSON.stringify({ method: 'tevm_call', params: [], id: 1 })
 		const result = parseRequest(body, { requireJsonrpc: true })
 		expect(result).toBeInstanceOf(InvalidRequestError)
 		expect((result as InvalidRequestError).message).toContain('jsonrpc')
 	})
 
-	it('should mark invalid strict batch entries without rejecting the whole batch', () => {
+	it('should mark invalid strict batch entries without rejecting the whole batch', (): void => {
 		const body = JSON.stringify([validJsonRpcRequest, { method: 'tevm_call', params: [], id: 2 }])
 		const result = parseRequest(body, { requireJsonrpc: true })
 		expect(Array.isArray(result)).toBe(true)
-		const batch = result as Array<any>
+		const batch = result as [typeof validJsonRpcRequest, InvalidBatchRequest]
 		expect(batch[0]).toEqual(validJsonRpcRequest)
 		expect(batch[1]).toMatchObject({
 			__invalidJsonRpcRequest: true,


### PR DESCRIPTION
Adds focused coverage for `parseRequest` option handling:
- rejecting empty batches when disabled
- rejecting batches over `maxBatchSize`
- enforcing `jsonrpc` for strict single requests
- marking invalid strict batch entries without rejecting the whole batch

Validation:
- `pnpm install --ignore-scripts --frozen-lockfile`
- `pnpm --filter @tevm/server exec biome check src/internal/parseRequest.spec.ts`

I also tried the focused vitest file, but this local checkout is blocked before tests execute because workspace packages such as `@tevm/errors` resolve to missing generated `dist/zevm` artifacts.