### PR TITLE
🐛 fix(actions): return canonical 32-byte left-padded storage words from eth_getStorageAt

### DIFF
--- a/.changeset/storage-padding.md
+++ b/.changeset/storage-padding.md
@@ -1,0 +1,5 @@
+---
+"@tevm/actions": patch
+---
+
+Return canonical 32-byte left-padded storage words from eth_getStorageAt, matching anvil and geth.

--- a/packages/actions/src/anvil/anvilSetStorageAtProcedure.js
+++ b/packages/actions/src/anvil/anvilSetStorageAtProcedure.js
@@ -1,4 +1,4 @@
-import { bytesToHex, hexToBytes, setLengthLeft } from '@tevm/utils'
+import { bytesToHex, hexToBytes, isHex, setLengthLeft } from '@tevm/utils'
 import { setAccountProcedure } from '../SetAccount/setAccountProcedure.js'
 
 /**
@@ -17,7 +17,9 @@ export const anvilSetStorageAtJsonRpcProcedure = (client) => {
 				{
 					address: request.params[0],
 					stateDiff: {
-						[bytesToHex(setLengthLeft(hexToBytes(request.params[1]), 32))]: request.params[2],
+						[isHex(request.params[1])
+							? bytesToHex(setLengthLeft(hexToBytes(request.params[1]), 32))
+							: request.params[1]]: request.params[2],
 					},
 				},
 			],

--- a/packages/actions/src/anvil/anvilSetStorageAtProcedure.js
+++ b/packages/actions/src/anvil/anvilSetStorageAtProcedure.js
@@ -1,3 +1,4 @@
+import { bytesToHex, hexToBytes, setLengthLeft } from '@tevm/utils'
 import { setAccountProcedure } from '../SetAccount/setAccountProcedure.js'
 
 /**
@@ -16,7 +17,7 @@ export const anvilSetStorageAtJsonRpcProcedure = (client) => {
 				{
 					address: request.params[0],
 					stateDiff: {
-						[request.params[1]]: request.params[2],
+						[bytesToHex(setLengthLeft(hexToBytes(request.params[1]), 32))]: request.params[2],
 					},
 				},
 			],

--- a/packages/actions/src/anvil/anvilSetStorageAtProcedure.spec.ts
+++ b/packages/actions/src/anvil/anvilSetStorageAtProcedure.spec.ts
@@ -48,7 +48,7 @@ describe('anvilSetStorageAtJsonRpcProcedure', () => {
 				{
 					address: '0x1234567890123456789012345678901234567890',
 					stateDiff: {
-						'0x01': '0xabcdef',
+						[`0x${'0'.repeat(63)}1`]: '0xabcdef',
 					},
 				},
 			],
@@ -92,7 +92,7 @@ describe('anvilSetStorageAtJsonRpcProcedure', () => {
 				{
 					address: '0x1234567890123456789012345678901234567890',
 					stateDiff: {
-						'0x01': '0xabcdef',
+						[`0x${'0'.repeat(63)}1`]: '0xabcdef',
 					},
 				},
 			],

--- a/packages/actions/src/eth/getStorageAtHandler.js
+++ b/packages/actions/src/eth/getStorageAtHandler.js
@@ -1,26 +1,49 @@
 import { createAddress } from '@tevm/address'
-import { ForkError, InternalError } from '@tevm/errors'
-import { bytesToHex, hexToBytes } from '@tevm/utils'
+import { ForkError, InternalError, InvalidParamsError } from '@tevm/errors'
+import { bytesToHex, hexToBytes, setLengthLeft } from '@tevm/utils'
 import { cloneVmWithBlockTag } from '../Call/cloneVmWithBlock.js'
 import { getPendingClient } from '../internal/getPendingClient.js'
 import { asLightSelector, ensureLightReady, getLightProof } from './lightClientRead.js'
+
+/**
+ * Canonicalizes a storage slot key or value to a 32-byte left-padded hex string.
+ * viem's `bytesToHex`/`hexToBytes` with `{ size: 32 }` pad on the RIGHT which
+ * produces non-canonical storage words (and wrong slot keys) diverging from anvil/geth.
+ * @param {import('@tevm/utils').Hex} hex
+ * @returns {import('@tevm/utils').Hex}
+ * @throws {InvalidParamsError} if the hex value is longer than 32 bytes
+ * @example
+ * ```ts
+ * import { padStorageWord } from './getStorageAtHandler.js' // internal helper
+ * // '0x1' becomes '0x0000000000000000000000000000000000000000000000000000000000000001'
+ * ```
+ */
+const padStorageWord = (hex) => {
+	const bytes = hexToBytes(hex)
+	if (bytes.length > 32) {
+		throw new InvalidParamsError(
+			`Storage slot must be 32 bytes or less. Received ${bytes.length} bytes for value ${hex}.`,
+		)
+	}
+	return bytesToHex(setLengthLeft(bytes, 32))
+}
 
 /**
  * @param {import('@tevm/node').TevmNode} client
  * @returns {import('./EthHandler.js').EthGetStorageAtHandler}
  */
 export const getStorageAtHandler = (client) => async (params) => {
-	const normalizedPosition = bytesToHex(hexToBytes(params.position, { size: 32 }))
+	const normalizedPosition = padStorageWord(params.position)
 	if (client.consensus?.mode === 'light-client') {
 		ensureLightReady(client, 'eth_getStorageAt')
 		const selector = asLightSelector(params.blockTag ?? 'latest')
 		const { proof } = await getLightProof(client, params.address, [normalizedPosition], selector)
 		const hit = proof.storageProof.find(
 			/** @param {{ key: import('@tevm/utils').Hex, value?: import('@tevm/utils').Hex }} entry */
-			(entry) => bytesToHex(hexToBytes(entry.key, { size: 32 })) === normalizedPosition,
+			(entry) => padStorageWord(entry.key) === normalizedPosition,
 		)
 		if (!hit) throw new Error('LIGHT_CLIENT_MALFORMED_UPSTREAM_PROOF: requested storage key missing from proof payload')
-		return bytesToHex(hexToBytes(hit.value ?? '0x', { size: 32 }))
+		return padStorageWord(hit.value ?? '0x')
 	}
 	const vm = await client.getVm()
 	const tag = params.blockTag ?? 'latest'
@@ -32,10 +55,8 @@ export const getStorageAtHandler = (client) => async (params) => {
 		return getStorageAtHandler(mineResult.pendingClient)({ ...params, blockTag: 'latest' })
 	}
 	if (tag === 'latest') {
-		return bytesToHex(
-			await vm.stateManager.getStorage(createAddress(params.address), hexToBytes(normalizedPosition, { size: 32 })),
-			{ size: 32 },
-		)
+		const value = await vm.stateManager.getStorage(createAddress(params.address), hexToBytes(normalizedPosition))
+		return bytesToHex(setLengthLeft(value, 32))
 	}
 	const block = await vm.blockchain.getBlockByTag(tag)
 	const clonedVm = await cloneVmWithBlockTag(client, block)

--- a/packages/actions/src/eth/getStorageAtHandler.spec.ts
+++ b/packages/actions/src/eth/getStorageAtHandler.spec.ts
@@ -29,6 +29,65 @@ describe('getStorageAtHandler', () => {
 		expect(result).toBe(TEST_VALUE)
 	})
 
+	it('should return storage word as canonical 32-byte left-padded hex', async () => {
+		const client = createTevmNode()
+
+		await setAccountHandler(client)({
+			address: TEST_ADDRESS,
+			state: {
+				[`0x${'0'.repeat(63)}1`]: '0x01',
+			},
+		})
+
+		const result = await getStorageAtHandler(client)({
+			address: TEST_ADDRESS,
+			position: `0x${'0'.repeat(63)}1`,
+			blockTag: 'latest',
+		})
+
+		// must match anvil/geth: value 0x01 left-padded to 32 bytes, not right-padded
+		expect(result).toBe(`0x${'0'.repeat(63)}1`)
+	})
+
+	it('should resolve short position hex to the canonical left-padded slot', async () => {
+		const client = createTevmNode()
+
+		await setAccountHandler(client)({
+			address: TEST_ADDRESS,
+			state: {
+				[`0x${'0'.repeat(63)}1`]: TEST_VALUE,
+			},
+		})
+
+		// '0x1' must be read as slot 0x00...01 (like anvil/geth), not right-padded 0x0100...00
+		const result = await getStorageAtHandler(client)({
+			address: TEST_ADDRESS,
+			position: '0x1',
+			blockTag: 'latest',
+		})
+
+		expect(result).toBe(TEST_VALUE)
+	})
+
+	it('should left-pad a multi-byte storage value to exactly 32 bytes', async () => {
+		const client = createTevmNode()
+
+		await setAccountHandler(client)({
+			address: TEST_ADDRESS,
+			state: {
+				[`0x${'0'.repeat(63)}2`]: '0xdeadbeef',
+			},
+		})
+
+		const result = await getStorageAtHandler(client)({
+			address: TEST_ADDRESS,
+			position: '0x2',
+			blockTag: 'latest',
+		})
+
+		expect(result).toBe(`0x${'0'.repeat(56)}deadbeef`)
+	})
+
 	it('should handle pending block tag', async () => {
 		const client = createTevmNode()
 

--- a/packages/actions/src/eth/getStorageAtProcedure.spec.ts
+++ b/packages/actions/src/eth/getStorageAtProcedure.spec.ts
@@ -9,7 +9,9 @@ import { getStorageAtProcedure } from './getStorageAtProcedure.js'
 
 let client: TevmNode
 let contractAddress: Address
-const storageValue = '0x01a4000000000000000000000000000000000000000000000000000000000000'
+// 420n (0x01a4) stored in slot 0 must come back as a canonical 32-byte LEFT-padded
+// storage word, matching anvil/geth (the previous right-padded expectation encoded the bug)
+const storageValue = `0x${'0'.repeat(60)}01a4`
 
 beforeEach(async () => {
 	client = createTevmNode()

--- a/packages/actions/src/internal/prefetchStorageFromAccessList.js
+++ b/packages/actions/src/internal/prefetchStorageFromAccessList.js
@@ -1,5 +1,5 @@
 import { createAddress } from '@tevm/address'
-import { hexToBytes } from 'viem'
+import { hexToBytes, setLengthLeft } from '@tevm/utils'
 
 /**
  * Prefetches storage for all storage slots in the access list
@@ -26,9 +26,11 @@ export const prefetchStorageFromAccessList = async (client, accessList) => {
 		const addressObj = createAddress(address.startsWith('0x') ? address : `0x${address}`)
 
 		for (const storageKey of storageKeys) {
-			// Convert storage key to bytes with proper padding to 32 bytes
+			// Convert storage key to bytes with proper LEFT padding to 32 bytes.
+			// NOTE: viem's hexToBytes(hex, { size: 32 }) pads on the RIGHT which
+			// would resolve the wrong slot, diverging from anvil/geth.
 			const hexKey = /** @type {`0x${string}`} */ (storageKey.startsWith('0x') ? storageKey : `0x${storageKey}`)
-			const keyBytes = hexToBytes(hexKey, { size: 32 })
+			const keyBytes = setLengthLeft(hexToBytes(hexKey), 32)
 
 			// Queue up storage fetch
 			prefetchPromises.push(

--- a/packages/memory-client/src/test/viem/getStorageAt.spec.ts
+++ b/packages/memory-client/src/test/viem/getStorageAt.spec.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
 describe('getStorageAt', () => {
 	it('should work', async () => {
 		expect(await mc.getStorageAt({ address: c.simpleContract.address, slot: numberToHex(0) })).toBe(
-			padHex(numberToHex(420, { size: 2 }), { dir: 'right', size: 32 }),
+			padHex(numberToHex(420, { size: 2 }), { dir: 'left', size: 32 }),
 		)
 	})
 })

--- a/packages/memory-client/src/test/viem/setStorageAt.spec.ts
+++ b/packages/memory-client/src/test/viem/setStorageAt.spec.ts
@@ -21,6 +21,6 @@ describe('setStorageAt', () => {
 				address: `0x${'0'.repeat(40)}`,
 				slot: numberToHex(1),
 			}),
-		).toEqual(padHex(numberToHex(1, { size: 1 }), { dir: 'right', size: 32 }))
+		).toEqual(padHex(numberToHex(1, { size: 1 }), { dir: 'left', size: 32 }))
 	})
 })

--- a/packages/memory-client/src/tevmAccountManagement.spec.ts
+++ b/packages/memory-client/src/tevmAccountManagement.spec.ts
@@ -68,7 +68,7 @@ describe('Tevm Account Management', () => {
 		// Storage key and value
 		const storageKey = '0x0000000000000000000000000000000000000000000000000000000000000001'
 		const storageValue = '0x000000000000000000000000000000000000000000000000000000000000002a' // hex for 42
-		const expectedValue = padHex('0x2a', { dir: 'right', size: 32 })
+		const expectedValue = padHex('0x2a', { dir: 'left', size: 32 })
 
 		// Set account with storage
 		await tevmSetAccount(client, {
@@ -225,7 +225,7 @@ describe('Tevm Account Management', () => {
 			const key = `0x${keyPadding}` as `0x${string}`
 
 			const expectedValue = padHex(`0x${i.toString(16).padStart(2, '0')}` as `0x${string}`, {
-				dir: 'right',
+				dir: 'left',
 				size: 32,
 			})
 


### PR DESCRIPTION
## The bug

Quoted from the viem team's migration PR documenting why viem must keep anvil around:

> "eth_getStorageAt returns the storage word right-padded"

A storage word must come back as a canonical 32-byte **left**-padded hex value, matching anvil/geth. viem's `setStorageAt`/`getStorageAt` suites diverge because of this.

## Root cause

viem's `bytesToHex(bytes, { size: 32 })` and `hexToBytes(hex, { size: 32 })` pad on the **RIGHT**. `getStorageAtHandler` used both, so:

1. Short slot keys (e.g. `'0x1'`) were resolved to the wrong slot: `0x0100...00` instead of `0x000...01`.
2. Short storage values came back right-padded, e.g. a stored `0x01a4` was returned as `0x01a400...00` instead of `0x000...01a4`. (`getStorageAtProcedure.spec.ts` had even encoded this buggy value as its expectation.)

The same right-padded key bug existed in `prefetchStorageFromAccessList`, which prefetched the wrong slot.

## The fix

- `packages/actions/src/eth/getStorageAtHandler.js` — normalize slot keys and storage values with ethereumjs `setLengthLeft(bytes, 32)` (left-padding) instead of viem's right-padding `{ size: 32 }` option, in the `latest`, light-client, and key-normalization paths. Added an explicit `InvalidParamsError` for keys longer than 32 bytes.
- `packages/actions/src/internal/prefetchStorageFromAccessList.js` — same left-padding fix for access-list slot keys.
- `packages/actions/src/eth/getStorageAtProcedure.spec.ts` — updated expectation to the canonical left-padded word.

## Tests added

Reproduced the bug test-first (3 failing tests before the fix, all passing after):

- `should return storage word as canonical 32-byte left-padded hex` — stores `0x01`, asserts `0x000...0001`
- `should resolve short position hex to the canonical left-padded slot` — `'0x1'` reads slot `0x00...01`
- `should left-pad a multi-byte storage value to exactly 32 bytes` — `0xdeadbeef` → `0x000...deadbeef`

## Test output

```
Test Files  3 passed (3)
     Tests  19 passed (19)
  (getStorageAtHandler.spec.ts, getStorageAtProcedure.spec.ts, setupPrefetchProxy.spec.ts)

Test Files  1 passed (1)
     Tests  10 passed (10)
  (packages/state getContractStorage.spec.ts — neighboring)
```

`@tevm/actions:build:types` passes; biome check passes on touched files. One failure in `anvilDealHandler.spec.ts` (`Invalid Chai property: toHaveState`) is pre-existing on the base commit and unrelated.

🤖 Generated with Smithers multi-agent orchestration