### PR TITLE
📝 docs: fix missing and incorrect JSDoc across core public API

### DIFF
--- a/.changeset/tidy-geese-speak.md
+++ b/.changeset/tidy-geese-speak.md
@@ -1,0 +1,11 @@
+---
+"@tevm/common": patch
+"@tevm/effect": patch
+"@tevm/http-client": patch
+"@tevm/jsonrpc": patch
+"@tevm/logger": patch
+"@tevm/sync-storage-persister": patch
+"@tevm/utils": patch
+---
+
+Fix missing and incorrect JSDoc across core public API: correct wrong package imports in `@tevm/effect` examples, replace non-runnable/elided `@example` blocks with complete working examples based on package tests, and add missing `@example`/`@throws`/`@returns` documentation

--- a/packages/common/src/createCommon.js
+++ b/packages/common/src/createCommon.js
@@ -22,22 +22,22 @@ const normalizeHardfork = (hardfork) =>
  * @example
  * ```typescript
  * import { createCommon } from 'tevm/common'
+ * import { mainnet } from 'viem/chains'
  *
  * const common = createCommon({
- *  customCrypto: {},
- *  loggingLevel: 'debug',
- *  hardfork: 'london',
- *  eips: [420],
- *  id: 69,
- *  name: 'MyChain',
- *  ...
+ *   ...mainnet,
+ *   customCrypto: {},
+ *   loggingLevel: 'debug',
+ *   hardfork: 'london',
+ *   eips: [420],
  * })
  * ```
  * Since common are stateful consider copying it before using it
  * @example
  * ```typescript
- * import { createCommon } from 'tevm/common'
- * const common = createCommon({ ... })
+ * import { createCommon, mainnet } from 'tevm/common'
+ *
+ * const common = createCommon({ ...mainnet, hardfork: 'prague', loggingLevel: 'warn' })
  *
  * const commonCopy = common.copy()
  * ```
@@ -45,7 +45,9 @@ const normalizeHardfork = (hardfork) =>
  * To access the underlying Common instance, use the ethjsCommon property.
  * @example
  * ```typescript
- * const common = createCommon({ ... })
+ * import { createCommon, mainnet } from 'tevm/common'
+ *
+ * const common = createCommon({ ...mainnet, hardfork: 'prague', loggingLevel: 'warn' })
  * const ethjsCommon = common.ethjsCommon
  * ```
  * @see [Tevm client docs](https://tevm.sh/learn/clients/)

--- a/packages/common/src/createMockKzg.js
+++ b/packages/common/src/createMockKzg.js
@@ -5,7 +5,7 @@ import { bytesToHex } from 'viem'
  * Returns a mock kzg object that always trusts never verifies
  * The real kzg commitmenet is over 500kb added to bundle size
  * so this is useful explicit opt-in alternative for smaller bundles
- * @returns {import("./MockKzg.js").MockKzg}
+ * @returns {import("./MockKzg.js").MockKzg} A mock KZG implementation where every verification method returns `true`
  * @throws {never}
  * @example
  * ```typescript

--- a/packages/effect/src/createRequireEffect.js
+++ b/packages/effect/src/createRequireEffect.js
@@ -39,9 +39,11 @@ export class RequireError extends Error {
  * @returns {import("effect/Effect").Effect<(id: string) => import("effect/Effect").Effect<ReturnType<NodeRequire>, RequireError, never>, CreateRequireError, never>} require function
  * @example
  * ```typescript
- * import { createRequireEffect } from '@eth-optimism/config'
- * const requireEffect = createRequireEffect(import.meta.url)
- * const solcEffect = requireEffect('solc')
+ * import { runPromise } from 'effect/Effect'
+ * import { createRequireEffect } from '@tevm/effect'
+ *
+ * const requireAsEffect = await runPromise(createRequireEffect(import.meta.url))
+ * const solc = await runPromise(requireAsEffect('solc'))
  * ```
  * @see https://nodejs.org/api/modules.html#modules_module_createrequire_filename
  * @internal

--- a/packages/effect/src/fileExists.js
+++ b/packages/effect/src/fileExists.js
@@ -8,8 +8,11 @@ import { flatMap, logDebug, promise, tap } from 'effect/Effect'
  * @returns {import("effect/Effect").Effect<boolean, never, never>} true if the file exists, false otherwise
  * @example
  * ```typescript
- * import { fileExists } from '@eth-optimism/config'
- * await fileExists('./someFile.txt')
+ * import { runPromise } from 'effect/Effect'
+ * import { fileExists } from '@tevm/effect'
+ *
+ * const exists = await runPromise(fileExists('./someFile.txt'))
+ * console.log(exists) // true or false
  * ```
  * @internal
  */

--- a/packages/effect/src/logAllErrors.js
+++ b/packages/effect/src/logAllErrors.js
@@ -7,11 +7,17 @@ import { all, logError } from 'effect/Effect'
  * @internal
  * @example
  * ```typescript
- * import { logAllErrors } from '@eth-optimism/config'
+ * import { fail, runPromise, tapError } from 'effect/Effect'
+ * import { logAllErrors } from '@tevm/effect'
  *
- * someEffect.pipe(
- *   tapError(logAllErrors)
- * )
+ * const someEffect = fail(new Error('Something went wrong'))
+ *
+ * await runPromise(
+ *   someEffect.pipe(
+ *     tapError(logAllErrors)
+ *   )
+ * ).catch(() => console.log('error was logged'))
+ * ```
  */
 export const logAllErrors = (e) => {
 	const errors = [e]

--- a/packages/effect/src/parseJson.js
+++ b/packages/effect/src/parseJson.js
@@ -23,11 +23,15 @@ export class ParseJsonError extends Error {
  * Parses a json string
  * @param {string} jsonStr
  * @returns {import("effect/Effect").Effect<unknown, ParseJsonError, never>}
- * @throws {ParseJsonError} when the tevm.json file is not valid json
+ * @throws {ParseJsonError} when the json string is not valid json
  * @example
  * ```ts
+ * import { runPromise } from 'effect/Effect'
+ * import { parseJson } from '@tevm/effect'
+ *
  * const jsonEffect = parseJson('{ "compilerOptions": { "plugins": [{ "name": "@tevm/ts-plugin" }] } }')
- * ````
+ * const json = await runPromise(jsonEffect)
+ * ```
  * @internal
  */
 export const parseJson = (jsonStr) => {

--- a/packages/effect/src/resolve.js
+++ b/packages/effect/src/resolve.js
@@ -35,13 +35,13 @@ export class CouldNotResolveImportError extends Error {
  * @type {ResolveSafe}
  * @example
  * ```ts
- * import {tap} from 'effect/Effect'
- * import {resolveSync} from '@tevm/effect'
- * resolveSync('react').pipe(
- *    tap(console.log)
+ * import { tap } from 'effect/Effect'
+ * import { resolveSync } from '@tevm/effect'
+ *
+ * resolveSync('react', { basedir: process.cwd() }).pipe(
+ *   tap(console.log)
  * )
- * ````
- * `
+ * ```
  */
 export const resolveSync = (importPath, options) => {
 	return trySync({
@@ -52,16 +52,17 @@ export const resolveSync = (importPath, options) => {
 }
 
 /**
- * Effect wrpper around import('node:resolve')
+ * Effect wrapper around import('node:resolve')
  * @type {ResolveSafe}
  * @example
  * ```ts
- * import {tap} from 'effect/Effect'
- * import {resolveAsync} from '@tevm/effect'
- * resolveAsync('react').pipe(
- *    tap(console.log)
+ * import { tap } from 'effect/Effect'
+ * import { resolveAsync } from '@tevm/effect'
+ *
+ * resolveAsync('react', { basedir: process.cwd() }).pipe(
+ *   tap(console.log)
  * )
- * ````
+ * ```
  */
 export const resolveAsync = (importPath, options) => {
 	return effectAsync((resume) => {

--- a/packages/http-client/src/createHttpClient.js
+++ b/packages/http-client/src/createHttpClient.js
@@ -7,6 +7,16 @@ import { createPublicClient, http } from 'viem'
  * @param {import('./HttpClientOptions.js').HttpClientOptions} params
  * @returns {import('./HttpClient.js').HttpClient}
  * @example
+ * ```typescript
+ * import { createHttpClient } from '@tevm/http-client'
+ *
+ * const client = createHttpClient({
+ *   url: 'https://mainnet.optimism.io',
+ * })
+ *
+ * const blockNumber = await client.eth.blockNumber()
+ * console.log(blockNumber)
+ * ```
  */
 export const createHttpClient = ({ url, name = `TevmClient:${url}` }) => {
 	// This is a shortcut. We are simply reusing viem to create this client so we can

--- a/packages/jsonrpc/src/createJsonRpcFetcher.js
+++ b/packages/jsonrpc/src/createJsonRpcFetcher.js
@@ -4,16 +4,25 @@
  * Returns the entire JSON-RPC response rather than throwing and only returning result
  * Used currently as an adapter to avoid refactoring existing code
  * @see https://ethereum.org/en/developers/docs/apis/json-rpc/
- * @param {{request: import('viem').EIP1193RequestFn}} client
- * @returns {import("./JsonRpcClient.js").JsonRpcClient} the `result` field from the JSON-RPC response
+ * @param {{request: import('viem').EIP1193RequestFn}} client - An EIP-1193 compatible client such as a viem client
+ * @returns {import("./JsonRpcClient.js").JsonRpcClient} A JSON-RPC client whose `request` method resolves with the full JSON-RPC response (including `result` or `error`)
  * @example
  * ```typescript
- * const url = 'https://mainnet.optimism.io'
- * const params = {
+ * import { createJsonRpcFetcher } from '@tevm/jsonrpc'
+ * import { createPublicClient, http } from 'viem'
+ * import { optimism } from 'viem/chains'
+ *
+ * const client = createPublicClient({
+ *   chain: optimism,
+ *   transport: http('https://mainnet.optimism.io'),
+ * })
+ * const fetcher = createJsonRpcFetcher(client)
+ *
+ * const { result: block } = await fetcher.request({
  *   method: 'eth_getBlockByNumber',
  *   params: ['latest', false],
- * }
- * const {result: block} = await fetchJsonRpc(url, params)
+ * })
+ * console.log(block.number)
  * ```
  */
 export const createJsonRpcFetcher = (client) => {

--- a/packages/logger/src/createLogger.js
+++ b/packages/logger/src/createLogger.js
@@ -3,8 +3,21 @@ import { pino } from 'pino'
 /**
  * Creates a tevm logger instance
  * Wraps [pino](https://github.com/pinojs/pino/blob/master/docs/api.md)
- * @param {import('./LogOptions.js').LogOptions} options
+ * @param {import('./LogOptions.js').LogOptions} options - The logger options including the logger `name` and minimum `level`
  * @returns {import('./Logger.js').Logger} A logger instance
+ * @throws {never}
+ * @example
+ * ```typescript
+ * import { createLogger } from '@tevm/logger'
+ *
+ * const logger = createLogger({
+ *   name: 'my-app',
+ *   level: 'debug',
+ * })
+ *
+ * logger.info('Hello world')
+ * logger.debug({ some: 'context' }, 'Debugging with context')
+ * ```
  */
 export const createLogger = (options) => {
 	const pinoLogger = pino({

--- a/packages/sync-storage-persister/src/createSyncStoragePersister.js
+++ b/packages/sync-storage-persister/src/createSyncStoragePersister.js
@@ -1,9 +1,42 @@
 import { throttle } from './throttle.js'
 
 /**
- * Creates a syncronous storage persister to be used in tevm clients
- * @param {import('./CreateSyncStoragePersisterOptions.js').CreateSyncStoragePersisterOptions} options
- * @returns {import('./SyncStoragePersister.js').SyncStoragePersister}
+ * Creates a synchronous storage persister to be used in tevm clients
+ * Persists tevm state to a synchronous storage backend such as `window.localStorage`
+ * so state can be restored between sessions. Saving is throttled to avoid
+ * spamming the storage backend.
+ * @param {import('./CreateSyncStoragePersisterOptions.js').CreateSyncStoragePersisterOptions} options - The persister options including the `storage` backend
+ * @returns {import('./SyncStoragePersister.js').SyncStoragePersister} A persister that can persist, restore, and remove tevm state
+ * @throws {never} Errors during persisting are returned rather than thrown
+ * @example
+ * ```typescript
+ * import { createSyncStoragePersister } from '@tevm/sync-storage-persister'
+ *
+ * const persister = createSyncStoragePersister({
+ *   storage: window.localStorage,
+ *   key: 'TEVM_CACHE',
+ *   throttleTime: 1000,
+ * })
+ *
+ * // Persist state (throttled)
+ * persister.persistTevmState({
+ *   '0x420': {
+ *     balance: '0x69',
+ *     codeHash: '0xdeadbeef',
+ *     nonce: '0x0',
+ *     storageRoot: '0xdeadbeef',
+ *     storage: {
+ *       '0x420420': '0x42069',
+ *     },
+ *   },
+ * })
+ *
+ * // Restore the persisted state later
+ * const restoredState = persister.restoreState()
+ *
+ * // Remove the persisted state
+ * persister.removePersistedState()
+ * ```
  */
 export const createSyncStoragePersister = ({
 	storage,

--- a/packages/sync-storage-persister/src/noopPersister.js
+++ b/packages/sync-storage-persister/src/noopPersister.js
@@ -1,6 +1,18 @@
 /**
  * A persister that does nothing, useful as a default
+ * Every method is a no-op that returns `undefined` so it can be dropped in
+ * anywhere a {@link import('./SyncStoragePersister.js').SyncStoragePersister} is expected
+ * without persisting any state.
  * @type {import('./SyncStoragePersister.js').SyncStoragePersister}
+ * @example
+ * ```typescript
+ * import { noopPersister } from '@tevm/sync-storage-persister'
+ *
+ * // Safe to call every method; nothing is persisted
+ * noopPersister.persistTevmState({})
+ * const state = noopPersister.restoreState() // undefined
+ * noopPersister.removePersistedState()
+ * ```
  */
 export const noopPersister = {
 	persistTevmState: () => undefined,

--- a/packages/utils/src/invariant.ts
+++ b/packages/utils/src/invariant.ts
@@ -1,5 +1,22 @@
 import { DefensiveNullCheckError } from '@tevm/errors'
 
+/**
+ * Asserts that a condition is truthy, throwing otherwise.
+ * Narrows the type of the condition via a TypeScript assertion signature.
+ * @param condition - The condition to check
+ * @param error - The error to throw if the condition is falsy. Defaults to a {@link DefensiveNullCheckError}
+ * @throws {DefensiveNullCheckError} If the condition is falsy and no error is provided
+ * @throws {Error} The provided error if the condition is falsy
+ * @example
+ * ```typescript
+ * import { invariant } from '@tevm/utils'
+ *
+ * const value: string | undefined = 'hello'
+ * invariant(value !== undefined, new Error('value must be defined'))
+ * // value is now narrowed to string
+ * console.log(value.toUpperCase())
+ * ```
+ */
 export function invariant(condition: any, error: Error = new DefensiveNullCheckError()): asserts condition {
 	if (!condition) {
 		throw error

--- a/packages/utils/src/prefundedAccounts.ts
+++ b/packages/utils/src/prefundedAccounts.ts
@@ -1,5 +1,19 @@
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts'
 
+/**
+ * The 10 well-known prefunded private keys used by anvil, hardhat, and tevm test nodes.
+ * Derived from the test mnemonic `test test test test test test test test test test test junk`.
+ *
+ * WARNING: Never use these keys on a live network. They are publicly known and
+ * any funds sent to them will be stolen.
+ * @example
+ * ```typescript
+ * import { PREFUNDED_PRIVATE_KEYS } from '@tevm/utils'
+ *
+ * const firstPrivateKey = PREFUNDED_PRIVATE_KEYS[0]
+ * // '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+ * ```
+ */
 export const PREFUNDED_PRIVATE_KEYS = [
 	'0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', // 0
 	'0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d', // 1
@@ -13,6 +27,17 @@ export const PREFUNDED_PRIVATE_KEYS = [
 	'0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6', // 9
 ] as const
 
+/**
+ * The 10 addresses corresponding to {@link PREFUNDED_PRIVATE_KEYS}.
+ * These accounts are prefunded with 10,000 ETH in tevm test nodes.
+ * @example
+ * ```typescript
+ * import { PREFUNDED_PUBLIC_KEYS } from '@tevm/utils'
+ *
+ * const firstAddress = PREFUNDED_PUBLIC_KEYS[0]
+ * // '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+ * ```
+ */
 export const PREFUNDED_PUBLIC_KEYS = [
 	'0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', // 0
 	'0x70997970C51812dc3A010C7d01b50e0d17dc79C8', // 1
@@ -26,6 +51,17 @@ export const PREFUNDED_PUBLIC_KEYS = [
 	'0xa0Ee7A142d267C1f36714E4a8F75612F20a79720', // 9
 ] as const
 
+/**
+ * The 10 prefunded accounts as viem {@link PrivateKeyAccount} objects,
+ * derived from {@link PREFUNDED_PRIVATE_KEYS}.
+ * @example
+ * ```typescript
+ * import { PREFUNDED_ACCOUNTS } from '@tevm/utils'
+ *
+ * const account = PREFUNDED_ACCOUNTS[0]
+ * console.log(account.address) // '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+ * ```
+ */
 export const PREFUNDED_ACCOUNTS: [
 	PrivateKeyAccount,
 	PrivateKeyAccount,
@@ -50,6 +86,20 @@ export const PREFUNDED_ACCOUNTS: [
 	privateKeyToAccount(PREFUNDED_PRIVATE_KEYS[9]),
 ] as const
 
+/**
+ * The seed used to derive the prefunded accounts: the well-known test mnemonic
+ * shared with anvil and hardhat, and its derivation path.
+ * @example
+ * ```typescript
+ * import { mnemonicToAccount } from '@tevm/utils'
+ * import { PREFUNDED_SEED } from '@tevm/utils'
+ *
+ * const account = mnemonicToAccount(PREFUNDED_SEED.mnemonic, {
+ *   addressIndex: 0,
+ * })
+ * console.log(account.address) // '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+ * ```
+ */
 export const PREFUNDED_SEED = Object.freeze({
 	mnemonic: 'test test test test test test test test test test test junk',
 	derivationPath: "m/44'/60'/0'/0/",

--- a/packages/utils/src/signature.js
+++ b/packages/utils/src/signature.js
@@ -126,11 +126,12 @@ export function hashMessage(message) {
  * const address = recoverMessageAddress({
  *   message: 'Hello world',
  *   signature: {
- *     r: 0x...,
- *     s: 0x...,
+ *     r: 0x157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87n,
+ *     s: 0x28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78n,
  *     v: 27
  *   }
  * })
+ * console.log(address) // '0xED54a7C1d8634BB589f24Bb7F05a5554b36F9618'
  * ```
  */
 export function recoverMessageAddress({ message, signature }) {
@@ -150,14 +151,15 @@ export function recoverMessageAddress({ message, signature }) {
  * import { verifyMessage } from '@tevm/utils'
  *
  * const isValid = verifyMessage({
- *   address: '0xa6fb229e9b0a4e4ef52ea6991adcfc59207c7711',
+ *   address: '0xED54a7C1d8634BB589f24Bb7F05a5554b36F9618',
  *   message: 'Hello world',
  *   signature: {
- *     r: 0x...,
- *     s: 0x...,
+ *     r: 0x157098a1d96fad0945d44978e3c8f2d1d2410f8ed742652cbf13b6b031391e87n,
+ *     s: 0x28521ff547f3c3242084d0d26f560a6ff1c91988d70d3284ff96f32caa373d78n,
  *     v: 27
  *   }
  * })
+ * console.log(isValid) // true
  * ```
  */
 export function verifyMessage({ address, message, signature }) {


### PR DESCRIPTION
## Summary

Audited the public API surface of core packages (avoiding `packages/actions`, `packages/errors`, `packages/node`, `packages/server`, `packages/memory-client` which have in-flight PRs) and fixed missing and **actively wrong** JSDoc.

### Actively wrong JSDoc (findings)

- **`@tevm/effect`** — `fileExists`, `logAllErrors`, and `createRequireEffect` examples imported from a nonexistent package `@eth-optimism/config` (stale copy-paste). `fileExists`'s example also `await`ed an Effect directly, which doesn't run it. `resolve.js` had a stray backtick breaking the docblock and four-backtick code fences.
- **`@tevm/jsonrpc`** — `createJsonRpcFetcher`'s example called a `fetchJsonRpc(url, params)` function that does not exist; its `@returns` claimed to return "the `result` field from the JSON-RPC response" when it actually returns a `JsonRpcClient` object.
- **`@tevm/http-client`** — `createHttpClient` had a completely empty `@example` block.
- **`@tevm/common`** — `createCommon` examples used `{ ... }` elisions that can't be pasted and run.
- **`@tevm/utils`** — `recoverMessageAddress` and `verifyMessage` examples used placeholder `r: 0x...` / `s: 0x...` values; replaced with the real test vectors from `signature.spec.ts` (message `'Hello world'`, expected address `0xED54a7C1d8634BB589f24Bb7F05a5554b36F9618`).

### Missing JSDoc added

- `@tevm/utils`: `invariant` (no JSDoc at all), `PREFUNDED_PRIVATE_KEYS` / `PREFUNDED_PUBLIC_KEYS` / `PREFUNDED_ACCOUNTS` / `PREFUNDED_SEED` (no JSDoc)
- `@tevm/logger`: `createLogger` gained `@example` + `@throws`
- `@tevm/sync-storage-persister`: `createSyncStoragePersister` gained `@example` + `@throws` (+ `syncronous` typo fix); `noopPersister` gained `@example`
- `@tevm/common`: `createMockKzg` gained a `@returns` description

All new examples are complete (real imports, no elisions) and based on the packages' own test files.

## Verification

- `tsc --noEmit` passes in all 7 touched packages (after `nx run-many --targets=build:types` for the 7 projects + 72 dependency tasks)
- `vitest run` results:
  - @tevm/effect: **17 passed**
  - @tevm/logger: **1 passed**
  - @tevm/jsonrpc: **7 passed**
  - @tevm/sync-storage-persister: **15 passed**
  - @tevm/common: **20 passed**
  - @tevm/utils: **59 passed, 1 skipped**
  - @tevm/http-client: suite is `describe.skip` upstream (8 skipped, 1 todo) — unchanged by this PR
- `biome check` / `biome format`: clean on all touched files

<prompt>
LANE: Fix missing and wrong JSDoc across the core public API. Audit and improve JSDoc across evmts/tevm's public API. The repo convention is explicit: when JSDoc is missing you add it, and existing JSDoc may be WRONG so fix it. Avoid packages/actions, packages/errors, packages/node, packages/server and packages/memory-client — in-flight PRs touch them.
</prompt>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved public API documentation across multiple packages.
  - Added complete, runnable examples for effects, HTTP clients, JSON-RPC, logging, persistence, utilities, and account helpers.
  - Corrected examples, imports, parameter descriptions, return values, and error behavior.
  - Documented prefunded account data and clarified that the associated private keys are publicly known.
  - Updated package patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->