### PR TITLE
🐛 fix(state): guard fork state read precedence

### DIFF
--- a/packages/state/src/forkStateReads.spec.ts
+++ b/packages/state/src/forkStateReads.spec.ts
@@ -1,0 +1,48 @@
+import { createAddress } from '@tevm/address'
+import { transports } from '@tevm/test-utils'
+import { bytesToHex, hexToBytes, numberToHex, toBytes } from '@tevm/utils'
+import { describe, expect, it } from 'vitest'
+import { createStateManager } from './createStateManager.js'
+
+const hasOptimismRpc = Boolean(process.env['TEVM_RPC_URLS_OPTIMISM'])
+
+describe.skipIf(!hasOptimismRpc)('fork state reads', () => {
+	it('returns local account and storage writes while fetching every uncached fork slot', async () => {
+		const stateManager = createStateManager({
+			fork: {
+				transport: transports.optimism,
+			},
+		})
+		await stateManager.ready()
+
+		const address = createAddress('0x4200000000000000000000000000000000000006')
+		const firstSlot = toBytes(0, { size: 32 })
+		const secondSlot = toBytes(1, { size: 32 })
+		const account = await stateManager.getAccount(address)
+
+		expect(account?.isContract()).toBe(true)
+		const forkBlock = stateManager._baseState.options.fork?.blockTag
+		expect(typeof forkBlock).toBe('bigint')
+
+		for (const slot of [firstSlot, secondSlot]) {
+			const upstreamValue = await transports.optimism.request({
+				method: 'eth_getStorageAt',
+				params: [address.toString(), bytesToHex(slot), numberToHex(forkBlock as bigint)],
+			})
+			expect(bytesToHex(await stateManager.getStorage(address, slot), { size: 32 })).toBe(
+				bytesToHex(hexToBytes(upstreamValue), { size: 32 }),
+			)
+		}
+
+		const localBalance = (account?.balance ?? 0n) + 123n
+		const localStorage = hexToBytes('0x123456')
+		await stateManager.modifyAccountFields(address, { balance: localBalance })
+		await stateManager.putStorage(address, secondSlot, localStorage)
+
+		expect((await stateManager.getAccount(address))?.balance).toBe(localBalance)
+		expect(await stateManager.getStorage(address, secondSlot)).toEqual(localStorage)
+
+		await stateManager.putStorage(address, firstSlot, new Uint8Array())
+		expect(await stateManager.getStorage(address, firstSlot)).toEqual(new Uint8Array())
+	})
+})


### PR DESCRIPTION
## Summary

Adds a real Optimism fork regression test for the rc.151 fork-state read blocker. The reported behavior cannot be reproduced on current `main`: local account and storage writes already take precedence over the fork cache, including an explicit zero-value storage override, and uncached storage slots already fall through to the upstream provider.

## Reported bug

The motivating viem migration note says:

> "on a forked node rc.151 resolves balances and storage through eth_getProof against the upstream *historical* block, so locally written values are invisible."

It also reports that forked slots other than the lazily cached slot read back as zero.

## Root cause / current behavior

The rc.151 gap has already been addressed on current `main` in `packages/state`: the mutable local account/storage caches are checked before the read-only fork caches, and a miss in both storage caches calls the pinned fork provider rather than returning zero. No production source change was necessary.

## Change

Adds `packages/state/src/forkStateReads.spec.ts`, using the real Optimism provider (no mocks) to verify:

- two independently uncached fork slots match the upstream state at the pinned fork block;
- a locally written balance wins over the remote account proof;
- a locally written storage value wins over the cached remote value;
- a local zero-value storage write remains visible instead of falling back remotely.

## Tests

- `pnpm vitest run packages/state/src/forkStateReads.spec.ts` — 1 passed
- `pnpm vitest run packages/state/src` — 36 files passed, 147 tests passed
- `pnpm biome check packages/state/src/forkStateReads.spec.ts` — passed

🤖 Generated with Smithers multi-agent orchestration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for reading account and storage data from an Optimism fork.
  * Verified that local account and storage updates override forked values correctly.
  * Added validation for clearing a storage slot and returning an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->