### PR TITLE
🐛 fix(state): fall back to scalar RPCs when fork lacks eth_getProof

### DIFF
--- a/.changeset/proud-otters-prove.md
+++ b/.changeset/proud-otters-prove.md
@@ -2,4 +2,4 @@
 "@tevm/state": patch
 ---
 
-Fork account hydration now falls back to eth_getBalance + eth_getTransactionCount + eth_getCode (pinned to the fork block) on providers that do not serve eth_getProof, such as Monad, ZKsync OS, and Moonbeam. The downgrade is detected once per fork transport and logged; fetched bytecode primes the contract code cache. Execution semantics are unchanged: codeHash is computed locally and account storageRoot (never read by EVM execution) defaults to the canonical empty trie root.
+Fork account hydration now falls back to eth_getBalance + eth_getTransactionCount + eth_getCode (pinned to the fork block) on providers that do not serve eth_getProof, such as Monad, ZKsync OS, and Moonbeam. The downgrade is detected once per fork transport and logged; fetched bytecode primes the contract code cache. Account existence detection accepts both zero-hash proof responses and canonical empty hashes produced by scalar hydration.

--- a/.changeset/proud-otters-prove.md
+++ b/.changeset/proud-otters-prove.md
@@ -1,0 +1,5 @@
+---
+"@tevm/state": patch
+---
+
+Fork account hydration now falls back to eth_getBalance + eth_getTransactionCount + eth_getCode (pinned to the fork block) on providers that do not serve eth_getProof, such as Monad, ZKsync OS, and Moonbeam. The downgrade is detected once per fork transport and logged; fetched bytecode primes the contract code cache. Execution semantics are unchanged: codeHash is computed locally and account storageRoot (never read by EVM execution) defaults to the canonical empty trie root.

--- a/packages/state/src/actions/getAccount.js
+++ b/packages/state/src/actions/getAccount.js
@@ -1,10 +1,10 @@
-import { bytesToHex } from '@tevm/utils'
+import { equalsBytes, KECCAK256_RLP, keccak256 } from '@tevm/utils'
 import { fromRlpSerializedAccount } from '../utils/accountHelpers.js'
 import { getAccountFromProvider } from './getAccountFromProvider.js'
 import { resolveForkBlockTag } from './resolveForkBlockTag.js'
 
-const EMPTY_CODE_HASH = '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
-const EMPTY_STORAGE_ROOT = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
+const ZERO_HASH = new Uint8Array(32)
+const EMPTY_CODE_HASH = keccak256(new Uint8Array(), 'bytes')
 
 /**
  * Gets the account corresponding to the provided `address`.
@@ -69,8 +69,8 @@ export const getAccount =
 		if (
 			account.nonce === 0n &&
 			account.balance === 0n &&
-			bytesToHex(account.codeHash) === EMPTY_CODE_HASH &&
-			bytesToHex(account.storageRoot) === EMPTY_STORAGE_ROOT
+			(equalsBytes(account.codeHash, ZERO_HASH) || equalsBytes(account.codeHash, EMPTY_CODE_HASH)) &&
+			(equalsBytes(account.storageRoot, ZERO_HASH) || equalsBytes(account.storageRoot, KECCAK256_RLP))
 		) {
 			// Store empty account in both caches
 			accounts.put(address, undefined)

--- a/packages/state/src/actions/getAccount.spec.ts
+++ b/packages/state/src/actions/getAccount.spec.ts
@@ -37,6 +37,7 @@ const mockProof = {
 }
 const emptyCodeHash = '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
 const emptyStorageRoot = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
+const zeroHash = `0x${'00'.repeat(32)}`
 const createMockForkTransport = () => ({
 	request: vi.fn(async ({ method }: { method: string }) => {
 		if (method === 'eth_getBlockByNumber') {
@@ -179,7 +180,10 @@ describe(`${getAccount.name} forking`, () => {
 		expect(baseState.caches.accounts.get(emptyAddress)?.accountRLP).toBeUndefined()
 	})
 
-	it('Should handle empty accounts from remote provider', async () => {
+	it.each([
+		['all-zero hashes', zeroHash, zeroHash],
+		['canonical empty hashes', emptyCodeHash, emptyStorageRoot],
+	])('Should handle empty accounts from remote provider with %s', async (_encoding, codeHash, storageRoot): Promise<void> => {
 		// Create an address for testing
 		const testAddress = createAddress('0x1234567890123456789012345678901234567890')
 
@@ -187,8 +191,8 @@ describe(`${getAccount.name} forking`, () => {
 		const mockEmptyAccount = createAccount({
 			balance: 0n,
 			nonce: 0n,
-			codeHash: hexToBytes(emptyCodeHash),
-			storageRoot: hexToBytes(emptyStorageRoot),
+			codeHash: hexToBytes(codeHash),
+			storageRoot: hexToBytes(storageRoot),
 		})
 
 		const mockGetAccountFromProvider = vi.spyOn(getAccountFromProviderModule, 'getAccountFromProvider')

--- a/packages/state/src/actions/getAccountFromProvider.js
+++ b/packages/state/src/actions/getAccountFromProvider.js
@@ -1,10 +1,49 @@
-import { toBytes } from '@tevm/utils'
+import { hexToBytes, keccak256, toBytes } from '@tevm/utils'
 import { fromAccountData } from '../utils/accountHelpers.js'
 import { getForkBlockTag } from './getForkBlockTag.js'
 import { getForkClient } from './getForkClient.js'
 
 /**
- * Retrieves an account from the provider and stores in the local trie
+ * Fork transports that do not serve eth_getProof (e.g. Monad, ZKsync OS, Moonbeam).
+ * Keyed by transport identity, which deepCopy/shallowCopy preserve, so the
+ * downgrade is detected once per provider and survives state-manager copies.
+ * @type {WeakMap<object, true>}
+ */
+const proofUnsupportedTransports = new WeakMap()
+
+/**
+ * Returns true for JSON-RPC errors meaning the provider does not serve the
+ * method, checked across the cause chain via viem's `BaseError.walk`.
+ * Duck-typed rather than `instanceof BaseError` so errors constructed by a
+ * duplicate viem install still match. Uncoded errors are never treated as
+ * capability failures.
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+const isMethodUnavailableError = (err) => {
+	/** @param {unknown} node @returns {boolean} */
+	const isMethodUnavailable = (node) => {
+		const code = /** @type {{code?: unknown}} */ (node)?.code
+		if (code === -32601 || code === -32004) return true
+		return (
+			code === -32600 &&
+			/not (available|found|supported)|unavailable/i.test(
+				String(/** @type {{message?: unknown}} */ (node)?.message ?? ''),
+			)
+		)
+	}
+	const walk = /** @type {{walk?: (fn: (err: unknown) => boolean) => unknown}} */ (err)?.walk
+	return typeof walk === 'function' ? walk.call(err, isMethodUnavailable) !== null : isMethodUnavailable(err)
+}
+
+/**
+ * Retrieves an account from the provider and stores in the local trie.
+ *
+ * Hydrates via a single empty-storageKeys eth_getProof. Providers that do not
+ * serve eth_getProof are downgraded once per transport to concurrent
+ * eth_getBalance + eth_getTransactionCount + eth_getCode pinned to the same
+ * fork block, with codeHash computed locally and storageRoot defaulting to the
+ * canonical empty trie root (never read by EVM execution).
  * @param {import('../BaseState.js').BaseState} baseState
  * @returns {(address: import('@tevm/utils').EthjsAddress) => Promise<import('@tevm/utils').EthjsAccount>}
  * @private
@@ -12,16 +51,51 @@ import { getForkClient } from './getForkClient.js'
 export const getAccountFromProvider = (baseState) => async (address) => {
 	const client = getForkClient(baseState)
 	const blockTag = getForkBlockTag(baseState)
-	const accountData = await client.getProof({
-		address: /** @type {import('@tevm/utils').Address}*/ (address.toString()),
-		storageKeys: [],
-		...blockTag,
+	const addressHex = /** @type {import('@tevm/utils').Address}*/ (address.toString())
+	const transport = /** @type {object} */ (baseState.options.fork?.transport)
+
+	if (!proofUnsupportedTransports.has(transport)) {
+		try {
+			const accountData = await client.getProof({
+				address: addressHex,
+				storageKeys: [],
+				...blockTag,
+			})
+			return fromAccountData({
+				balance: BigInt(accountData.balance),
+				nonce: BigInt(accountData.nonce),
+				codeHash: toBytes(accountData.codeHash),
+				storageRoot: toBytes(accountData.storageHash),
+			})
+		} catch (err) {
+			if (!isMethodUnavailableError(err)) throw err
+			proofUnsupportedTransports.set(transport, true)
+			baseState.logger.warn(
+				{ address: addressHex, error: /** @type {Error} */ (err).message },
+				'eth_getProof is not served by the fork provider; permanently falling back to eth_getBalance/eth_getTransactionCount/eth_getCode for account hydration on this transport',
+			)
+		}
+	}
+
+	const [balance, nonce, code] = await Promise.all([
+		client.getBalance({ address: addressHex, ...blockTag }),
+		client.getTransactionCount({ address: addressHex, ...blockTag }),
+		client.getCode({ address: addressHex, ...blockTag }),
+	])
+
+	// Prime both code caches so getContractCode skips its own eth_getCode; the
+	// main cache is the source of truth for local overrides so never overwrite it
+	const codeBytes = hexToBytes(code ?? '0x')
+	if (!baseState.caches.contracts.has(address)) {
+		baseState.caches.contracts.put(address, codeBytes)
+	}
+	baseState.forkCache.contracts.put(address, codeBytes)
+
+	return fromAccountData({
+		balance,
+		nonce: BigInt(nonce),
+		codeHash: keccak256(codeBytes, 'bytes'),
+		// storageRoot omitted: createAccount defaults it to the canonical empty
+		// trie root, which getAccount's nonexistent-account predicate requires
 	})
-	const account = fromAccountData({
-		balance: BigInt(accountData.balance),
-		nonce: BigInt(accountData.nonce),
-		codeHash: toBytes(accountData.codeHash),
-		storageRoot: toBytes(accountData.storageHash),
-	})
-	return account
 }

--- a/packages/state/src/actions/getAccountFromProvider.js
+++ b/packages/state/src/actions/getAccountFromProvider.js
@@ -52,9 +52,9 @@ export const getAccountFromProvider = (baseState) => async (address) => {
 	const client = getForkClient(baseState)
 	const blockTag = getForkBlockTag(baseState)
 	const addressHex = /** @type {import('@tevm/utils').Address}*/ (address.toString())
-	const transport = /** @type {object} */ (baseState.options.fork?.transport)
+	const transport = /** @type {object | undefined} */ (baseState.options.fork?.transport)
 
-	if (!proofUnsupportedTransports.has(transport)) {
+	if (transport === undefined || !proofUnsupportedTransports.has(transport)) {
 		try {
 			const accountData = await client.getProof({
 				address: addressHex,
@@ -69,7 +69,7 @@ export const getAccountFromProvider = (baseState) => async (address) => {
 			})
 		} catch (err) {
 			if (!isMethodUnavailableError(err)) throw err
-			proofUnsupportedTransports.set(transport, true)
+			if (transport !== undefined) proofUnsupportedTransports.set(transport, true)
 			baseState.logger.warn(
 				{ address: addressHex, error: /** @type {Error} */ (err).message },
 				'eth_getProof is not served by the fork provider; permanently falling back to eth_getBalance/eth_getTransactionCount/eth_getCode for account hydration on this transport',
@@ -95,7 +95,6 @@ export const getAccountFromProvider = (baseState) => async (address) => {
 		balance,
 		nonce: BigInt(nonce),
 		codeHash: keccak256(codeBytes, 'bytes'),
-		// storageRoot omitted: createAccount defaults it to the canonical empty
-		// trie root, which getAccount's nonexistent-account predicate requires
+		// storageRoot omitted: createAccount defaults it to the canonical empty trie root
 	})
 }

--- a/packages/state/src/actions/getAccountFromProvider.spec.ts
+++ b/packages/state/src/actions/getAccountFromProvider.spec.ts
@@ -74,6 +74,7 @@ const EMPTY_STORAGE_ROOT = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001
 const SCALAR_METHODS = ['eth_getBalance', 'eth_getTransactionCount', 'eth_getCode']
 
 type RecordedCall = { method: string; params: unknown[] }
+type RecordingTransport = { calls: RecordedCall[]; request: ReturnType<typeof vi.fn> }
 
 // The capability WeakMap is keyed by transport identity — each test needs a fresh transport
 const createRecordingTransport = ({
@@ -86,7 +87,7 @@ const createRecordingTransport = ({
 	balance?: string
 	transactionCount?: string
 	code?: string
-} = {}) => {
+} = {}): RecordingTransport => {
 	const calls: RecordedCall[] = []
 	return {
 		calls,
@@ -105,12 +106,12 @@ const createRecordingTransport = ({
 	}
 }
 
-const methodCount = (calls: RecordedCall[], method: string) => calls.filter((c) => c.method === method).length
+const methodCount = (calls: RecordedCall[], method: string): number => calls.filter((c) => c.method === method).length
 
 describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 	const address = createAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
 
-	it('uses eth_getProof alone when the provider serves it', async () => {
+	it('uses eth_getProof alone when the provider serves it', async (): Promise<void> => {
 		const transport = createRecordingTransport()
 		const state = createBaseState({ fork: { transport, blockTag: 1n } })
 
@@ -126,7 +127,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('falls back to scalar methods on -32601 Method not found', async () => {
+	it('falls back to scalar methods on -32601 Method not found', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32601, message: 'Method not found' },
 		})
@@ -144,7 +145,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('falls back to scalar methods on -32004 Method not supported', async () => {
+	it('falls back to scalar methods on -32004 Method not supported', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32004, message: 'Method not supported' },
 		})
@@ -159,7 +160,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('falls back on -32600 whose message says the method is not available (Monad shape)', async () => {
+	it('falls back on -32600 whose message says the method is not available (Monad shape)', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32600, message: 'eth_getProof is not available on the MONAD_MAINNET' },
 		})
@@ -173,7 +174,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('falls back on -32600 whose message says the method is unavailable', async () => {
+	it('falls back on -32600 whose message says the method is unavailable', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32600, message: 'Method unavailable' },
 		})
@@ -187,7 +188,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('does NOT fall back on a generic -32600 invalid request', async () => {
+	it('does NOT fall back on a generic -32600 invalid request', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32600, message: 'invalid request' },
 		})
@@ -201,7 +202,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('does NOT fall back or stick on -32005 rate limiting', async () => {
+	it('does NOT fall back or stick on -32005 rate limiting', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32005, message: 'rate limited' },
 		})
@@ -222,7 +223,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	}, 30_000)
 
-	it('does NOT fall back or stick on plain network errors', async () => {
+	it('does NOT fall back or stick on plain network errors', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: new Error('ECONNRESET'),
 		})
@@ -242,7 +243,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	}, 30_000)
 
-	it('downgrades the transport permanently: second address skips eth_getProof entirely', async () => {
+	it('downgrades the transport permanently: second address skips eth_getProof entirely', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32601, message: 'Method not found' },
 		})
@@ -258,7 +259,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('pins every scalar request to the fork block', async () => {
+	it('pins every scalar request to the fork block', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32601, message: 'Method not found' },
 		})
@@ -273,7 +274,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		}
 	})
 
-	it('primes the contract code cache so getContractCode makes no extra eth_getCode call', async () => {
+	it('primes the contract code cache so getContractCode makes no extra eth_getCode call', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32601, message: 'Method not found' },
 		})
@@ -288,7 +289,7 @@ describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
 		expect(methodCount(transport.calls, 'eth_getCode')).toBe(1)
 	})
 
-	it('resolves a nonexistent account to undefined through the real getAccount action', async () => {
+	it('resolves a nonexistent account to undefined through the real getAccount action', async (): Promise<void> => {
 		const transport = createRecordingTransport({
 			getProofError: { code: -32601, message: 'Method not found' },
 			balance: '0x0',

--- a/packages/state/src/actions/getAccountFromProvider.spec.ts
+++ b/packages/state/src/actions/getAccountFromProvider.spec.ts
@@ -1,7 +1,10 @@
 import { createAddress } from '@tevm/address'
+import { bytesToHex, hexToBytes, keccak256 } from '@tevm/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createBaseState } from '../createBaseState.js'
+import { getAccount } from './getAccount.js'
 import { getAccountFromProvider } from './getAccountFromProvider.js'
+import { getContractCode } from './getContractCode.js'
 
 const createMockForkTransport = () => ({
 	request: vi.fn(async ({ method }: { method: string }) => {
@@ -32,5 +35,276 @@ describe(getAccountFromProvider.name, () => {
 		expect(typeof account?._nonce).toBe('bigint')
 		expect(account?._codeHash).toHaveLength(32)
 		expect(account?._storageRoot).toHaveLength(32)
+	})
+})
+
+const mockProof = {
+	address: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+	accountProof: [],
+	balance: '0x1a4',
+	codeHash: `0x${'00'.repeat(32)}`,
+	nonce: '0x2',
+	storageHash: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+	storageProof: [],
+}
+
+const mockBlock = {
+	hash: `0x${'11'.repeat(32)}`,
+	parentHash: `0x${'00'.repeat(32)}`,
+	sha3Uncles: `0x${'00'.repeat(32)}`,
+	miner: `0x${'00'.repeat(20)}`,
+	stateRoot: `0x${'00'.repeat(32)}`,
+	transactionsRoot: `0x${'00'.repeat(32)}`,
+	receiptsRoot: `0x${'00'.repeat(32)}`,
+	logsBloom: `0x${'00'.repeat(256)}`,
+	difficulty: '0x0',
+	number: '0x1',
+	gasLimit: '0x1',
+	gasUsed: '0x0',
+	timestamp: '0x1',
+	extraData: '0x',
+	mixHash: `0x${'00'.repeat(32)}`,
+	nonce: '0x0000000000000000',
+	transactions: [],
+	uncles: [],
+}
+
+const MOCK_CODE = '0x6080604052'
+const EMPTY_STORAGE_ROOT = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
+const SCALAR_METHODS = ['eth_getBalance', 'eth_getTransactionCount', 'eth_getCode']
+
+type RecordedCall = { method: string; params: unknown[] }
+
+// The capability WeakMap is keyed by transport identity — each test needs a fresh transport
+const createRecordingTransport = ({
+	getProofError,
+	balance = '0x1bc16d674ec80000',
+	transactionCount = '0x5',
+	code = MOCK_CODE,
+}: {
+	getProofError?: unknown
+	balance?: string
+	transactionCount?: string
+	code?: string
+} = {}) => {
+	const calls: RecordedCall[] = []
+	return {
+		calls,
+		request: vi.fn(async ({ method, params }: { method: string; params: unknown[] }) => {
+			calls.push({ method, params })
+			if (method === 'eth_getProof') {
+				if (getProofError !== undefined) throw getProofError
+				return mockProof
+			}
+			if (method === 'eth_getBalance') return balance
+			if (method === 'eth_getTransactionCount') return transactionCount
+			if (method === 'eth_getCode') return code
+			if (method === 'eth_getBlockByNumber') return mockBlock
+			throw new Error(`Unexpected RPC method: ${method}`)
+		}),
+	}
+}
+
+const methodCount = (calls: RecordedCall[], method: string) => calls.filter((c) => c.method === method).length
+
+describe(`${getAccountFromProvider.name} eth_getProof scalar fallback`, () => {
+	const address = createAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+
+	it('uses eth_getProof alone when the provider serves it', async () => {
+		const transport = createRecordingTransport()
+		const state = createBaseState({ fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(BigInt(mockProof.balance))
+		expect(account.nonce).toBe(BigInt(mockProof.nonce))
+		expect(bytesToHex(account.codeHash)).toBe(mockProof.codeHash)
+		expect(bytesToHex(account.storageRoot)).toBe(mockProof.storageHash)
+		expect(methodCount(transport.calls, 'eth_getProof')).toBe(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	})
+
+	it('falls back to scalar methods on -32601 Method not found', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		expect(account.nonce).toBe(5n)
+		expect(bytesToHex(account.codeHash)).toBe(keccak256(MOCK_CODE))
+		expect(bytesToHex(account.storageRoot)).toBe(EMPTY_STORAGE_ROOT)
+		expect(methodCount(transport.calls, 'eth_getProof')).toBe(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('falls back to scalar methods on -32004 Method not supported', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32004, message: 'Method not supported' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		expect(account.nonce).toBe(5n)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('falls back on -32600 whose message says the method is not available (Monad shape)', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32600, message: 'eth_getProof is not available on the MONAD_MAINNET' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('falls back on -32600 whose message says the method is unavailable', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32600, message: 'Method unavailable' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		const account = await getAccountFromProvider(state)(address)
+
+		expect(account.balance).toBe(2000000000000000000n)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+	})
+
+	it('does NOT fall back on a generic -32600 invalid request', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32600, message: 'invalid request' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+
+		expect(methodCount(transport.calls, 'eth_getProof')).toBeGreaterThanOrEqual(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	})
+
+	it('does NOT fall back or stick on -32005 rate limiting', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32005, message: 'rate limited' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		// viem retries rate-limit errors, so eth_getProof count is >= 1, not exactly 1
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		const callsAfterFirst = methodCount(transport.calls, 'eth_getProof')
+		expect(callsAfterFirst).toBeGreaterThanOrEqual(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		expect(methodCount(transport.calls, 'eth_getProof')).toBeGreaterThan(callsAfterFirst)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	}, 30_000)
+
+	it('does NOT fall back or stick on plain network errors', async () => {
+		const transport = createRecordingTransport({
+			getProofError: new Error('ECONNRESET'),
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		const callsAfterFirst = methodCount(transport.calls, 'eth_getProof')
+		expect(callsAfterFirst).toBeGreaterThanOrEqual(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+
+		await expect(getAccountFromProvider(state)(address)).rejects.toThrow()
+		expect(methodCount(transport.calls, 'eth_getProof')).toBeGreaterThan(callsAfterFirst)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(0)
+		}
+	}, 30_000)
+
+	it('downgrades the transport permanently: second address skips eth_getProof entirely', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+		const secondAddress = createAddress(`0x${'02'.repeat(20)}`)
+
+		await getAccountFromProvider(state)(address)
+		await getAccountFromProvider(state)(secondAddress)
+
+		expect(methodCount(transport.calls, 'eth_getProof')).toBe(1)
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(2)
+		}
+	})
+
+	it('pins every scalar request to the fork block', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 123n } })
+
+		await getAccountFromProvider(state)(address)
+
+		const scalarCalls = transport.calls.filter((c) => SCALAR_METHODS.includes(c.method))
+		expect(scalarCalls).toHaveLength(3)
+		for (const call of scalarCalls) {
+			expect(call.params).toContain('0x7b')
+		}
+	})
+
+	it('primes the contract code cache so getContractCode makes no extra eth_getCode call', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+
+		await getAccountFromProvider(state)(address)
+		expect(methodCount(transport.calls, 'eth_getCode')).toBe(1)
+
+		const codeBytes = await getContractCode(state)(address)
+
+		expect(codeBytes).toEqual(hexToBytes(MOCK_CODE))
+		expect(methodCount(transport.calls, 'eth_getCode')).toBe(1)
+	})
+
+	it('resolves a nonexistent account to undefined through the real getAccount action', async () => {
+		const transport = createRecordingTransport({
+			getProofError: { code: -32601, message: 'Method not found' },
+			balance: '0x0',
+			transactionCount: '0x0',
+			code: '0x',
+		})
+		const state = createBaseState({ loggingLevel: 'error', fork: { transport, blockTag: 1n } })
+		const emptyAddress = createAddress(`0x${'03'.repeat(20)}`)
+
+		const result = await getAccount(state)(emptyAddress)
+
+		expect(result).toBeUndefined()
+		for (const method of SCALAR_METHODS) {
+			expect(methodCount(transport.calls, method)).toBe(1)
+		}
+		expect(state.caches.accounts.get(emptyAddress)?.accountRLP).toBeUndefined()
+		expect(state.forkCache.accounts.get(emptyAddress)?.accountRLP).toBeUndefined()
 	})
 })


### PR DESCRIPTION
Supersedes #2093

Closes #2093

Carries Edward Bramanti's scalar RPC fallback forward with the requested correctness and lint follow-ups.

- recognize nonexistent fork accounts under both all-zero provider hashes and canonical empty hashes
- add dual-encoding regression coverage
- guard the per-transport WeakMap downgrade cache when no transport is present
- add explicit return types to the new TypeScript test helpers and callbacks
- correct the changeset wording

Tests:
- packages/state: vitest run src/actions/ (30 files, 129 tests passed)
- packages/memory-client: vitest run src/test (62 files passed, 9 skipped; 146 tests passed, 11 todo)
- @tevm/state typecheck
- Biome check on changed source and test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forked account loading when proof-based retrieval is unavailable.
  * Added fallback retrieval for balances, transaction counts, and contract code while preserving fork-block accuracy.
  * Improved detection of empty and nonexistent accounts across different provider responses.
  * Loaded contract bytecode into the cache during fallback account hydration.
  * Prevented repeated fallback detection for the same connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->