### PR TITLE
🐛 fix(state): fall back to scalar RPCs when fork lacks `eth_getProof`

### DIFF
--- a/.changeset/proud-otters-prove.md
+++ b/.changeset/proud-otters-prove.md
@@ -1,0 +1,5 @@
+---
+"@tevm/state": patch
+---
+
+Fork account hydration now falls back to eth_getBalance + eth_getTransactionCount + eth_getCode (pinned to the fork block) on providers that do not serve eth_getProof, such as Monad, ZKsync OS, and Moonbeam. The downgrade is detected once per fork transport and logged; fetched bytecode primes the contract code cache. Execution semantics are unchanged: codeHash is computed locally and account storageRoot (never read by EVM execution) defaults to the canonical empty trie root.

--- a/packages/state/src/actions/getAccountFromProvider.js
+++ b/packages/state/src/actions/getAccountFromProvider.js
@@ -1,10 +1,49 @@
-import { toBytes } from '@tevm/utils'
+import { hexToBytes, keccak256, toBytes } from '@tevm/utils'
 import { fromAccountData } from '../utils/accountHelpers.js'
 import { getForkBlockTag } from './getForkBlockTag.js'
 import { getForkClient } from './getForkClient.js'
 
 /**
- * Retrieves an account from the provider and stores in the local trie
+ * Fork transports that do not serve eth_getProof (e.g. Monad, ZKsync OS, Moonbeam).
+ * Keyed by transport identity, which deepCopy/shallowCopy preserve, so the
+ * downgrade is detected once per provider and survives state-manager copies.
+ * @type {WeakMap<object, true>}
+ */
+const proofUnsupportedTransports = new WeakMap()
+
+/**
+ * Returns true for JSON-RPC errors meaning the provider does not serve the
+ * method, checked across the cause chain via viem's `BaseError.walk`.
+ * Duck-typed rather than `instanceof BaseError` so errors constructed by a
+ * duplicate viem install still match. Uncoded errors are never treated as
+ * capability failures.
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+const isMethodUnavailableError = (err) => {
+	/** @param {unknown} node @returns {boolean} */
+	const isMethodUnavailable = (node) => {
+		const code = /** @type {{code?: unknown}} */ (node)?.code
+		if (code === -32601 || code === -32004) return true
+		return (
+			code === -32600 &&
+			/not (available|found|supported)|unavailable/i.test(
+				String(/** @type {{message?: unknown}} */ (node)?.message ?? ''),
+			)
+		)
+	}
+	const walk = /** @type {{walk?: (fn: (err: unknown) => boolean) => unknown}} */ (err)?.walk
+	return typeof walk === 'function' ? walk.call(err, isMethodUnavailable) !== null : isMethodUnavailable(err)
+}
+
+/**
+ * Retrieves an account from the provider and stores in the local trie.
+ *
+ * Hydrates via a single empty-storageKeys eth_getProof. Providers that do not
+ * serve eth_getProof are downgraded once per transport to concurrent
+ * eth_getBalance + eth_getTransactionCount + eth_getCode pinned to the same
+ * fork block, with codeHash computed locally and storageRoot defaulting to the
+ * canonical empty trie root (never read by EVM execution).
  * @param {import('../BaseState.js').BaseState} baseState
  * @returns {(address: import('@tevm/utils').EthjsAddress) => Promise<import('@tevm/utils').EthjsAccount>}
  * @private
@@ -12,16 +51,51 @@ import { getForkClient } from './getForkClient.js'
 export const getAccountFromProvider = (baseState) => async (address) => {
 	const client = getForkClient(baseState)
 	const blockTag = getForkBlockTag(baseState)
-	const accountData = await client.getProof({
-		address: /** @type {import('@tevm/utils').Address}*/ (address.toString()),
-		storageKeys: [],
-		...blockTag,
+	const addressHex = /** @type {import('@tevm/utils').Address}*/ (address.toString())
+	const transport = /** @type {object} */ (baseState.options.fork?.transport)
+
+	if (!proofUnsupportedTransports.has(transport)) {
+		try {
+			const accountData = await client.getProof({
+				address: addressHex,
+				storageKeys: [],
+				...blockTag,
+			})
+			return fromAccountData({
+				balance: BigInt(accountData.balance),
+				nonce: BigInt(accountData.nonce),
+				codeHash: toBytes(accountData.codeHash),
+				storageRoot: toBytes(accountData.storageHash),
+			})
+		} catch (err) {
+			if (!isMethodUnavailableError(err)) throw err
+			proofUnsupportedTransports.set(transport, true)
+			baseState.logger.warn(
+				{ address: addressHex, error: /** @type {Error} */ (err).message },
+				'eth_getProof is not served by the fork provider; permanently falling back to eth_getBalance/eth_getTransactionCount/eth_getCode for account hydration on this transport',
+			)
+		}
+	}
+
+	const [balance, nonce, code] = await Promise.all([
+		client.getBalance({ address: addressHex, ...blockTag }),
+		client.getTransactionCount({ address: addressHex, ...blockTag }),
+		client.getCode({ address: addressHex, ...blockTag }),
+	])
+
+	// Prime both code caches so getContractCode skips its own eth_getCode; the
+	// main cache is the source of truth for local overrides so never overwrite it
+	const codeBytes = hexToBytes(code ?? '0x')
+	if (!baseState.caches.contracts.has(address)) {
+		baseState.caches.contracts.put(address, codeBytes)
+	}
+	baseState.forkCache.contracts.put(address, codeBytes)
+
+	return fromAccountData({
+		balance,
+		nonce: BigInt(nonce),
+		codeHash: keccak256(codeBytes, 'bytes'),
+		// storageRoot omitted: createAccount defaults it to the canonical empty
+		// trie root, which getAccount's nonexistent-account predicate requires
 	})
-	const account = fromAccountData({
-		balance: BigInt(accountData.balance),
-		nonce: BigInt(accountData.nonce),
-		codeHash: toBytes(accountData.codeHash),
-		storageRoot: toBytes(accountData.storageHash),
-	})
-	return account
 }

--- a/packages/state/src/actions/getAccountFromProvider.spec.ts
+++ b/packages/state/src/actions/getAccountFromProvider.spec.ts
@@ -1,7 +1,10 @@
 import { createAddress } from '@tevm/address'
+import { bytesToHex, hexToBytes, keccak256 } from '@tevm/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createBaseState } from '../createBaseState.js'
+import { getAccount } from './getAccount.js'
 import { getAccountFromProvider } from './getAccountFromProvider.js'
+import { getContractCode } from './getContractCode.js'
 
 const createMockForkTransport = () => ({
 	request: vi.fn(async ({ method }: { method: string }) => {
@@ -32,5 +35,276 @@ describe(getAccountFromProvider.name, () => {
 		expect(typeof account?._nonce).toBe('bigint')
 		expect(account?._codeHash).toHaveLength(32)
 		expect(account?._storageRoot).toHaveLength(32)
+	})
+})
+
+const mockProof = {
+	address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+	accountProof: [],
+	balance: '0x1a4',
+	codeHash: `0x${'00'.repeat(32)}`,
+	nonce: '0x2',
+	storageHash: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+	storageProof: [],
+}
+
+const mockBlock = {
+	hash: `0x${'11'.repeat(32)}`,
+	parentHash: `0x${'00'.repeat(32)}`,
+	sha3Uncles: `0x${'00'.repeat(32)}`,
+	miner: `0x${'00'.repeat(20)}`,
+	stateRoot: `0x${'00'.repeat(32)}`,
+	transactionsRoot: `0x${'00'.repeat(32)}`,
+	receiptsRoot: `0x${'00'.repeat(32)}`,
+	logsBloom: `0x${'00'.repeat(256)}`,
+	difficulty: '0x0',
+	number: '0x1',
+	gasLimit: '0x1',
+	gasUsed: '0x0',
+	timestamp: '0x1',
+	extraData: '0x',
+	mixHash: `0x${'00'.repeat(32)}`,
+	nonce: '0x0000000000000000',
+	transactions: [],
+	uncles: [],
+}
+
+const MOCK_CODE = '0x6080604052'
+const EMPTY_STORAGE_ROOT = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
+const SCALAR_METHODS = ['eth_getBalance', 'eth_getTransactionCount', 'eth_getCode']
+
+type RecordedCall = { method: string; params: unknown[] }
+
+// The capability WeakMap is keyed by transport identity — each test needs a fresh transport
+const createRecordingTransport = ({
+	getProofError,
+	balance = '0x1bc16d674ec80000',
+	transactionCount = '0x5',
+	code = MOCK_CODE,
+}: {
+	getProofError?: unknown
+	balance?: string
+	transactionCount?: string
+	code?: string
+} = {}) => {
+	const calls: RecordedCall[] = []
+	return {
+		calls,
+		request: vi.fn(async ({ method, params }: { method: string; params: unknown[] }) => {
+			calls.push({ method, params })
+			if (method === 'eth_getProof') {
+				if (getProofError !== undefined) throw getProofError
+				return mockProof
+			}
+			if (method === 'eth_getBalance') return balance
+			if (method === 'eth_getTransactionCount') return transactionCount
+			if (method === 'eth_getCode') return code
+			if (method === 'eth_getBlockByNumber') return mockBlock
+			throw new Error(`Unexpected RPC method: ${method}`)
+		}),
+	}
+}
+
+const methodCount = (calls: RecordedCall[], method: string) => calls.filter((c) => c.method === method).length
+
+describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
+	const address = createAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+
+	it('uses eth_getProof alone when the provider serves it', async () => {
+		const transport = createRecordingTransport()
+		const state = createBaseState({ fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(BigInt(mockProof.balance))
+		expect(account.nonce).toBe(BigInt(mockProof.nonce))
+		expect(bytesToHex(account.codeHash)).toBe(mockProof.codeHash)
+		expect(bytesToHex(account.storageRoot)).toBe(mockProof.storageHash)
+		expect(methodCount(transport.calls, 'eth_getProof')).toBe(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	})
+
+	it('falls back to scalar methods on -32601 Method not found', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		expect(account.nonce).toBe(5n)
+		expect(bytesToHex(account.codeHash)).toBe(keccak256(MOCK_CODE))
+		expect(bytesToHex(account.storageRoot)).toBe(EMPTY_STORAGE_ROOT)
+		expect(methodCount(transport.calls, 'eth_getProof')).toBe(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('falls back to scalar methods on -32004 Method not supported', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32004, message: 'Method not supported' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		expect(account.nonce).toBe(5n)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('falls back on -32600 whose message says the method is not available (Monad shape)', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32600, message: 'eth_getProof is not available on the MONAD_MAINNET' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('falls back on -32600 whose message says the method is unavailable', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32600, message: 'Method unavailable' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('does NOT fall back on a generic -32600 invalid request', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32600, message: 'invalid request' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+
+		expect(methodCount(transport.calls, 'eth_getProof')).toBeGreaterThanOrEqual(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	})
+
+	it('does NOT fall back or stick on -32005 rate limiting', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32005, message: 'rate limited' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		// viem retries rate-limit errors, so eth_getProof count is >= 1, not exactly 1
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		const callsAfterFirst = methodCount(transport.calls, 'eth_getProof')
+		expect(callsAfterFirst).toBeGreaterThanOrEqual(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		expect(methodCount(transport.calls, 'eth_getProof')).toBeGreaterThan(callsAfterFirst)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	}, 30_000)
+
+	it('does NOT fall back or stick on plain network errors', async () => {
+		const transport = createRecordingTransport({
+			getProofError: new Error('ECONNRESET'),
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		const callsAfterFirst = methodCount(transport.calls, 'eth_getProof')
+		expect(callsAfterFirst).toBeGreaterThanOrEqual(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		expect(methodCount(transport.calls, 'eth_getProof')).toBeGreaterThan(callsAfterFirst)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	}, 30_000)
+
+	it('downgrades the transport permanently: second address skips eth_getProof entirely', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+		const secondAddress = createAddress(`0x${'02'.repeat(20)}`)
+
+		await getAccountFromProvider(state)(address)
+		await getAccountFromProvider(state)(secondAddress)
+
+		expect(methodCount(transport.calls, 'eth_getProof')).toBe(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(2)
+		}
+	})
+
+	it('pins every scalar request to the fork block', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 123n } })
+
+		await getAccountFromProvider(state)(address)
+
+		const scalarCalls = transport.calls.filter((c) => SCALAR_METHODS.includes(c.method))
+		expect(scalarCalls).toHaveLength(3)
+		for (const call of scalarCalls) {
+			expect(call.params).toContain('0x7b')
+		}
+	})
+
+	it('primes the contract code cache so getContractCode makes no extra eth_getCode call', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		await getAccountFromProvider(state)(address)
+		expect(methodCount(transport.calls, 'eth_getCode')).toBe(1)
+
+		const codeBytes = await getContractCode(state)(address)
+
+		expect(codeBytes).toEqual(hexToBytes(MOCK_CODE))
+		expect(methodCount(transport.calls, 'eth_getCode')).toBe(1)
+	})
+
+	it('resolves a nonexistent account to undefined through the real getAccount action', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+			balance: '0x0',
+			transactionCount: '0x0',
+			code: '0x',
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+		const emptyAddress = createAddress(`0x${'03'.repeat(20)}`)
+
+		const result = await getAccount(state)(emptyAddress)
+
+		expect(result).toBeUndefined()
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+		expect(state.caches.accounts.get(emptyAddress)?.accountRLP).toBeUndefined()
+		expect(state.forkCache.accounts.get(emptyAddress)?.accountRLP).toBeUndefined()
 	})
 })


### PR DESCRIPTION
## Description

Fork account hydration falls back to `eth_getBalance` + `eth_getTransactionCount` + `eth_getCode` on providers that do not serve `eth_getProof`.

### Motivation

Tevm's fork mode hydrates every uncached remote account through a single empty-`storageKeys` `eth_getProof` call in `getAccountFromProvider` — the only RPC path for loading an account's balance/nonce/codeHash/storageRoot. Some EVM chains do not serve `eth_getProof` at all, so a fork *starts* fine (startup only needs `eth_chainId` + `eth_getBlockByNumber`) and then dies on the first touch of any uncached account — the first `tevmCall`, `tevmSetAccount`, `tevmDeal`, or `eth_createAccessList`.

**Monad mainnet (chainId 143)** does not serve `eth_getProof` on any provider, so tevm cannot fork it today. The gap is not Monad-specific — [ZKsync OS chains officially don't support it](https://docs.zksync.io/zksync-protocol/api/ethereum-rpc) and [Moonbeam lists it as unsupported](https://docs.moonbeam.network/builders/ethereum/json-rpc/eth-rpc/) — while all of them serve the scalar quartet (`eth_getBalance`/`eth_getTransactionCount`/`eth_getCode`/`eth_getStorageAt`).

Tevm is the outlier here only because it inherited EthereumJS `RPCStateManager`'s proof-coupled loader. Every other major fork simulator already uses the scalar mechanism this PR falls back to:
- **Foundry** fetches accounts via block-pinned `get_balance`+`get_transaction_count`+`get_code_at`, with its own availability downgrade (`ACCOUNT_FETCH_SEPARATE_REQUESTS`) ([foundry-fork-db backend.rs](https://github.com/foundry-rs/foundry-core/blob/main/crates/fork-db/src/backend.rs#L288-L399))
- **Hardhat/EDR** runs the same trio under `tokio::try_join!` and synthesizes `code_hash: Bytecode::hash_slow(code)` ([edr client.rs](https://github.com/NomicFoundation/edr/blob/main/crates/edr_rpc_eth/src/client.rs#L110-L141))
- **Ganache** did the same, with `codeHash = keccak(code)` computed locally

### Change

`getAccountFromProvider` still prefers the single-round-trip `eth_getProof`. On a method-unavailable error — `-32601`, `-32004`, or `-32600` with a "not available/found/supported" message, matched across the error cause chain via viem's `BaseError.walk` — it permanently downgrades that fork transport to the three concurrent scalar calls, pinned to the same resolved fork block. All other errors rethrow unchanged; uncoded errors (network failures wrapped as `UnknownRpcError`) never trigger the downgrade. The fetched bytecode primes both contract-code caches, and the public `eth_getProof` action and light-client verified reads are untouched.

## Additional Information

- [x] I read the [contributing docs](../tevm/docs/_media/CONTRIBUTING.md) (if this is your first contribution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic account data retrieval fallback when proof requests aren’t supported by the connected provider.
  * Fallback requests are pinned to the fork block for consistent balances, transaction counts, and contract code.
  * Retrieved contract bytecode is cached for faster subsequent access.

* **Bug Fixes**
  * Improved handling of unsupported proof requests while preserving errors for rate-limit, network, and other provider failures.
  * Added reliable handling for accounts that do not exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->