### PR TITLE
✨ feat(node): opt-in strictImpersonation so tevm can emulate anvil's "No Signer available"

### DIFF
--- a/.changeset/impersonation.md
+++ b/.changeset/impersonation.md
@@ -1,0 +1,5 @@
+---
+"@tevm/node": minor
+---
+
+Add opt-in strictImpersonation so tevm can emulate anvil's "No Signer available" behavior. Defaults to the existing permissive behavior, so this is not a breaking change.

--- a/docs/node/pages/api/methods.mdx
+++ b/docs/node/pages/api/methods.mdx
@@ -130,6 +130,27 @@ node.setImpersonatedAccount(undefined)
 Impersonation primarily affects the JSON-RPC layer, enabling `eth_sendRawTransaction` to execute as the impersonated account. Works best in fork mode.
 :::
 
+#### Strict impersonation (anvil parity)
+
+By default Tevm auto-impersonates every sender, so `eth_sendTransaction` succeeds from any address. Anvil instead rejects unknown senders with `No Signer available`. Opt into anvil's behavior with `strictImpersonation`:
+
+```ts
+import { createTevmNode } from '@tevm/node'
+
+const node = createTevmNode({ strictImpersonation: true })
+
+// throws NoSignerAvailableError: No Signer available for 0xd8dA...
+await node.request({
+  method: 'eth_sendTransaction',
+  params: [{ from: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', to: '0x0000000000000000000000000000000000000001', value: '0x0' }],
+})
+
+// anvil_impersonateAccount grants access, anvil_stopImpersonatingAccount revokes it again
+node.setImpersonatedAccount('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+```
+
+Prefunded dev accounts always have a signer, and `anvil_autoImpersonateAccount` still bypasses the check while enabled. The mode can also be toggled at runtime with `node.setStrictImpersonation(true)` and is preserved across `deepCopy` and snapshot/revert. It defaults to `false`, so existing behavior is unchanged.
+
 ### Event Filtering
 
 ```ts

--- a/docs/parity-suites.md
+++ b/docs/parity-suites.md
@@ -22,6 +22,12 @@ EIP-3155 flags: `--input=<tevm-trace.json> --out=artifacts/eip3155/trace.jsonl` 
 - `zevm_lightSyncStatus` is kept as a narrow compatibility alias.
 - `zevm_voltaire_*` and `zevm_guillotineMini_*` are intentionally blocked — outside Tevm's scope.
 
+## Impersonation
+
+- Tevm auto-impersonates every sender by default, so `eth_sendTransaction` never produces anvil's `No Signer available` error. This is why viem's `impersonateAccount` / `stopImpersonatingAccount` negative assertions cannot hold against a default Tevm node.
+- `createTevmNode({ strictImpersonation: true })` (or `node.setStrictImpersonation(true)`) opts into anvil's semantics: only prefunded dev accounts, the actively impersonated account, and auto-impersonation grant a signer; anything else throws `NoSignerAvailableError`.
+- `anvil_stopImpersonatingAccount` is meaningful under strict mode — it revokes access that `anvil_impersonateAccount` granted.
+
 ## Snapshot / reset / state blobs
 
 - `anvil_snapshot` / `evm_snapshot` capture state root + state, chain indexes, pending txpool, receipts/logs, mining config, block env overrides, impersonation, and time controls.

--- a/packages/actions/src/eth/ethSendTransactionHandler.js
+++ b/packages/actions/src/eth/ethSendTransactionHandler.js
@@ -3,6 +3,7 @@ import { createAddress } from '@tevm/address'
 import { prefundedAccounts } from '@tevm/node'
 import { bytesToHex, EthjsAddress } from '@tevm/utils'
 import { callHandler } from '../Call/callHandler.js'
+import { assertSignerAvailable } from '../internal/assertSignerAvailable.js'
 
 // TODO we should be properly checking signatures
 
@@ -11,6 +12,8 @@ import { callHandler } from '../Call/callHandler.js'
  * @returns {import('./EthHandler.js').EthSendTransactionHandler}
  */
 export const ethSendTransactionHandler = (client) => async (params) => {
+	// In strict impersonation mode tevm emulates anvil and refuses to sign for unknown senders
+	assertSignerAvailable(client, params.from)
 	let tx = TransactionFactory(
 		{
 			...params,

--- a/packages/actions/src/eth/ethSendTransactionHandler.strictImpersonation.spec.ts
+++ b/packages/actions/src/eth/ethSendTransactionHandler.strictImpersonation.spec.ts
@@ -1,0 +1,57 @@
+import { NoSignerAvailableError } from '@tevm/errors'
+import { createTevmNode, prefundedAccounts } from '@tevm/node'
+import type { Address } from '@tevm/utils'
+import { describe, expect, it } from 'vitest'
+import { anvilImpersonateAccountJsonRpcProcedure } from '../anvil/anvilImpersonateAccountProcedure.js'
+import { anvilStopImpersonatingAccountJsonRpcProcedure } from '../anvil/anvilStopImpersonatingAccountProcedure.js'
+import { ethSendTransactionHandler } from './ethSendTransactionHandler.js'
+
+const vitalik = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const
+const recipient = '0x0000000000000000000000000000000000000001' as const
+
+const send = (node: ReturnType<typeof createTevmNode>, from: Address) =>
+	ethSendTransactionHandler(node)({ from, to: recipient, value: 0n, data: '0x' })
+
+describe('ethSendTransactionHandler strict impersonation', () => {
+	it('sends from any account by default (tevm auto impersonates)', async () => {
+		const node = createTevmNode()
+		await node.ready()
+		expect(await send(node, vitalik)).toMatch(/^0x[0-9a-f]{64}$/)
+	})
+
+	it('errors like anvil for a non impersonated account under strict mode', async () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		await node.ready()
+		await expect(send(node, vitalik)).rejects.toThrow(NoSignerAvailableError)
+		await expect(send(node, vitalik)).rejects.toThrow(/No Signer available/)
+	})
+
+	it('still allows the prefunded dev accounts under strict mode', async () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		await node.ready()
+		expect(await send(node, prefundedAccounts[0] as Address)).toMatch(/^0x[0-9a-f]{64}$/)
+	})
+
+	it('anvil_impersonateAccount grants access and anvil_stopImpersonatingAccount revokes it', async () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		await node.ready()
+
+		await expect(send(node, vitalik)).rejects.toThrow(NoSignerAvailableError)
+
+		await anvilImpersonateAccountJsonRpcProcedure(node)({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'anvil_impersonateAccount',
+			params: [vitalik],
+		})
+		expect(await send(node, vitalik)).toMatch(/^0x[0-9a-f]{64}$/)
+
+		await anvilStopImpersonatingAccountJsonRpcProcedure(node)({
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'anvil_stopImpersonatingAccount',
+			params: [vitalik],
+		})
+		await expect(send(node, vitalik)).rejects.toThrow(NoSignerAvailableError)
+	})
+})

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -9,6 +9,7 @@ export * from './debug/index.js'
 export * from './eth/index.js'
 export * from './GetAccount/index.js'
 // need this in procedures types atm and avoiding wasting time refactoring to ship faster
+export * from './internal/assertSignerAvailable.js'
 export * from './internal/forkAndCacheBlock.js'
 export * from './internal/zod/index.js'
 export * from './LoadState/index.js'

--- a/packages/actions/src/internal/assertSignerAvailable.js
+++ b/packages/actions/src/internal/assertSignerAvailable.js
@@ -1,0 +1,59 @@
+import { NoSignerAvailableError } from '@tevm/errors'
+import { prefundedAccounts } from '@tevm/node'
+
+/**
+ * Asserts that the node is able to sign for `from`, emulating anvil's signer semantics.
+ *
+ * Tevm auto-impersonates every sender by default, which makes anvil's `No Signer available`
+ * failure path unobservable. When a node is created with `strictImpersonation: true` (or
+ * `node.setStrictImpersonation(true)` is called) this assertion enforces anvil's rules:
+ *
+ * - one of the prefunded dev accounts → allowed (anvil has their private keys)
+ * - the currently impersonated account → allowed
+ * - auto impersonation enabled (`anvil_autoImpersonateAccount`) → allowed
+ * - anything else → `NoSignerAvailableError`
+ *
+ * When strict impersonation is disabled (the default) this is a no-op, so existing
+ * permissive behavior is preserved.
+ *
+ * @param {import('@tevm/node').TevmNode} client - The tevm node.
+ * @param {import('@tevm/utils').Address | undefined} from - The sender of the transaction.
+ * @returns {void}
+ * @throws {NoSignerAvailableError} When strict impersonation is enabled and no signer exists for `from`.
+ * @example
+ * ```js
+ * import { createTevmNode } from '@tevm/node'
+ * import { assertSignerAvailable } from '@tevm/actions'
+ *
+ * const node = createTevmNode({ strictImpersonation: true })
+ *
+ * // throws NoSignerAvailableError
+ * assertSignerAvailable(node, '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+ *
+ * node.setImpersonatedAccount('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+ * // no longer throws
+ * assertSignerAvailable(node, '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+ * ```
+ */
+export const assertSignerAvailable = (client, from) => {
+	if (typeof client.getStrictImpersonation !== 'function' || !client.getStrictImpersonation()) {
+		return
+	}
+	if (from === undefined) {
+		return
+	}
+	if (client.getAutoImpersonate()) {
+		return
+	}
+	const normalized = from.toLowerCase()
+	const impersonated = client.getImpersonatedAccount()
+	if (impersonated !== undefined && impersonated.toLowerCase() === normalized) {
+		return
+	}
+	if (prefundedAccounts.some((account) => account.toLowerCase() === normalized)) {
+		return
+	}
+	throw new NoSignerAvailableError(
+		`No Signer available for ${from}. Impersonate it with anvil_impersonateAccount, or disable strictImpersonation.`,
+	)
+}

--- a/packages/actions/src/internal/assertSignerAvailable.spec.ts
+++ b/packages/actions/src/internal/assertSignerAvailable.spec.ts
@@ -1,0 +1,68 @@
+import { NoSignerAvailableError } from '@tevm/errors'
+import { createTevmNode, prefundedAccounts } from '@tevm/node'
+import { describe, expect, it } from 'vitest'
+import { assertSignerAvailable } from './assertSignerAvailable.js'
+
+const vitalik = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const
+
+describe('assertSignerAvailable', () => {
+	it('is a no-op by default (permissive auto impersonation)', () => {
+		const node = createTevmNode()
+		expect(() => assertSignerAvailable(node, vitalik)).not.toThrow()
+	})
+
+	it('throws for an unknown sender when strictImpersonation is enabled', () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		expect(() => assertSignerAvailable(node, vitalik)).toThrow(NoSignerAvailableError)
+		expect(() => assertSignerAvailable(node, vitalik)).toThrow(/No Signer available/)
+	})
+
+	it('allows prefunded dev accounts under strict mode', () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		for (const account of prefundedAccounts) {
+			expect(() => assertSignerAvailable(node, account)).not.toThrow()
+		}
+	})
+
+	it('allows the impersonated account and rejects again after stopping', () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		node.setImpersonatedAccount(vitalik)
+		expect(() => assertSignerAvailable(node, vitalik)).not.toThrow()
+		node.setImpersonatedAccount(undefined)
+		expect(() => assertSignerAvailable(node, vitalik)).toThrow(NoSignerAvailableError)
+	})
+
+	it('matches the impersonated account case-insensitively', () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		node.setImpersonatedAccount(vitalik)
+		expect(() => assertSignerAvailable(node, vitalik.toLowerCase() as typeof vitalik)).not.toThrow()
+	})
+
+	it('bypasses the check while auto impersonation is on', () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		node.setAutoImpersonate(true)
+		expect(() => assertSignerAvailable(node, vitalik)).not.toThrow()
+		node.setAutoImpersonate(false)
+		expect(() => assertSignerAvailable(node, vitalik)).toThrow(NoSignerAvailableError)
+	})
+
+	it('can be toggled at runtime', () => {
+		const node = createTevmNode()
+		expect(node.getStrictImpersonation()).toBe(false)
+		node.setStrictImpersonation(true)
+		expect(node.getStrictImpersonation()).toBe(true)
+		expect(() => assertSignerAvailable(node, vitalik)).toThrow(NoSignerAvailableError)
+	})
+
+	it('survives a deepCopy of the node', async () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		const copy = await node.deepCopy()
+		expect(copy.getStrictImpersonation()).toBe(true)
+		expect(() => assertSignerAvailable(copy, vitalik)).toThrow(NoSignerAvailableError)
+	})
+
+	it('ignores an undefined sender', () => {
+		const node = createTevmNode({ strictImpersonation: true })
+		expect(() => assertSignerAvailable(node, undefined)).not.toThrow()
+	})
+})

--- a/packages/actions/src/internal/snapshotMetadata.js
+++ b/packages/actions/src/internal/snapshotMetadata.js
@@ -34,6 +34,7 @@ export const captureSnapshotMetadata = async (client, vm) => {
 	const metadata = {
 		version: 1,
 		autoImpersonate: client.getAutoImpersonate(),
+		strictImpersonation: client.getStrictImpersonation(),
 		blockchain: {
 			blocks: [.../** @type {Map<any, any>} */ (vm.blockchain.blocks ?? new Map()).entries()],
 			blocksByNumber: [.../** @type {Map<any, any>} */ (vm.blockchain.blocksByNumber ?? new Map()).entries()],
@@ -96,6 +97,10 @@ export const restoreSnapshotState = async (client, snapshot, vm) => {
 		client.setImpersonatedAccount(undefined)
 	}
 	client.setAutoImpersonate(Boolean(snapshot.autoImpersonate))
+	// Older snapshots predate strictImpersonation so leave the node's current mode alone
+	if (snapshot.strictImpersonation !== undefined) {
+		client.setStrictImpersonation(snapshot.strictImpersonation)
+	}
 	client.miningConfig = snapshot.miningConfig ?? client.miningConfig
 	client.setNextBlockTimestamp(
 		snapshot.nextBlockTimestamp !== undefined ? BigInt(snapshot.nextBlockTimestamp) : undefined,

--- a/packages/errors/src/__snapshots__/errors.spec.ts.snap
+++ b/packages/errors/src/__snapshots__/errors.spec.ts.snap
@@ -732,6 +732,16 @@ Docs: https://tevm.sh/errors/test-error
 Version: 1.0.0-next.148]
 `;
 
+exports[`Error Classes > should have all error classes available with expected shape > NoSignerAvailableError 1`] = `
+[NoSignerAvailable: Test error message
+
+Meta message 1
+Meta message 2
+
+Docs: https://tevm.sh/reference/tevm/errors/classes/nosigneravailableerror/
+Version: 1.0.0-next.148]
+`;
+
 exports[`Error Classes > should have all error classes available with expected shape > NonceAlreadyUsedError 1`] = `
 [NonceAlreadyUsed: Test error message
 

--- a/packages/errors/src/errors.spec.ts
+++ b/packages/errors/src/errors.spec.ts
@@ -47,6 +47,7 @@ describe('Error Classes', () => {
 			'ExecutionError',
 			'NonceTooLowError',
 			'NonceTooHighError',
+			'NoSignerAvailableError',
 			'UnknownBlockError',
 			'AccountLockedError',
 			'InvalidOpcodeError',

--- a/packages/errors/src/ethereum/NoSignerAvailableError.js
+++ b/packages/errors/src/ethereum/NoSignerAvailableError.js
@@ -1,0 +1,80 @@
+import { BaseError } from './BaseError.js'
+
+/**
+ * Parameters for constructing a NoSignerAvailableError.
+ * @typedef {Object} NoSignerAvailableErrorParameters
+ * @property {string} [docsBaseUrl]
+ * @property {string} [docsPath]
+ * @property {string} [docsSlug]
+ * @property {string[]} [metaMessages]
+ * @property {BaseError|Error} [cause]
+ * @property {string} [details]
+ * @property {object} [meta]
+ */
+
+/**
+ * Represents an error that occurs when a transaction is sent from an address the
+ * node cannot sign for.
+ *
+ * Tevm is permissive by default: any `from` address is implicitly impersonated so
+ * transactions always succeed. That is convenient for testing but it diverges from
+ * anvil, which rejects `eth_sendTransaction` with `No Signer available` when the
+ * sender is neither one of its dev accounts nor an actively impersonated account.
+ *
+ * This error is thrown only when a node is created with `strictImpersonation: true`,
+ * which makes tevm faithfully emulate anvil's behavior so that suites asserting the
+ * failure path (for example viem's `impersonateAccount` / `stopImpersonatingAccount`
+ * tests) can hold against tevm.
+ *
+ * @example
+ * ```ts
+ * import { createTevmNode } from '@tevm/node'
+ * import { NoSignerAvailableError } from '@tevm/errors'
+ * import { ethSendTransactionHandler } from '@tevm/actions'
+ *
+ * const node = createTevmNode({ strictImpersonation: true })
+ *
+ * try {
+ *   await ethSendTransactionHandler(node)({
+ *     from: '0x1234567890123456789012345678901234567890',
+ *     to: '0x0000000000000000000000000000000000000001',
+ *     value: 0n,
+ *   })
+ * } catch (error) {
+ *   if (error instanceof NoSignerAvailableError) {
+ *     console.error(error.message) // No Signer available for 0x1234...
+ *   }
+ * }
+ * ```
+ *
+ * @param {string} message - A human-readable error message.
+ * @param {NoSignerAvailableErrorParameters} [args={}] - Additional parameters for the BaseError.
+ */
+export class NoSignerAvailableError extends BaseError {
+	/**
+	 * The error code for NoSignerAvailableError. Matches anvil/hardhat's
+	 * "resource not found" JSON-RPC code for an unknown account.
+	 * @type {number}
+	 */
+	static code = -32000
+
+	/**
+	 * Constructs a NoSignerAvailableError.
+	 *
+	 * @param {string} message - Human-readable error message.
+	 * @param {NoSignerAvailableErrorParameters} [args={}] - Additional parameters for the BaseError.
+	 * @param {string} [tag='NoSignerAvailable'] - The tag for the error.
+	 */
+	constructor(message, args = {}, tag = 'NoSignerAvailable') {
+		super(
+			message,
+			{
+				...args,
+				docsBaseUrl: 'https://tevm.sh',
+				docsPath: '/reference/tevm/errors/classes/nosigneravailableerror/',
+			},
+			tag,
+			NoSignerAvailableError.code,
+		)
+	}
+}

--- a/packages/errors/src/ethereum/index.ts
+++ b/packages/errors/src/ethereum/index.ts
@@ -92,6 +92,7 @@ export { MethodNotSupportedError, type MethodNotSupportedErrorParameters } from 
 export { NonceAlreadyUsedError, type NonceAlreadyUsedErrorParameters } from './NonceAlreadyUsedError.js'
 export { NonceTooHighError, type NonceTooHighErrorParameters } from './NonceTooHighError.js'
 export { NonceTooLowError, type NonceTooLowErrorParameters } from './NonceTooLowError.js'
+export { NoSignerAvailableError, type NoSignerAvailableErrorParameters } from './NoSignerAvailableError.js'
 export { ParseError, type ParseErrorParameters } from './ParseErrorError.js'
 export {
 	PendingTransactionTimeoutError,

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -96,6 +96,8 @@ export {
 	type NonceTooHighErrorParameters,
 	NonceTooLowError,
 	type NonceTooLowErrorParameters,
+	NoSignerAvailableError,
+	type NoSignerAvailableErrorParameters,
 	OutOfGasError,
 	type OutOfGasErrorParameters,
 	OutOfRangeError,

--- a/packages/node/src/TevmNode.ts
+++ b/packages/node/src/TevmNode.ts
@@ -24,6 +24,7 @@ export type SnapshotMetadata = {
 	minGasPrice?: bigint
 	impersonatedAccount?: Address
 	autoImpersonate?: boolean
+	strictImpersonation?: boolean
 	txHashes?: readonly Hex[]
 	txPoolTransactions?: readonly unknown[]
 	receiptEntries?: readonly (readonly [unknown, unknown])[]
@@ -141,6 +142,19 @@ export type TevmNode<TMode extends 'fork' | 'normal' = 'fork' | 'normal', TExten
 	 * When enabled, all transactions will have their sender automatically impersonated.
 	 */
 	readonly setAutoImpersonate: (enabled: boolean) => void
+	/**
+	 * Gets whether strict impersonation is enabled.
+	 * When enabled, tevm emulates anvil: sending a transaction from an address that is
+	 * neither a prefunded dev account nor actively impersonated throws a
+	 * `NoSignerAvailableError`. Defaults to false, which keeps tevm's permissive
+	 * auto-impersonation behavior.
+	 */
+	readonly getStrictImpersonation: () => boolean
+	/**
+	 * Sets whether to enforce strict impersonation.
+	 * @see {@link getStrictImpersonation}
+	 */
+	readonly setStrictImpersonation: (enabled: boolean) => void
 	/**
 	 * Gets whether automatic tracing is enabled.
 	 * When enabled, all transactions include traces in their responses.

--- a/packages/node/src/TevmNodeOptions.ts
+++ b/packages/node/src/TevmNodeOptions.ts
@@ -109,6 +109,39 @@ export type TevmNodeOptions<TCommon extends Common = Common> = StateOptions & {
 	 */
 	readonly customPredeploys?: ReadonlyArray<Predeploy<any, any>>
 	/**
+	 * Makes tevm emulate anvil's signer semantics. Defaults to `false`.
+	 *
+	 * By default tevm auto-impersonates every sender, so a transaction from any address
+	 * succeeds. That is convenient but it means suites that assert anvil's failure path
+	 * (viem's `impersonateAccount` / `stopImpersonatingAccount` tests, for example) cannot
+	 * hold against tevm.
+	 *
+	 * When set to `true`, sending a transaction from an address that is neither one of the
+	 * prefunded dev accounts nor actively impersonated throws a `NoSignerAvailableError`
+	 * (`No Signer available`), exactly like anvil. `anvil_impersonateAccount` then grants
+	 * access and `anvil_stopImpersonatingAccount` revokes it again. `anvil_autoImpersonateAccount`
+	 * still bypasses the check while enabled.
+	 *
+	 * This can also be toggled at runtime with `node.setStrictImpersonation(enabled)`.
+	 *
+	 * @example
+	 * ```typescript
+	 * import { createTevmNode } from '@tevm/node'
+	 * import { ethSendTransactionHandler } from '@tevm/actions'
+	 *
+	 * const node = createTevmNode({ strictImpersonation: true })
+	 * const vitalik = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+	 *
+	 * // throws NoSignerAvailableError: No Signer available for 0xd8dA...
+	 * await ethSendTransactionHandler(node)({ from: vitalik, to: vitalik, value: 0n })
+	 *
+	 * node.setImpersonatedAccount(vitalik)
+	 * // now succeeds
+	 * await ethSendTransactionHandler(node)({ from: vitalik, to: vitalik, value: 0n })
+	 * ```
+	 */
+	readonly strictImpersonation?: boolean
+	/**
 	 * Enable/disable unlimited contract size. Defaults to false.
 	 * If set to true you may still run up against block limits
 	 */

--- a/packages/node/src/createTevmNode.js
+++ b/packages/node/src/createTevmNode.js
@@ -92,6 +92,25 @@ export const createTevmNode = (options = {}) => {
 	}
 
 	/**
+	 * When true the node refuses to send transactions from addresses it has no signer for,
+	 * emulating anvil's `No Signer available` error. Defaults to false (permissive).
+	 * @type {boolean}
+	 */
+	let strictImpersonation = options.strictImpersonation ?? false
+	/**
+	 * Gets whether strict impersonation is enabled
+	 * @returns {boolean}
+	 */
+	const getStrictImpersonation = () => strictImpersonation
+	/**
+	 * Sets whether to enforce strict impersonation
+	 * @param {boolean} enabled
+	 */
+	const setStrictImpersonation = (enabled) => {
+		strictImpersonation = enabled
+	}
+
+	/**
 	 * @type {boolean}
 	 */
 	let tracesEnabled = false
@@ -630,6 +649,18 @@ export const createTevmNode = (options = {}) => {
 			copiedAutoImpersonate = enabled
 		}
 		/**
+		 * Strict impersonation state copied from parent
+		 * @type {boolean}
+		 */
+		let copiedStrictImpersonation = baseClient.getStrictImpersonation()
+		const getCopiedStrictImpersonation = () => copiedStrictImpersonation
+		/**
+		 * @param {boolean} enabled
+		 */
+		const setCopiedStrictImpersonation = (enabled) => {
+			copiedStrictImpersonation = enabled
+		}
+		/**
 		 * Traces enabled state copied from parent
 		 * @type {boolean}
 		 */
@@ -787,6 +818,8 @@ export const createTevmNode = (options = {}) => {
 			setImpersonatedAccount,
 			getAutoImpersonate: getCopiedAutoImpersonate,
 			setAutoImpersonate: setCopiedAutoImpersonate,
+			getStrictImpersonation: getCopiedStrictImpersonation,
+			setStrictImpersonation: setCopiedStrictImpersonation,
 			getTracesEnabled: getCopiedTracesEnabled,
 			setTracesEnabled: setCopiedTracesEnabled,
 			getNextBlockTimestamp: () => copiedNextBlockTimestamp,
@@ -1052,6 +1085,8 @@ export const createTevmNode = (options = {}) => {
 		setImpersonatedAccount,
 		getAutoImpersonate,
 		setAutoImpersonate,
+		getStrictImpersonation,
+		setStrictImpersonation,
 		getTracesEnabled,
 		setTracesEnabled,
 		getNextBlockTimestamp,


### PR DESCRIPTION
## The bug

Tevm auto-impersonates every transaction sender. `eth_sendTransaction` from a completely arbitrary address always succeeds, because the handler wraps any unsigned tx in an impersonated tx and falls back to `prefundedAccounts[0]` when nothing is impersonated.

Anvil does the opposite: it rejects a sender it has no signer for with `No Signer available`. Because tevm never produces that error, `anvil_stopImpersonatingAccount` has **no observable effect** — there is nothing to stop.

This was called out directly in the viem migration PR as a reason viem must keep anvil around:

> "Tevm auto-impersonates, so the 'No Signer available' negatives cannot hold."

viem's `impersonateAccount` / `stopImpersonatingAccount` suites assert the failure path, so they cannot run against tevm today.

## Reproduction

Confirmed before writing the fix. With the assertion commented out, the new negative tests fail exactly as described — the send resolves instead of rejecting:

```
FAIL  src/eth/ethSendTransactionHandler.strictImpersonation.spec.ts > anvil_impersonateAccount grants access and anvil_stopImpersonatingAccount revokes it
AssertionError: promise resolved "'0x396a5638c81327e64e0ba0eb7dcc547421f…'" instead of rejecting

Test Files  1 failed (1)
     Tests  2 failed | 2 passed (4)
```

## Root cause

`packages/actions/src/eth/ethSendTransactionHandler.js` has no concept of "this node has no signer for that address". Every unsigned transaction becomes an impersonated transaction unconditionally, so impersonation state is never actually consulted as an authorization check.

## The fix

A new **opt-in** `strictImpersonation` node option. **It defaults to `false`, so this is not a breaking change** — the permissive auto-impersonation behavior is untouched unless you ask for anvil parity.

When enabled, tevm follows anvil's rules. A sender is authorized if it is:
- one of the prefunded dev accounts (anvil holds their keys),
- the actively impersonated account, or
- any account while `anvil_autoImpersonateAccount` is on.

Anything else throws the new `NoSignerAvailableError` (`No Signer available for 0x…`, JSON-RPC code `-32000`). This makes `anvil_stopImpersonatingAccount` meaningful: it revokes access that `anvil_impersonateAccount` granted.

The mode can be toggled at runtime via `node.setStrictImpersonation(true)`, is inherited by `deepCopy`, and is preserved across snapshot/revert (older snapshots without the field leave the current mode alone).

Signed transactions via `eth_sendRawTransaction` are deliberately unaffected — a valid signature is its own authorization, exactly as in anvil.

```ts
import { createTevmNode } from '@tevm/node'

const node = createTevmNode({ strictImpersonation: true })
const vitalik = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'

// throws NoSignerAvailableError: No Signer available for 0xd8dA...
await ethSendTransactionHandler(node)({ from: vitalik, to: vitalik, value: 0n })

node.setImpersonatedAccount(vitalik)
// now succeeds
await ethSendTransactionHandler(node)({ from: vitalik, to: vitalik, value: 0n })
```

## Packages touched

- `packages/errors` — new `NoSignerAvailableError` (exported through both barrels; `tevm/errors` re-exports `*`)
- `packages/node` — `strictImpersonation` option, `get/setStrictImpersonation`, `deepCopy` propagation, `SnapshotMetadata` field
- `packages/actions` — `assertSignerAvailable` helper (exported from the barrel), wired into `ethSendTransactionHandler`, snapshot capture/restore
- `docs/` — `docs/node/pages/api/methods.mdx` and `docs/parity-suites.md`

## Tests added

Real clients throughout, no mocks.

- `packages/actions/src/internal/assertSignerAvailable.spec.ts` (9 tests) — default no-op, unknown sender rejected, prefunded accounts allowed, impersonate/stop round trip, case-insensitive matching, auto-impersonate bypass, runtime toggle, `deepCopy` inheritance, undefined sender
- `packages/actions/src/eth/ethSendTransactionHandler.strictImpersonation.spec.ts` (4 tests) — default permissive behavior still holds, anvil-style error under strict mode, prefunded accounts still work, and the full `anvil_impersonateAccount` → send → `anvil_stopImpersonatingAccount` → reject cycle

```
$ pnpm vitest run src/internal/assertSignerAvailable.spec.ts src/eth/ethSendTransactionHandler.strictImpersonation.spec.ts

 Test Files  2 passed (2)
      Tests  13 passed (13)
```

## No regressions

```
$ pnpm vitest run src/eth/ethSendTransactionHandler.spec.ts src/anvil src/internal   # @tevm/actions
 Test Files  65 passed | 2 skipped (67)
      Tests  318 passed | 16 skipped | 1 todo (335)

$ pnpm vitest run    # @tevm/node
 Test Files  11 passed (11)
      Tests  102 passed (102)

$ pnpm vitest run    # @tevm/errors
 Test Files  9 passed (9)
      Tests  92 passed | 3 skipped (95)
```

🤖 Generated with Smithers multi-agent orchestration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional strict impersonation mode for Anvil-compatible signer behavior.
  * Transactions from unknown, non-impersonated accounts now return a `NoSignerAvailableError` when strict mode is enabled.
  * Added runtime controls for enabling or disabling strict impersonation.
  * Strict impersonation settings persist across snapshots, reverts, and node copies.

* **Documentation**
  * Added usage guidance, examples, and impersonation behavior details to the API and parity documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->