### PR TITLE
🐛 fix(mining): match Anvil mining modes

### DIFF
--- a/.changeset/mining-modes.md
+++ b/.changeset/mining-modes.md
@@ -1,0 +1,5 @@
+---
+"@tevm/actions": minor
+---
+
+Implement anvil_setAutomine and anvil_setIntervalMining to match anvil mining semantics.

--- a/packages/actions/src/createHandlers.js
+++ b/packages/actions/src/createHandlers.js
@@ -458,6 +458,7 @@ export const createHandlers = (client) => {
 
 	const evmHandlers = {
 		evm_mine: mineProcedure(client),
+		evm_setAutomine: anvilSetAutomineJsonRpcProcedure(client),
 		/**
 		 * @param {any} request
 		 */

--- a/packages/memory-client/src/test/intervalMiningBehavior.spec.ts
+++ b/packages/memory-client/src/test/intervalMiningBehavior.spec.ts
@@ -152,28 +152,21 @@ describe('Interval Mining Behavior', () => {
 			vi.useFakeTimers()
 		})
 
-		it('should not mine empty blocks when no transactions are available', async () => {
+		it('should mine empty blocks at the configured wall-clock interval', async () => {
 			vi.useRealTimers()
 
-			await client.request({
-				method: 'anvil_setIntervalMining',
-				params: [0.1],
-			})
+			await client.setIntervalMining({ interval: 0.1 })
 
 			const initialBlockNumber = await client.getBlockNumber()
 
-			// Wait for multiple intervals without adding transactions
-			await new Promise((resolve) => setTimeout(resolve, 250))
+			const minedBlockNumber = await waitForBlockNumberGreaterThan(client, initialBlockNumber)
 
-			// Block number should remain the same (no transactions, no mining)
-			const currentBlockNumber = await client.getBlockNumber()
-			expect(currentBlockNumber).toBe(initialBlockNumber)
+			expect(minedBlockNumber).toBeGreaterThan(initialBlockNumber)
 
-			// Disable interval mining
-			await client.request({
-				method: 'anvil_setIntervalMining',
-				params: [0],
-			})
+			await client.setIntervalMining({ interval: 0 })
+			const stoppedBlockNumber = await client.getBlockNumber()
+			await new Promise((resolve) => setTimeout(resolve, 200))
+			expect(await client.getBlockNumber()).toBe(stoppedBlockNumber)
 
 			vi.useFakeTimers()
 		})

--- a/packages/memory-client/src/test/viem/setAutomine.spec.ts
+++ b/packages/memory-client/src/test/viem/setAutomine.spec.ts
@@ -1,21 +1,12 @@
 import { SimpleContract } from '@tevm/contract'
 import { type Address, encodeFunctionData } from '@tevm/utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { parseEther } from 'viem'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createMemoryClient } from '../../createMemoryClient.js'
 import type { MemoryClient } from '../../MemoryClient.js'
 
 /**
- * Tests for TEVM mining behavior and automine functionality
- *
- * Note: These tests focus on the mining aspects that are actually implemented
- * in the current version of TEVM. While the viem test actions interface
- * declares support for setAutomine, the actual implementation of
- * anvil_setAutomine is not available in the current version.
- *
- * These tests verify:
- * 1. The ability to query automine status via anvil_getAutomine
- * 2. The behavior of transactions when manually mining blocks
- * 3. Multiple transactions being included in a single mined block
+ * Tests for TEVM mining behavior and automine functionality.
  */
 
 let mc: MemoryClient
@@ -41,7 +32,47 @@ beforeEach(async () => {
 	expect(initialValue.data).toBe(420n)
 })
 
+afterEach(() => {
+	mc.transport.tevm.close()
+})
+
 describe('automine', () => {
+	it('should disable and re-enable immediate mining through the viem test action', async () => {
+		const sender = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+		const secondSender = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
+		const recipient = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+		await mc.tevmSetAccount({
+			address: sender,
+			balance: parseEther('100'),
+		})
+		await mc.tevmSetAccount({
+			address: secondSender,
+			balance: parseEther('100'),
+		})
+
+		await mc.setAutomine(false)
+		expect(await mc.getAutomine()).toBe(false)
+
+		const blockNumber = await mc.getBlockNumber()
+		await mc.sendTransaction({
+			account: sender,
+			to: recipient,
+			value: parseEther('1'),
+		})
+		expect(await mc.getBlockNumber()).toBe(blockNumber)
+
+		await mc.setAutomine(true)
+		expect(await mc.getAutomine()).toBe(true)
+
+		const secondHash = await mc.sendTransaction({
+			account: secondSender,
+			to: recipient,
+			value: parseEther('1'),
+		})
+		expect(await mc.getBlockNumber()).toBe(blockNumber + 1n)
+		expect((await mc.getTransactionReceipt({ hash: secondHash })).blockNumber).toBe(blockNumber + 1n)
+	})
+
 	it('should get the automine status', async () => {
 		// Get the current automine status through direct request
 		const result = await mc.request({

--- a/packages/node/src/createIntervalMiner.js
+++ b/packages/node/src/createIntervalMiner.js
@@ -33,7 +33,7 @@
  */
 export const createIntervalMiner = (client) => {
 	/**
-	 * @type {NodeJS.Timeout | undefined}
+	 * @type {ReturnType<typeof setTimeout> | undefined}
 	 */
 	let timeoutId
 
@@ -41,6 +41,13 @@ export const createIntervalMiner = (client) => {
 	 * @type {boolean}
 	 */
 	let isRunning = false
+
+	/**
+	 * Identifies the active timer generation so a mining cycle that was stopped
+	 * while awaiting its callback cannot schedule a stale follow-up timer.
+	 * @type {number}
+	 */
+	let generation = 0
 
 	/**
 	 * Callback function for mining - will be set by the client
@@ -59,24 +66,20 @@ export const createIntervalMiner = (client) => {
 
 	/**
 	 * Executes mining cycle if callback is available
+	 * @param {number} activeGeneration - Timer generation that started this cycle
 	 * @returns {Promise<void>}
 	 */
-	const mineBlock = async () => {
-		if (!isRunning) {
+	const mineBlock = async (activeGeneration) => {
+		if (!isRunning || activeGeneration !== generation) {
 			return
 		}
 
 		try {
 			client.logger.debug('Interval mining: Starting block mining cycle')
 
-			// Read mempool state synchronously at the beginning to prevent race conditions
-			const txPool = await client.getTxPool()
-			const txsInPool = txPool.txsInPool
-
-			client.logger.debug({ txsInPool }, 'Interval mining: Mempool state captured')
-
-			// Only mine if there are transactions in the pool and we have a mining callback
-			if (txsInPool > 0 && miningCallback) {
+			// Anvil fixed-block-time mining creates a block on every wall-clock tick,
+			// including when the transaction pool is empty.
+			if (miningCallback) {
 				try {
 					await miningCallback()
 					client.logger.debug('Interval mining: Block mined successfully')
@@ -85,23 +88,22 @@ export const createIntervalMiner = (client) => {
 				}
 			} else if (!miningCallback) {
 				client.logger.debug('Interval mining: No mining callback set, skipping mining cycle')
-			} else {
-				client.logger.debug('Interval mining: No transactions in mempool, skipping mining cycle')
 			}
 		} catch (error) {
 			client.logger.error(error, 'Interval mining: Unexpected error during mining')
 		} finally {
-			// Schedule the next mining cycle if still running
-			scheduleNext()
+			// Schedule only if this cycle still owns the active generation.
+			scheduleNext(activeGeneration)
 		}
 	}
 
 	/**
 	 * Schedules the next mining cycle using setTimeout
+	 * @param {number} activeGeneration - Timer generation that owns this schedule
 	 * @returns {void}
 	 */
-	const scheduleNext = () => {
-		if (!isRunning || client.miningConfig.type !== 'interval') {
+	const scheduleNext = (activeGeneration) => {
+		if (!isRunning || activeGeneration !== generation || client.miningConfig.type !== 'interval') {
 			return
 		}
 
@@ -114,10 +116,13 @@ export const createIntervalMiner = (client) => {
 		}
 
 		timeoutId = setTimeout(() => {
-			if (isRunning) {
-				mineBlock()
+			if (isRunning && activeGeneration === generation) {
+				void mineBlock(activeGeneration)
 			}
 		}, blockTime)
+		if (typeof timeoutId === 'object' && timeoutId !== null && 'unref' in timeoutId) {
+			timeoutId.unref()
+		}
 
 		client.logger.debug({ blockTime }, 'Interval mining: Next mining cycle scheduled')
 	}
@@ -138,8 +143,9 @@ export const createIntervalMiner = (client) => {
 		}
 
 		isRunning = true
+		generation += 1
 		client.logger.debug('Interval mining: Starting')
-		scheduleNext()
+		scheduleNext(generation)
 	}
 
 	/**
@@ -152,6 +158,7 @@ export const createIntervalMiner = (client) => {
 		}
 
 		isRunning = false
+		generation += 1
 
 		if (timeoutId) {
 			clearTimeout(timeoutId)

--- a/packages/node/src/createTevmNode.js
+++ b/packages/node/src/createTevmNode.js
@@ -890,12 +890,13 @@ export const createTevmNode = (options = {}) => {
 	}
 
 	/**
-	 * Mines all currently pending transactions using the same state, receipt, and
-	 * txpool updates as manual mining.
+	 * Mines one interval block using the same state, receipt, and txpool updates
+	 * as manual mining. Fixed-block-time mining includes empty blocks.
 	 * @param {import('./TevmNode.js').TevmNode} client
 	 * @returns {Promise<void>}
+	 * @throws {Error} If block construction fails or the mined state root is unavailable
 	 */
-	const minePendingTransactions = async (client) => {
+	const mineIntervalBlock = async (client) => {
 		const pool = await client.getTxPool()
 		const originalVm = await client.getVm()
 		const vm = await originalVm.deepCopy()
@@ -904,10 +905,6 @@ export const createTevmNode = (options = {}) => {
 		const overrideBaseFee = client.getNextBlockBaseFeePerGas()
 		const baseFeePerGas = overrideBaseFee ?? parentBlock.header.calcNextBaseFee()
 		const orderedTxs = await pool.txsByPriceAndNonce({ baseFee: baseFeePerGas })
-		if (orderedTxs.length === 0) {
-			client.logger.debug('Interval mining: No transactions to mine')
-			return
-		}
 		if (overrideBaseFee !== undefined) {
 			client.setNextBlockBaseFeePerGas(undefined)
 		}
@@ -1028,7 +1025,7 @@ export const createTevmNode = (options = {}) => {
 					// Set up the mining callback
 					intervalMiner.setMiningCallback(async () => {
 						try {
-							await minePendingTransactions(baseClient)
+							await mineIntervalBlock(baseClient)
 						} catch (error) {
 							baseClient.logger.error(error, 'Failed to mine block in setMiningConfig')
 						}
@@ -1129,7 +1126,7 @@ export const createTevmNode = (options = {}) => {
 			// Set up the mining callback to handle block creation
 			intervalMiner.setMiningCallback(async () => {
 				try {
-					await minePendingTransactions(baseClient)
+					await mineIntervalBlock(baseClient)
 				} catch (error) {
 					baseClient.logger.error(error, 'Failed to mine block in interval mining')
 				}

--- a/packages/node/src/intervalMining.spec.ts
+++ b/packages/node/src/intervalMining.spec.ts
@@ -251,7 +251,7 @@ describe('TevmNode interval mining integration', () => {
 			const txPool = await client.getTxPool()
 			await txPool.add(buildSignedTx('0x00'), true)
 
-			await vi.advanceTimersByTimeAsync(10)
+			await vi.advanceTimersToNextTimerAsync()
 
 			const finalBlock = await vm.blockchain.getCanonicalHeadBlock()
 			expect(finalBlock.header.number).toBe(initialBlock.header.number + 1n)


### PR DESCRIPTION
## Bug

The viem migration PR explicitly listed what “still needs [anvil]”: `setAutomine and setIntervalMining`.

Two root causes kept those actions from matching Anvil:

- viem sends `evm_setAutomine`, but the Tevm handler registry exposed only `anvil_setAutomine`, so the public viem action failed with JSON-RPC `-32601`.
- Tevm's interval miner skipped its callback when the transaction pool was empty. Anvil's fixed-block-time mode mines a block on every wall-clock interval, including empty blocks.

The interval timer also had a stale-cycle race: stopping or reconfiguring mining while an asynchronous callback was in flight could allow that old cycle to schedule a new timeout.

## Fix

- Route `evm_setAutomine` to the existing Anvil automine procedure while retaining `anvil_setAutomine`.
- Mine an interval block on every configured tick, including when the txpool is empty, using the existing block/state/receipt/event path.
- Give timer cycles generation ownership so stopped or superseded cycles cannot reschedule.
- Clear timers on stop and `unref()` Node timer handles so interval mining cannot keep a test process alive.
- Preserve interval `0` as the clean stop operation used by viem/Anvil.

## Tests

Added real-client regressions without mocks:

- Toggle automine through viem, send real signed transactions, and verify disabled versus immediate block production.
- Configure interval mining through viem, verify an empty block is mined on a real wall-clock interval, then set interval `0` and verify block production stops.

Verification on the final rebased commit:

- Mining regressions: 2 files passed, 13 tests passed.
- Neighboring node/actions tests: 6 files passed, 80 tests passed.
- Full `@tevm/node` suite: 11 files passed, 102 tests passed.
- Typecheck: all three touched projects and 69 dependency tasks passed.
- Biome: 6 changed files checked with no fixes required.

The final-base full `@tevm/actions` suite also reported 11 unrelated stale snapshots for main's prefunded-balance/precompile changes (1,183 tests passed), and the full `@tevm/memory-client` suite reported one unrelated stale multicall expectation after main added the multicall predeploy (201 tests passed). The focused mining and handler coverage is green.

🤖 Generated with Smithers multi-agent orchestration
