### PR TITLE
🐛 fix(release): point package.json repository URLs at evmts/tevm

### DIFF
--- a/bundler-packages/base-bundler/package.json
+++ b/bundler-packages/base-bundler/package.json
@@ -13,7 +13,7 @@
 	"homepage": "https://tevm.sh",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/base-bundler"
 	},
 	"license": "MIT",

--- a/bundler-packages/bun/package.json
+++ b/bundler-packages/bun/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/bun"
 	},
 	"license": "MIT",

--- a/bundler-packages/bundler-cache/package.json
+++ b/bundler-packages/bundler-cache/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/bundler-cache"
 	},
 	"license": "MIT",

--- a/bundler-packages/compiler/package.json
+++ b/bundler-packages/compiler/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/compiler"
 	},
 	"license": "MIT",

--- a/bundler-packages/config/package.json
+++ b/bundler-packages/config/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/config"
 	},
 	"license": "MIT",

--- a/bundler-packages/esbuild/package.json
+++ b/bundler-packages/esbuild/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/esbuild"
 	},
 	"license": "MIT",

--- a/bundler-packages/mud/package.json
+++ b/bundler-packages/mud/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/evmts/tevm-monorepo.git",
+		"url": "https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/mud"
 	},
 	"license": "MIT",

--- a/bundler-packages/requirejs/package.json
+++ b/bundler-packages/requirejs/package.json
@@ -13,7 +13,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/requirejs"
 	},
 	"license": "MIT",

--- a/bundler-packages/resolutions-rs/npm/darwin-arm64/package.json
+++ b/bundler-packages/resolutions-rs/npm/darwin-arm64/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/darwin-arm64"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/darwin-x64/package.json
+++ b/bundler-packages/resolutions-rs/npm/darwin-x64/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/darwin-x64"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/freebsd-x64/package.json
+++ b/bundler-packages/resolutions-rs/npm/freebsd-x64/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/freebsd-x64"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/linux-arm-gnueabihf/package.json
+++ b/bundler-packages/resolutions-rs/npm/linux-arm-gnueabihf/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/linux-arm-gnueabihf"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/linux-arm64-gnu/package.json
+++ b/bundler-packages/resolutions-rs/npm/linux-arm64-gnu/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/linux-arm64-gnu"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/linux-arm64-musl/package.json
+++ b/bundler-packages/resolutions-rs/npm/linux-arm64-musl/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/linux-arm64-musl"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/linux-x64-musl/package.json
+++ b/bundler-packages/resolutions-rs/npm/linux-x64-musl/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/linux-x64-musl"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/wasm32-wasi/package.json
+++ b/bundler-packages/resolutions-rs/npm/wasm32-wasi/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/wasm32-wasi"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/win32-arm64-msvc/package.json
+++ b/bundler-packages/resolutions-rs/npm/win32-arm64-msvc/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/win32-arm64-msvc"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/npm/win32-ia32-msvc/package.json
+++ b/bundler-packages/resolutions-rs/npm/win32-ia32-msvc/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs/npm/win32-ia32-msvc"
 	},
 	"cpu": [

--- a/bundler-packages/resolutions-rs/package.json
+++ b/bundler-packages/resolutions-rs/package.json
@@ -5,7 +5,7 @@
 	"description": "Rust implementation of solidity resolution",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions-rs"
 	},
 	"license": "MIT",

--- a/bundler-packages/resolutions/package.json
+++ b/bundler-packages/resolutions/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/resolutions"
 	},
 	"license": "MIT",

--- a/bundler-packages/rollup/package.json
+++ b/bundler-packages/rollup/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/rollup"
 	},
 	"license": "MIT",

--- a/bundler-packages/rspack/package.json
+++ b/bundler-packages/rspack/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/rspack"
 	},
 	"license": "MIT",

--- a/bundler-packages/runtime-rs/npm/darwin-arm64/package.json
+++ b/bundler-packages/runtime-rs/npm/darwin-arm64/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/darwin-arm64"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/darwin-x64/package.json
+++ b/bundler-packages/runtime-rs/npm/darwin-x64/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/darwin-x64"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/freebsd-x64/package.json
+++ b/bundler-packages/runtime-rs/npm/freebsd-x64/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/freebsd-x64"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/linux-arm-gnueabihf/package.json
+++ b/bundler-packages/runtime-rs/npm/linux-arm-gnueabihf/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/linux-arm-gnueabihf"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/linux-arm64-gnu/package.json
+++ b/bundler-packages/runtime-rs/npm/linux-arm64-gnu/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/linux-arm64-gnu"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/linux-arm64-musl/package.json
+++ b/bundler-packages/runtime-rs/npm/linux-arm64-musl/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/linux-arm64-musl"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/linux-x64-musl/package.json
+++ b/bundler-packages/runtime-rs/npm/linux-x64-musl/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/linux-x64-musl"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/wasm32-wasi/package.json
+++ b/bundler-packages/runtime-rs/npm/wasm32-wasi/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/wasm32-wasi"
 	},
 	"main": "tevm_runtime_rs.wasi.cjs",

--- a/bundler-packages/runtime-rs/npm/win32-arm64-msvc/package.json
+++ b/bundler-packages/runtime-rs/npm/win32-arm64-msvc/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/win32-arm64-msvc"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/npm/win32-ia32-msvc/package.json
+++ b/bundler-packages/runtime-rs/npm/win32-ia32-msvc/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs/npm/win32-ia32-msvc"
 	},
 	"os": [

--- a/bundler-packages/runtime-rs/package.json
+++ b/bundler-packages/runtime-rs/package.json
@@ -5,7 +5,7 @@
 	"description": "Rust implementation of Tevm runtime",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime-rs"
 	},
 	"license": "MIT",

--- a/bundler-packages/runtime/package.json
+++ b/bundler-packages/runtime/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/runtime"
 	},
 	"license": "MIT",

--- a/bundler-packages/solc/package.json
+++ b/bundler-packages/solc/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/solc"
 	},
 	"license": "MIT",

--- a/bundler-packages/tevm-run/package.json
+++ b/bundler-packages/tevm-run/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/tevm-run"
 	},
 	"type": "module",

--- a/bundler-packages/unplugin/package.json
+++ b/bundler-packages/unplugin/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/unplugin"
 	},
 	"license": "MIT",

--- a/bundler-packages/vite/package.json
+++ b/bundler-packages/vite/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/vite"
 	},
 	"license": "MIT",

--- a/bundler-packages/webpack/package.json
+++ b/bundler-packages/webpack/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/webpack"
 	},
 	"license": "MIT",

--- a/bundler-packages/whatsabi/package.json
+++ b/bundler-packages/whatsabi/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/whatsabi"
 	},
 	"license": "MIT",

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "cli"
 	},
 	"bin": "dist/cli.js",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "bundler-packages/compiler"
 	},
 	"license": "MIT",

--- a/configs/tsconfig/package.json
+++ b/configs/tsconfig/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "configs/tsconfig"
 	},
 	"private": false,

--- a/configs/tsupconfig/package.json
+++ b/configs/tsupconfig/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "configs/tsupconfig"
 	},
 	"private": false,

--- a/extensions/ethers/package.json
+++ b/extensions/ethers/package.json
@@ -15,7 +15,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "extensions/ethers"
 	},
 	"license": "MIT",

--- a/extensions/test-matchers/package.json
+++ b/extensions/test-matchers/package.json
@@ -19,7 +19,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "extensions/test-matchers"
 	},
 	"license": "MIT",

--- a/extensions/test-node/package.json
+++ b/extensions/test-node/package.json
@@ -25,7 +25,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "extensions/test-node"
 	},
 	"license": "MIT",

--- a/extensions/viem/package.json
+++ b/extensions/viem/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "extensions/viem"
 	},
 	"license": "MIT",

--- a/lsp/lsp/package.json
+++ b/lsp/lsp/package.json
@@ -16,7 +16,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "lsp/lsp"
 	},
 	"files": [

--- a/lsp/ts-plugin/package.json
+++ b/lsp/ts-plugin/package.json
@@ -13,7 +13,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "lsp/ts-plugin"
 	},
 	"license": "MIT",

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -4,7 +4,7 @@
 	"version": "1.0.0-rc.151",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "lsp/vscode"
 	},
 	"categories": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/evmts/tevm-monorepo.git"
+		"url": "https://github.com/evmts/tevm.git"
 	},
 	"license": "MIT",
 	"contributors": [

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/actions"
 	},
 	"license": "MIT",

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/address"
 	},
 	"license": "MIT",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/block"
 	},
 	"license": "MIT",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -11,7 +11,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/blockchain"
 	},
 	"license": "MIT",

--- a/packages/client-types/package.json
+++ b/packages/client-types/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/client-types"
 	},
 	"license": "MIT",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/common"
 	},
 	"license": "MIT",

--- a/packages/consensus/package.json
+++ b/packages/consensus/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/consensus"
 	},
 	"license": "MIT",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/contracts"
 	},
 	"license": "MIT",

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/decorators"
 	},
 	"license": "MIT",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -9,7 +9,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/effect"
 	},
 	"license": "MIT",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/errors"
 	},
 	"license": "MIT",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/evm"
 	},
 	"license": "MIT",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/http-client"
 	},
 	"license": "MIT",

--- a/packages/jsonrpc/package.json
+++ b/packages/jsonrpc/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/jsonrpc"
 	},
 	"license": "MIT",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/logger"
 	},
 	"license": "MIT",

--- a/packages/memory-client/package.json
+++ b/packages/memory-client/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/memory-client"
 	},
 	"license": "MIT",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/node"
 	},
 	"license": "MIT",

--- a/packages/precompiles/package.json
+++ b/packages/precompiles/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/precompiles"
 	},
 	"license": "MIT",

--- a/packages/predeploys/package.json
+++ b/packages/predeploys/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/predeploys"
 	},
 	"license": "MIT",

--- a/packages/procedures/package.json
+++ b/packages/procedures/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/procedures"
 	},
 	"license": "MIT",

--- a/packages/receipt-manager/package.json
+++ b/packages/receipt-manager/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/receipt-manager"
 	},
 	"license": "MIT",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/rlp"
 	},
 	"license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/server"
 	},
 	"license": "MIT",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/state"
 	},
 	"license": "MIT",

--- a/packages/sync-storage-persister/package.json
+++ b/packages/sync-storage-persister/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/sync-storage-persister"
 	},
 	"license": "MIT",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/trie"
 	},
 	"license": "MIT",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/tx"
 	},
 	"license": "MIT",

--- a/packages/txpool/package.json
+++ b/packages/txpool/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/txpool"
 	},
 	"license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/utils"
 	},
 	"license": "MIT",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "packages/vm"
 	},
 	"license": "MIT",

--- a/test/bench/package.json
+++ b/test/bench/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "test/bench"
 	},
 	"license": "MIT",

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/evmts/tevm-monorepo.git",
+		"url": "git+https://github.com/evmts/tevm.git",
 		"directory": "test/test-utils"
 	},
 	"license": "MIT",

--- a/tevm/package.json
+++ b/tevm/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/evmts/tevm-monorepo.git",
+    "url": "git+https://github.com/evmts/tevm.git",
     "directory": "tevm"
   },
   "license": "MIT",


### PR DESCRIPTION
## The failure

Every package fails to publish with `E422`:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/tevm
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/evmts/tevm-monorepo.git",
expected to match "https://github.com/evmts/tevm" from provenance
```

## Cause

The repo was renamed `evmts/tevm-monorepo` → `evmts/tevm`. GitHub redirects the old URL, so nothing looked broken — but the OIDC **provenance statement carries the current repository name**, and npm validates it against `repository.url` in package.json. All 85 package.json files still declared the old name, so the package signed successfully and then failed verification at the registry.

This is the same class of rename fallout as the four release workflows that were gated on `github.repository == 'evmts/tevm-monorepo'` (fixed in #2083).

## Change

All 85 `package.json` repository URLs updated. JSON validity verified across every file.

Publishing is blocked until this merges.

🤖 Generated with Smithers multi-agent orchestration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository links across all package metadata to point to the current project repository.
  - No package functionality, dependencies, scripts, exports, or configuration behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->