### PR TITLE
✨ feat(server): add IPC JSON-RPC transport

### DIFF
--- a/.changeset/fresh-sockets-listen.md
+++ b/.changeset/fresh-sockets-listen.md
@@ -1,0 +1,6 @@
+---
+"@tevm/server": minor
+"tevm": minor
+---
+
+Added a Unix domain socket JSON-RPC server with newline-delimited framing and subscription notifications.

--- a/.changeset/ipc-server.md
+++ b/.changeset/ipc-server.md
@@ -1,0 +1,5 @@
+---
+"@tevm/server": minor
+---
+
+Add an IPC (unix domain socket) JSON-RPC transport so viem's ipc() transport can connect to a tevm node.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -25,6 +25,7 @@
 Creates a JSON-RPC server for serving Tevm requests from a Tevm node.
 
 - [`createHttpHandler`](./src/createHttpHandler.js) Creates a generic http handler
+- [`createIpcServer`](./src/createIpcServer.js) Creates a Unix domain socket server with JSON-RPC subscriptions
 - [`createServer`](./src/createServer.js) Creates a simple vanilla node.js server to serve TEVM json-rpc api
 - [`createExpressMiddleware`](./src/adapters/createExpressMiddleware.js) Creates an express middleware to serve TEVM json-rpc api
 - [`createNextApiHandler`](./src/adapters/createNextApiHandler.js.js) Creates a next.js handler for tevm.
@@ -51,6 +52,27 @@ import { mainnet } from "viem/chains";
 const publicClient = createPublicClient({
   chain: mainnet,
   transport: http("https://localhost:8545"),
+});
+
+console.log(await publicClient.getChainId());
+```
+
+For Node.js clients, Tevm can also serve newline-delimited JSON-RPC over a Unix domain socket. The IPC server supports `eth_subscribe` notifications on the same connection.
+
+```typescript
+import { createMemoryClient } from "tevm";
+import { createIpcServer } from "tevm/server";
+import { createPublicClient } from "viem";
+import { ipc } from "viem/node";
+
+const socketPath = "/tmp/tevm.ipc";
+const tevm = createMemoryClient();
+const server = createIpcServer(tevm);
+
+server.listen(socketPath);
+
+const publicClient = createPublicClient({
+  transport: ipc(socketPath),
 });
 
 console.log(await publicClient.getChainId());

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -81,7 +81,8 @@
 		"@tevm/tsupconfig": "workspace:^",
 		"@types/express": "^5.0.6",
 		"express": "^5.2.1",
-		"next": "^16.2.6"
+		"next": "^16.2.6",
+		"viem": "^2.49.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/server/src/createIpcServer.js
+++ b/packages/server/src/createIpcServer.js
@@ -1,0 +1,29 @@
+import { createServer as createNetServer } from 'node:net'
+import { createIpcConnectionHandler } from './internal/createIpcConnectionHandler.js'
+
+/**
+ * Creates a Unix domain socket JSON-RPC server backed by a Tevm client.
+ *
+ * The server accepts concatenated or newline-delimited JSON-RPC messages and
+ * streams `eth_subscription` notifications over the same connection.
+ *
+ * @param {import('./Client.js').Client} client - Tevm client that handles JSON-RPC requests.
+ * @param {import('node:net').ServerOpts} [serverOptions] - Options passed to `node:net.createServer`.
+ * @param {{ maxMessageSize?: number; maxBatchSize?: number }} [handlerOptions] - IPC framing limits.
+ * @returns {import('node:net').Server} A Node.js server that can listen on a Unix domain socket path.
+ * @throws {never} Startup and connection errors are emitted by the returned server.
+ * @example
+ * ```typescript
+ * import { createMemoryClient } from 'tevm'
+ * import { createIpcServer } from 'tevm/server'
+ *
+ * const client = createMemoryClient()
+ * const server = createIpcServer(client)
+ *
+ * server.listen('/tmp/tevm.ipc', () => {
+ *   console.log('Tevm IPC server listening at /tmp/tevm.ipc')
+ * })
+ * ```
+ */
+export const createIpcServer = (client, serverOptions = {}, handlerOptions = {}) =>
+	createNetServer(serverOptions, createIpcConnectionHandler(client, handlerOptions))

--- a/packages/server/src/createIpcServer.spec.ts
+++ b/packages/server/src/createIpcServer.spec.ts
@@ -1,0 +1,290 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { connect, type Server, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createMemoryClient, type MemoryClient } from '@tevm/memory-client'
+import { SimpleContract } from '@tevm/test-utils'
+import { createPublicClient, encodeEventTopics, encodeFunctionData } from 'viem'
+import { getIpcRpcClient, type IpcRpcClient, ipc } from 'viem/node'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createIpcServer } from './createIpcServer.js'
+import { extractJsonRpcFrames } from './internal/extractJsonRpcFrames.js'
+
+const listen = (server: Server, path: string) =>
+	new Promise<void>((resolve, reject) => {
+		server.once('error', reject)
+		server.listen(path, () => {
+			server.off('error', reject)
+			resolve()
+		})
+	})
+
+const close = (server: Server) =>
+	new Promise<void>((resolve, reject) => {
+		server.close((error) => {
+			if (error) reject(error)
+			else resolve()
+		})
+	})
+
+const openSocket = (path: string) =>
+	new Promise<Socket>((resolve, reject) => {
+		const socket = connect(path)
+		socket.once('error', reject)
+		socket.once('connect', () => {
+			socket.off('error', reject)
+			resolve(socket)
+		})
+	})
+
+const readJsonLines = (socket: Socket, count: number) =>
+	new Promise<Array<unknown>>((resolve, reject) => {
+		let buffer = ''
+		const messages: Array<unknown> = []
+		const onData = (chunk: Buffer) => {
+			buffer += chunk.toString('utf8')
+			const lines = buffer.split('\n')
+			buffer = lines.pop() ?? ''
+			for (const line of lines) {
+				if (line.trim().length === 0) continue
+				try {
+					messages.push(JSON.parse(line))
+				} catch (error) {
+					cleanup()
+					reject(error)
+					return
+				}
+				if (messages.length === count) {
+					cleanup()
+					resolve(messages)
+					return
+				}
+			}
+		}
+		const onError = (error: Error) => {
+			cleanup()
+			reject(error)
+		}
+		const cleanup = () => {
+			socket.off('data', onData)
+			socket.off('error', onError)
+		}
+		socket.on('data', onData)
+		socket.on('error', onError)
+	})
+
+describe('createIpcServer', () => {
+	let client: MemoryClient
+	let directory: string
+	let rpcClient: IpcRpcClient | undefined
+	let server: Server
+	let socket: Socket | undefined
+	let socketPath: string
+
+	beforeEach(async () => {
+		client = createMemoryClient({ miningConfig: { type: 'manual' } })
+		directory = await mkdtemp(join(tmpdir(), 'tevm-ipc-'))
+		socketPath = join(directory, 'tevm.ipc')
+		server = createIpcServer(client)
+		await listen(server, socketPath)
+	})
+
+	afterEach(async () => {
+		socket?.destroy()
+		rpcClient?.close()
+		await close(server)
+		await rm(directory, { recursive: true, force: true })
+	})
+
+	it('serves requests from viem ipc()', async () => {
+		const publicClient = createPublicClient({
+			transport: ipc(socketPath, { reconnect: false }),
+		})
+		rpcClient = await getIpcRpcClient(socketPath, { reconnect: false })
+
+		await expect(publicClient.getChainId()).resolves.toBe(900)
+	})
+
+	it('handles fragmented newline-delimited JSON-RPC messages', async () => {
+		socket = await openSocket(socketPath)
+		const responses = readJsonLines(socket, 2)
+
+		socket.write('{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}\n{"json')
+		socket.write('rpc":"2.0","method":"eth_blockNumber","params":[],"id":2}\n')
+
+		await expect(responses).resolves.toEqual([
+			expect.objectContaining({ id: 1, jsonrpc: '2.0', result: '0x384' }),
+			expect.objectContaining({ id: 2, jsonrpc: '2.0', result: '0x0' }),
+		])
+	})
+
+	it('extracts concatenated frames without treating string braces as delimiters', () => {
+		const frame = JSON.stringify({ jsonrpc: '2.0', method: 'test', params: ['a } brace and a " quote'], id: 1 })
+
+		expect(extractJsonRpcFrames(`${frame}${frame}`)).toEqual([[frame, frame], ''])
+		expect(extractJsonRpcFrames('not-json')).toEqual([[], 'not-json'])
+	})
+
+	it('handles batch requests, notifications, and invalid newline-delimited messages', async () => {
+		socket = await openSocket(socketPath)
+		const responses = readJsonLines(socket, 3)
+
+		socket.write(
+			`${JSON.stringify([
+				{ jsonrpc: '2.0', method: 'eth_chainId', params: [] },
+				{ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 2 },
+			])}\n`,
+		)
+		socket.write('not-json\n')
+		socket.write('{"jsonrpc":"2.0","params":[],"id":3}\n')
+
+		await expect(responses).resolves.toEqual([
+			[expect.objectContaining({ id: 2, result: '0x0' })],
+			expect.objectContaining({ error: expect.objectContaining({ code: -32700 }), id: null }),
+			expect.objectContaining({ error: expect.objectContaining({ code: -32600 }), id: null }),
+		])
+	})
+
+	it('rejects messages larger than the configured limit', async () => {
+		await close(server)
+		server = createIpcServer(client, {}, { maxMessageSize: 8 })
+		await listen(server, socketPath)
+		socket = await openSocket(socketPath)
+		const response = readJsonLines(socket, 1)
+
+		socket.write('{"jsonrpc":"2.0","method":"eth_chainId","id":1}\n')
+
+		await expect(response).resolves.toEqual([
+			expect.objectContaining({ error: expect.objectContaining({ code: -32600 }), id: null }),
+		])
+	})
+
+	it('streams subscription notifications through viem ipc()', async () => {
+		const transport = ipc(socketPath, { reconnect: false })({
+			chain: undefined,
+			retryCount: 0,
+			timeout: 2_000,
+		})
+		rpcClient = await getIpcRpcClient(socketPath)
+		let rejectNotification: (reason?: unknown) => void
+		let resolveNotification: (value: Record<string, unknown>) => void
+		const notification = new Promise<Record<string, unknown>>((resolve, reject) => {
+			rejectNotification = reject
+			resolveNotification = resolve
+		})
+		if (!transport.value) throw new Error('IPC transport did not expose a subscription client')
+		const { unsubscribe } = await transport.value.subscribe({
+			params: ['newHeads'],
+			onData: resolveNotification!,
+			onError: rejectNotification!,
+		})
+
+		await client.tevmMine({ blockCount: 1 })
+		await expect(notification).resolves.toEqual({
+			result: expect.objectContaining({ number: '0x1' }),
+			subscription: expect.stringMatching(/^0x/),
+		})
+		await unsubscribe()
+	})
+
+	it('streams pending transaction subscriptions through viem ipc()', async () => {
+		const transport = ipc(socketPath, { reconnect: false })({
+			chain: undefined,
+			retryCount: 0,
+			timeout: 2_000,
+		})
+		rpcClient = await getIpcRpcClient(socketPath)
+		const notification = Promise.withResolvers<Record<string, unknown>>()
+		if (!transport.value) throw new Error('IPC transport did not expose a subscription client')
+		const { unsubscribe } = await transport.value.subscribe({
+			params: ['newPendingTransactions'],
+			onData: notification.resolve,
+			onError: notification.reject,
+		})
+		const sender = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+		await client.tevmSetAccount({ address: sender, balance: 10n ** 20n })
+
+		const transaction = await client.tevmCall({
+			createTransaction: true,
+			from: sender,
+			to: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+			value: 1n,
+		})
+
+		expect(transaction.errors).toBeUndefined()
+		await expect(notification.promise).resolves.toEqual({
+			result: transaction.txHash,
+			subscription: expect.stringMatching(/^0x/),
+		})
+		await unsubscribe()
+	})
+
+	it('streams filtered log subscriptions through viem ipc()', async () => {
+		const transport = ipc(socketPath, { reconnect: false })({
+			chain: undefined,
+			retryCount: 0,
+			timeout: 2_000,
+		})
+		rpcClient = await getIpcRpcClient(socketPath)
+		const notification = Promise.withResolvers<Record<string, unknown>>()
+		const contract = '0x1234567890123456789012345678901234567890'
+		const sender = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+		await client.tevmSetAccount({ address: sender, balance: 10n ** 20n })
+		await client.tevmSetAccount({ address: contract, deployedBytecode: SimpleContract.deployedBytecode })
+		const [eventTopic] = encodeEventTopics({
+			abi: SimpleContract.abi,
+			eventName: 'ValueSet',
+		})
+		if (!transport.value) throw new Error('IPC transport did not expose a subscription client')
+		const { unsubscribe } = await transport.value.subscribe({
+			params: [
+				'logs',
+				{
+					address: ['0x0000000000000000000000000000000000000000', contract],
+					topics: [[`0x${'0'.repeat(64)}`, eventTopic]],
+				},
+			],
+			onData: notification.resolve,
+			onError: notification.reject,
+		})
+
+		const transaction = await client.tevmCall({
+			createTransaction: true,
+			data: encodeFunctionData(SimpleContract.write.set(42n)),
+			from: sender,
+			to: contract,
+		})
+		expect(transaction.errors).toBeUndefined()
+		await client.tevmMine({ blockCount: 1 })
+
+		await expect(notification.promise).resolves.toEqual({
+			result: expect.objectContaining({
+				address: contract,
+				blockNumber: '0x1',
+				topics: expect.arrayContaining([expect.stringMatching(/^0x/)]),
+				transactionHash: transaction.txHash,
+			}),
+			subscription: expect.stringMatching(/^0x/),
+		})
+		await unsubscribe()
+	})
+
+	it('supports syncing subscriptions and cleans them up when the socket closes', async () => {
+		const transport = ipc(socketPath, { reconnect: false })({
+			chain: undefined,
+			retryCount: 0,
+			timeout: 2_000,
+		})
+		rpcClient = await getIpcRpcClient(socketPath)
+		if (!transport.value) throw new Error('IPC transport did not expose a subscription client')
+		const { subscriptionId } = await transport.value.subscribe({
+			params: ['syncing'],
+			onData: () => {},
+		})
+
+		expect(client.transport.tevm.getFilters().has(subscriptionId)).toBe(true)
+		rpcClient.close()
+		rpcClient = undefined
+		await expect.poll(() => client.transport.tevm.getFilters().has(subscriptionId)).toBe(false)
+	})
+})

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -3,6 +3,7 @@ export {
 	createNextApiHandler,
 } from './adapters/index.js'
 export { createHttpHandler } from './createHttpHandler.js'
+export { createIpcServer } from './createIpcServer.js'
 export { createServer } from './createServer.js'
 export * from './errors/InvalidJsonError.js'
 export * from './errors/ReadRequestBodyError.js'

--- a/packages/server/src/index.spec.ts
+++ b/packages/server/src/index.spec.ts
@@ -6,6 +6,10 @@ describe('index exports', () => {
 		expect(indexExports.createHttpHandler).toBeDefined()
 	})
 
+	it('should export createIpcServer', () => {
+		expect(indexExports.createIpcServer).toBeDefined()
+	})
+
 	it('should export createServer', () => {
 		expect(indexExports.createServer).toBeDefined()
 	})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ export {
 } from './adapters/index.js'
 export * from './Client.js'
 export { createHttpHandler } from './createHttpHandler.js'
+export { createIpcServer } from './createIpcServer.js'
 export { createServer } from './createServer.js'
 export * from './errors/InvalidJsonError.js'
 export * from './errors/ReadRequestBodyError.js'

--- a/packages/server/src/internal/createIpcConnectionHandler.js
+++ b/packages/server/src/internal/createIpcConnectionHandler.js
@@ -1,0 +1,161 @@
+import { StringDecoder } from 'node:string_decoder'
+import { InternalError, InvalidRequestError } from '@tevm/errors'
+import { InvalidJsonError } from '../errors/InvalidJsonError.js'
+import { createIpcSubscription } from './createIpcSubscription.js'
+import { extractJsonRpcFrames } from './extractJsonRpcFrames.js'
+import { handleBulkRequest } from './handleBulkRequest.js'
+import { parseRequest } from './parseRequest.js'
+
+const DEFAULT_MAX_MESSAGE_SIZE = 1024 * 1024
+const DEFAULT_MAX_BATCH_SIZE = 100
+
+/**
+ * Creates the connection listener used by a Node.js IPC server.
+ *
+ * @param {import('../Client.js').Client} client - Tevm client that handles JSON-RPC requests.
+ * @param {{ maxMessageSize?: number; maxBatchSize?: number }} [options] - IPC framing limits.
+ * @returns {(socket: import('node:net').Socket) => void} Node.js connection listener.
+ * @throws {never}
+ */
+export const createIpcConnectionHandler = (client, options = {}) => {
+	const { maxBatchSize = DEFAULT_MAX_BATCH_SIZE, maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE } = options
+	const tevm = client.transport.tevm
+
+	return (socket) => {
+		let buffer = ''
+		let queue = Promise.resolve()
+		const decoder = new StringDecoder('utf8')
+		/** @type {Map<string, () => void>} */
+		const subscriptions = new Map()
+
+		/**
+		 * @param {unknown} message
+		 * @returns {void}
+		 */
+		const send = (message) => {
+			if (!socket.destroyed && socket.writable) socket.write(`${JSON.stringify(message)}\n`)
+		}
+
+		/**
+		 * @param {import('@tevm/jsonrpc').JsonRpcRequest<string, any>} request
+		 * @returns {Promise<import('@tevm/jsonrpc').JsonRpcResponse<any, any, any> | undefined>}
+		 */
+		const dispatch = async (request) => {
+			const [response] = await handleBulkRequest(client, [request], { suppressNotifications: true })
+			if (
+				request.method === 'eth_subscribe' &&
+				response &&
+				'result' in response &&
+				typeof response.result === 'string' &&
+				Array.isArray(request.params)
+			) {
+				const removeListener = createIpcSubscription(tevm, response.result, request.params, send)
+				subscriptions.set(response.result, removeListener)
+			}
+			if (
+				request.method === 'eth_unsubscribe' &&
+				response &&
+				'result' in response &&
+				response.result === true &&
+				Array.isArray(request.params) &&
+				typeof request.params[0] === 'string'
+			) {
+				subscriptions.get(request.params[0])?.()
+				subscriptions.delete(request.params[0])
+			}
+			return response
+		}
+
+		/**
+		 * @param {string} frame
+		 * @returns {Promise<void>}
+		 */
+		const handleFrame = async (frame) => {
+			const parsed = parseRequest(frame, {
+				allowEmptyBatch: false,
+				maxBatchSize,
+				requireJsonrpc: true,
+			})
+			if (parsed instanceof InvalidJsonError || parsed instanceof InvalidRequestError) {
+				tevm.logger.error(parsed)
+				send({
+					error: { code: parsed.code, message: parsed.message },
+					id: null,
+					jsonrpc: '2.0',
+					method: 'unknown',
+				})
+				return
+			}
+
+			if (Array.isArray(parsed)) {
+				const responses = (await Promise.all(parsed.map((request) => dispatch(/** @type {any} */ (request))))).filter(
+					(response) => response !== undefined,
+				)
+				if (responses.length > 0) send(responses)
+				return
+			}
+
+			const response = await dispatch(/** @type {any} */ (parsed))
+			if (response !== undefined) send(response)
+		}
+
+		/** @param {Buffer} chunk */
+		const onData = (chunk) => {
+			buffer += decoder.write(chunk)
+			if (Buffer.byteLength(buffer, 'utf8') > maxMessageSize) {
+				const error = new InvalidRequestError(`IPC message exceeds configured max message size of ${maxMessageSize}`)
+				tevm.logger.error(error)
+				send({
+					error: { code: error.code, message: error.message },
+					id: null,
+					jsonrpc: '2.0',
+					method: 'unknown',
+				})
+				buffer = ''
+				socket.end()
+				return
+			}
+
+			const [frames, remaining] = extractJsonRpcFrames(buffer)
+			buffer = remaining
+			for (const frame of frames) {
+				queue = queue
+					.then(() => handleFrame(frame))
+					.catch((cause) => {
+						const error = new InternalError('Unexpected IPC request error', { cause })
+						tevm.logger.error(error)
+						send({
+							error: { code: error.code, message: error.message },
+							id: null,
+							jsonrpc: '2.0',
+							method: 'unknown',
+						})
+					})
+			}
+		}
+
+		const cleanup = () => {
+			const subscriptionIds = [...subscriptions.keys()]
+			for (const removeListener of subscriptions.values()) removeListener()
+			subscriptions.clear()
+			for (const subscriptionId of subscriptionIds) {
+				void handleBulkRequest(
+					client,
+					[
+						{
+							id: null,
+							jsonrpc: '2.0',
+							method: 'eth_unsubscribe',
+							params: [subscriptionId],
+						},
+					],
+					{ suppressNotifications: true },
+				)
+			}
+		}
+
+		socket.on('data', onData)
+		socket.once('close', cleanup)
+		socket.once('error', (error) => tevm.logger.error(error))
+	}
+}

--- a/packages/server/src/internal/createIpcSubscription.js
+++ b/packages/server/src/internal/createIpcSubscription.js
@@ -1,0 +1,117 @@
+import { bytesToHex, numberToHex } from '@tevm/utils'
+
+/**
+ * @param {import('@tevm/utils').Hex} address
+ * @param {Array<import('@tevm/utils').Hex>} topics
+ * @param {unknown} filter
+ * @returns {boolean}
+ * @throws {never}
+ */
+const matchesLogFilter = (address, topics, filter) => {
+	if (typeof filter !== 'object' || filter === null) return true
+	const addressFilter = 'address' in filter ? filter.address : undefined
+	if (typeof addressFilter === 'string' && addressFilter.toLowerCase() !== address.toLowerCase()) return false
+	if (
+		Array.isArray(addressFilter) &&
+		!addressFilter.some(
+			(candidate) => typeof candidate === 'string' && candidate.toLowerCase() === address.toLowerCase(),
+		)
+	) {
+		return false
+	}
+
+	const topicFilters = 'topics' in filter && Array.isArray(filter.topics) ? filter.topics : undefined
+	if (!topicFilters) return true
+	return topicFilters.every((topicFilter, index) => {
+		if (topicFilter === null || topicFilter === undefined) return true
+		const topic = topics[index]
+		if (topic === undefined) return false
+		if (typeof topicFilter === 'string') return topicFilter.toLowerCase() === topic.toLowerCase()
+		if (Array.isArray(topicFilter)) {
+			return topicFilter.some(
+				(candidate) => typeof candidate === 'string' && candidate.toLowerCase() === topic.toLowerCase(),
+			)
+		}
+		return false
+	})
+}
+
+/**
+ * Registers the event listener that streams a Tevm subscription to one IPC connection.
+ *
+ * @param {import('../Client.js').Tevm} tevm - Tevm node backing the IPC server.
+ * @param {string} subscriptionId - ID returned by `eth_subscribe`.
+ * @param {ReadonlyArray<unknown>} params - `eth_subscribe` parameters.
+ * @param {(message: unknown) => void} send - Writes a JSON-RPC notification to the socket.
+ * @returns {() => void} Removes the transport event listener.
+ * @throws {never}
+ */
+export const createIpcSubscription = (tevm, subscriptionId, params, send) => {
+	const subscriptionType = params[0]
+	/** @param {unknown} result */
+	const notify = (result) => {
+		send({
+			jsonrpc: '2.0',
+			method: 'eth_subscription',
+			params: {
+				result,
+				subscription: subscriptionId,
+			},
+		})
+	}
+
+	switch (subscriptionType) {
+		case 'newHeads': {
+			/**
+			 * @param {import('@tevm/block').Block} block
+			 * @returns {Promise<void>}
+			 */
+			const listener = async (block) => {
+				try {
+					const result = await tevm.request({
+						method: 'eth_getBlockByHash',
+						params: [bytesToHex(block.hash()), false],
+					})
+					notify(result)
+				} catch (error) {
+					tevm.logger.error(error)
+				}
+			}
+			tevm.on('newBlock', listener)
+			return () => tevm.removeListener('newBlock', listener)
+		}
+		case 'newPendingTransactions': {
+			/** @param {import('@evmts/zevm/tx').TypedTransaction | import('@evmts/zevm/tx').ImpersonatedTx} transaction */
+			const listener = (transaction) => notify(bytesToHex(transaction.hash()))
+			tevm.on('newPendingTransaction', listener)
+			return () => tevm.removeListener('newPendingTransaction', listener)
+		}
+		case 'logs': {
+			/**
+			 * @param {import('@tevm/utils').EthjsLog} rawLog
+			 * @param {{ blockHash?: import('@tevm/utils').Hex; blockNumber?: bigint; transactionHash?: import('@tevm/utils').Hex; transactionIndex?: bigint; logIndex?: bigint }} [metadata]
+			 */
+			const listener = (rawLog, metadata = {}) => {
+				const [addressBytes, topicBytes, dataBytes] = rawLog
+				const address = bytesToHex(addressBytes)
+				const topics = topicBytes.map((topic) => bytesToHex(topic))
+				if (!matchesLogFilter(address, topics, params[1])) return
+				notify({
+					address,
+					blockHash: metadata.blockHash ?? '0x',
+					blockNumber: numberToHex(metadata.blockNumber ?? 0n),
+					data: bytesToHex(dataBytes),
+					logIndex: numberToHex(metadata.logIndex ?? 0n),
+					removed: false,
+					topics,
+					transactionHash: metadata.transactionHash ?? '0x',
+					transactionIndex: numberToHex(metadata.transactionIndex ?? 0n),
+				})
+			}
+			tevm.on('newLog', listener)
+			return () => tevm.removeListener('newLog', listener)
+		}
+		default:
+			return () => {}
+	}
+}

--- a/packages/server/src/internal/extractJsonRpcFrames.js
+++ b/packages/server/src/internal/extractJsonRpcFrames.js
@@ -1,0 +1,72 @@
+/**
+ * Extracts complete JSON object or array frames from an IPC byte stream.
+ * JSON-RPC over IPC commonly uses newlines, concatenated JSON values, or both,
+ * so framing is based on balanced JSON containers while ignoring braces inside strings.
+ *
+ * @param {string} input - Buffered UTF-8 input from an IPC connection.
+ * @returns {[frames: Array<string>, remaining: string]} Complete JSON frames and the incomplete remainder.
+ * @throws {never}
+ */
+export const extractJsonRpcFrames = (input) => {
+	/** @type {Array<string>} */
+	const frames = []
+	let cursor = 0
+	let depth = 0
+	let escaped = false
+	let frameStart = -1
+	let inString = false
+
+	for (let index = 0; index < input.length; index++) {
+		const character = input[index]
+
+		if (frameStart === -1) {
+			if (character === undefined || /\s/.test(character)) {
+				cursor = index + 1
+				continue
+			}
+			if (character !== '{' && character !== '[') {
+				const newlineIndex = input.indexOf('\n', index)
+				if (newlineIndex === -1) {
+					return [frames, input.slice(index)]
+				}
+				frames.push(input.slice(index, newlineIndex).trim())
+				index = newlineIndex
+				cursor = newlineIndex + 1
+				continue
+			}
+			frameStart = index
+			depth = 1
+			continue
+		}
+
+		if (inString) {
+			if (escaped) {
+				escaped = false
+			} else if (character === '\\') {
+				escaped = true
+			} else if (character === '"') {
+				inString = false
+			}
+			continue
+		}
+
+		if (character === '"') {
+			inString = true
+			continue
+		}
+		if (character === '{' || character === '[') {
+			depth++
+			continue
+		}
+		if (character === '}' || character === ']') {
+			depth--
+			if (depth === 0) {
+				frames.push(input.slice(frameStart, index + 1))
+				cursor = index + 1
+				frameStart = -1
+			}
+		}
+	}
+
+	return [frames, input.slice(frameStart === -1 ? cursor : frameStart)]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2328,6 +2328,9 @@ importers:
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      viem:
+        specifier: ^2.49.3
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@5.0.10)(zod@4.4.3)
 
   packages/state:
     dependencies:


### PR DESCRIPTION
## Bug

`@tevm/server` only exposed an HTTP JSON-RPC server, so Node clients using viem's `ipc()` transport had no Unix domain socket endpoint to connect to. A test importing `createIpcServer` was written first and reproduced the missing public API.

This closes the viem migration blocker described as:

> "WebSocket and IPC transports ... still need it [anvil]."

## Root cause

The server package had no `node:net` server, stream framing, or persistent connection layer. Although Tevm's JSON-RPC actions can create subscriptions, there was also no transport adapter to forward node events as `eth_subscription` notifications or clean them up when a connection closes.

## Fix

- Add public `createIpcServer` API backed by a Unix domain socket.
- Parse fragmented, concatenated, and newline-delimited JSON-RPC frames safely across UTF-8 chunks.
- Route regular, batch, and notification requests through the existing Tevm JSON-RPC dispatcher.
- Stream `newHeads`, `newPendingTransactions`, and filtered `logs` subscription notifications.
- Clean up subscription filters and event listeners on `eth_unsubscribe` or socket close.
- Add configurable message and batch limits, public barrel exports, documentation, and a changeset.

## Tests

- `pnpm vitest run packages/server/src/createIpcServer.spec.ts` — 9 passed.
- `pnpm --dir packages/server typecheck` — passed.
- `pnpm --dir packages/server lint:check` — passed.
- `pnpm --dir packages/server build:dist` and `pnpm --dir packages/server build:types` — passed.

The IPC integration tests use real Unix sockets, a real Tevm memory client, and viem's real `ipc()` transport. They cover request/response framing, invalid requests, batches, notifications, size limits, all supported subscription types, filtering, unsubscribe behavior, and connection cleanup without mocks.

The full neighboring server run completed with 67 passing and 2 failing tests. Both failures are newly landed `parseRequest.spec.ts` exact-message assertions already present on `origin/main`; this branch has no diff in either `parseRequest.js` or `parseRequest.spec.ts`. On the original requested clone base, the neighboring server suite passed all 65 tests and the coverage run passed every configured threshold (87.52% statements, 81.02% branches, 91.25% functions, 89.3% lines).

<prompt>Add a Unix domain socket JSON-RPC server to packages/server with newline-delimited framing and subscription support so viem's ipc() transport can use Tevm instead of Anvil.</prompt>

🤖 Generated with Smithers multi-agent orchestration
