### PR TITLE
🐛 fix(actions): apply anvil_setBlockTimestampInterval to every mined block

### DIFF
--- a/.changeset/timestamp-interval.md
+++ b/.changeset/timestamp-interval.md
@@ -1,0 +1,5 @@
+---
+"@tevm/actions": patch
+---
+
+Apply anvil_setBlockTimestampInterval to every mined block instead of only recording it.

--- a/packages/actions/src/Mine/mineHandler.js
+++ b/packages/actions/src/Mine/mineHandler.js
@@ -73,14 +73,16 @@ export const mineHandler =
 				const overrideTimestamp = count === 0 ? client.getNextBlockTimestamp() : undefined
 				// Get the automatic interval if set
 				const automaticInterval = client.getBlockTimestampInterval()
-				const intervalToUse = automaticInterval !== undefined ? Number(automaticInterval) : interval
 				let timestamp
 				if (overrideTimestamp !== undefined) {
 					timestamp = Number(overrideTimestamp)
+				} else if (automaticInterval !== undefined) {
+					// anvil_setBlockTimestampInterval applies to every mined block including the first
+					timestamp = Number(parentBlock.header.timestamp) + Number(automaticInterval)
 				} else if (count === 0) {
 					timestamp = Math.max(Math.floor(Date.now() / 1000), Number(parentBlock.header.timestamp))
 				} else {
-					timestamp = Number(parentBlock.header.timestamp) + intervalToUse
+					timestamp = Number(parentBlock.header.timestamp) + interval
 				}
 				// Keep block timestamps monotonic.
 				timestamp = Math.max(timestamp, Number(parentBlock.header.timestamp) + 1)

--- a/packages/actions/src/Mine/mineHandler.spec.ts
+++ b/packages/actions/src/Mine/mineHandler.spec.ts
@@ -422,6 +422,40 @@ describe(mineHandler.name, () => {
 		expect(block1.header.timestamp).toBe(base + 114n)
 	})
 
+	it('should apply blockTimestampInterval to every mined block including the first', async () => {
+		const client = createTevmNode()
+		const vm = await client.getVm()
+		const parent = await vm.blockchain.getCanonicalHeadBlock()
+		const base = parent.header.timestamp
+
+		client.setBlockTimestampInterval(7n)
+		await mineHandler(client)({ blockCount: 3 })
+
+		const block3 = await vm.blockchain.getCanonicalHeadBlock()
+		const block2 = await vm.blockchain.getBlock(block3.header.parentHash)
+		const block1 = await vm.blockchain.getBlock(block2.header.parentHash)
+
+		expect(block1.header.timestamp).toBe(base + 7n)
+		expect(block2.header.timestamp).toBe(base + 14n)
+		expect(block3.header.timestamp).toBe(base + 21n)
+	})
+
+	it('should restore wall-clock timestamps after blockTimestampInterval is removed', async () => {
+		const client = createTevmNode()
+		const vm = await client.getVm()
+
+		client.setBlockTimestampInterval(1_000_000n)
+		client.setBlockTimestampInterval(undefined)
+
+		const before = Math.floor(Date.now() / 1000)
+		await mineHandler(client)({})
+		const after = Math.floor(Date.now() / 1000)
+
+		const block = await vm.blockchain.getCanonicalHeadBlock()
+		expect(Number(block.header.timestamp)).toBeGreaterThanOrEqual(before)
+		expect(Number(block.header.timestamp)).toBeLessThanOrEqual(after + 1)
+	})
+
 	it('should consume next block prevRandao only once', async () => {
 		const client = createTevmNode()
 		const vm = await client.getVm()

--- a/packages/actions/src/anvil/anvilMineDetailedProcedure.js
+++ b/packages/actions/src/anvil/anvilMineDetailedProcedure.js
@@ -107,14 +107,16 @@ export const anvilMineDetailedJsonRpcProcedure = (client) => {
 				const overrideTimestamp = count === 0 ? client.getNextBlockTimestamp() : undefined
 				// Get the automatic interval if set
 				const automaticInterval = client.getBlockTimestampInterval()
-				const intervalToUse = automaticInterval !== undefined ? Number(automaticInterval) : interval
 				let timestamp
 				if (overrideTimestamp !== undefined) {
 					timestamp = Number(overrideTimestamp)
+				} else if (automaticInterval !== undefined) {
+					// anvil_setBlockTimestampInterval applies to every mined block including the first
+					timestamp = Number(parentBlock.header.timestamp) + Number(automaticInterval)
 				} else if (count === 0) {
 					timestamp = Math.max(Math.floor(Date.now() / 1000), Number(parentBlock.header.timestamp))
 				} else {
-					timestamp = Number(parentBlock.header.timestamp) + intervalToUse
+					timestamp = Number(parentBlock.header.timestamp) + interval
 				}
 				// Keep block timestamps monotonic.
 				timestamp = Math.max(timestamp, Number(parentBlock.header.timestamp) + 1)

--- a/packages/memory-client/src/test/viem/removeBlockTimestampInterval.spec.ts
+++ b/packages/memory-client/src/test/viem/removeBlockTimestampInterval.spec.ts
@@ -7,13 +7,25 @@ let client: MemoryClient<any, any> & TestActions
 
 beforeEach(async () => {
 	// Create a memory client extended with test actions
-	client = createMemoryClient().extend(testActions({ mode: 'anvil' }))
+	client = createMemoryClient({ miningConfig: { type: 'manual' } }).extend(testActions({ mode: 'anvil' }))
 	await client.tevmReady()
 })
 
 describe('removeBlockTimestampInterval', () => {
-	it('should remove a previously set block timestamp interval', async () => {
-		// Skip the test for now as the method is not available
-		expect.assertions(0)
+	it('should remove a previously set block timestamp interval and restore default timestamps', async () => {
+		const interval = 1_000_000n
+
+		await client.setBlockTimestampInterval({ interval })
+		await client.removeBlockTimestampInterval()
+
+		const before = Math.floor(Date.now() / 1000)
+		await client.mine({ blocks: 1 })
+		const after = Math.floor(Date.now() / 1000)
+
+		const block = await client.getBlock({ blockTag: 'latest' })
+		// With the interval removed, the next block timestamp must go back to being
+		// based on the current wall-clock time instead of parent + interval
+		expect(Number(block.timestamp)).toBeGreaterThanOrEqual(before)
+		expect(Number(block.timestamp)).toBeLessThanOrEqual(after + 1)
 	})
 })

--- a/packages/memory-client/src/test/viem/setBlockTimestampInterval.spec.ts
+++ b/packages/memory-client/src/test/viem/setBlockTimestampInterval.spec.ts
@@ -7,13 +7,26 @@ let client: MemoryClient<any, any> & TestActions
 
 beforeEach(async () => {
 	// Create a memory client extended with test actions
-	client = createMemoryClient().extend(testActions({ mode: 'anvil' }))
+	client = createMemoryClient({ miningConfig: { type: 'manual' } }).extend(testActions({ mode: 'anvil' }))
 	await client.tevmReady()
 })
 
 describe('setBlockTimestampInterval', () => {
 	it('should set a consistent interval between block timestamps', async () => {
-		// Skip the test for now as the method is not available
-		expect.assertions(0)
+		const interval = 5n
+		const headBefore = await client.getBlock()
+
+		await client.setBlockTimestampInterval({ interval })
+		await client.mine({ blocks: 3 })
+
+		const block1 = await client.getBlock({ blockNumber: headBefore.number + 1n })
+		const block2 = await client.getBlock({ blockNumber: headBefore.number + 2n })
+		const block3 = await client.getBlock({ blockNumber: headBefore.number + 3n })
+
+		// Every mined block - including the first one after setting the interval - must
+		// advance its timestamp by exactly the configured interval (anvil semantics)
+		expect(block1.timestamp - headBefore.timestamp).toBe(interval)
+		expect(block2.timestamp - block1.timestamp).toBe(interval)
+		expect(block3.timestamp - block2.timestamp).toBe(interval)
 	})
 })


### PR DESCRIPTION
## The bug

Quoted from the viem team's migration PR (the reason viem must keep anvil around):

> "anvil_setBlockTimestampInterval is recorded but not applied to mined blocks."

`anvil_setBlockTimestampInterval` stored the interval on the node, and mining partially honored it — but the **first block mined after setting the interval** still used wall-clock time (`Math.floor(Date.now() / 1000)`) instead of `parent.timestamp + interval`. Both `mineHandler` (`tevm_mine` / `anvil_mine`) and `anvilMineDetailedProcedure` (`anvil_mineDetailed`) shared the same flawed branching where the automatic interval was only applied for `count > 0`.

## Root cause

In `packages/actions/src/Mine/mineHandler.js` (and its twin in `packages/actions/src/anvil/anvilMineDetailedProcedure.js`):

```js
if (overrideTimestamp !== undefined) { ... }
else if (count === 0) {
  timestamp = Math.max(Math.floor(Date.now() / 1000), Number(parentBlock.header.timestamp)) // interval ignored
} else {
  timestamp = Number(parentBlock.header.timestamp) + intervalToUse
}
```

## The fix

When a `blockTimestampInterval` is set and no `nextBlockTimestamp` override exists, **every** mined block — including the first — advances its timestamp by exactly the configured interval, matching anvil semantics. Precedence is preserved: `nextBlockTimestamp` > `blockTimestampInterval` > wall clock / mine interval. `anvil_removeBlockTimestampInterval` (which sets the interval to `undefined`) already restored default wall-clock behavior and is now covered by tests.

Reproduced before fixing: setting interval `5` and mining 3 blocks produced a first-block delta of `1785298091n` (wall clock) instead of `5n`.

## Tests

- `packages/memory-client/src/test/viem/setBlockTimestampInterval.spec.ts` — real test replacing the `expect.assertions(0)` stub: set interval via viem test actions, mine 3 blocks, assert **every** timestamp delta equals the interval
- `packages/memory-client/src/test/viem/removeBlockTimestampInterval.spec.ts` — real test replacing the stub: after removal, mined block timestamps return to wall-clock time
- `packages/actions/src/Mine/mineHandler.spec.ts` — unit tests for first-block interval application and removal restoring defaults

All 47 tests across `mineHandler`, `anvilMineDetailed`, the interval procedures, revert, and memory-client viem mine/timestamp specs pass (`pnpm vitest run`). The one failure in the neighboring `anvilDealHandler.spec.ts` is pre-existing on main (verified via `git stash`) and unrelated.

🤖 Generated with Smithers multi-agent orchestration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Block timestamp intervals now apply consistently to every mined block, including the first block in a mining run.
  - Mining behavior correctly honors explicit timestamp overrides.
  - Removing a configured timestamp interval now restores wall-clock-based timestamps for newly mined blocks.

- **Tests**
  - Added coverage confirming interval progression and timestamp behavior after removing the interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->