### PR TITLE
🐛 fix(release): allow Tevm packages to version with Zevm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,6 @@
     "svelte-ethers",
     "mdt-repro",
     "@tevm/bench",
-    "@tevm/scripts",
-    "@evmts/*"
+    "@tevm/scripts"
   ]
 }


### PR DESCRIPTION
Removes the external Zevm workspace packages from Changesets ignore rules. Changesets rejects versioning any Tevm package that depends on an ignored workspace package, which currently prevents the prerelease version PR from being created. Zevm has no Tevm changesets and remains unchanged/unpublished by this release.\n\nVerified locally in the pinned sibling workspace: `pnpm changeset version` completes and does not modify the Zevm checkout.