### PR TITLE
📝 docs: add Context7 indexing configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://context7.com/schema/context7.json",
+	"projectTitle": "Tevm",
+	"description": "A JavaScript-native Ethereum runtime for TypeScript apps, tests, and tools — fork chains and run the EVM locally with viem-compatible APIs and type-safe Solidity imports.",
+	"folders": ["docs/node/pages"],
+	"excludeFolders": [
+		"node_modules",
+		"dist",
+		"docs/node/dist",
+		"lib",
+		"releases",
+		".changeset",
+		"coverage",
+		"memory-bank",
+		"prompts",
+		"docs/triage",
+		"docs/triage-reports"
+	],
+	"excludeFiles": [
+		"CLAUDE.md",
+		"CONTRIBUTING.md",
+		"COVERAGE.md",
+		"Debugger.md",
+		"JSR.md",
+		"TODO.md",
+		"fix-report.md",
+		"review.md",
+		"verification_report.md"
+	],
+	"rules": [
+		"Tevm is a JavaScript-native Ethereum runtime that runs in browsers, Node.js, Bun, Deno, serverless functions, and edge runtimes",
+		"Use createMemoryClient() as the batteries-included entrypoint for viem public, wallet, and test actions plus Tevm-specific actions",
+		"Import chain configurations from 'tevm/common'; the removed 'tevm/chains' alias is not supported",
+		"Use Tevm bundler plugins to import Solidity directly in TypeScript; .sol imports contain ABI data while .s.sol imports also contain deployable bytecode"
+	],
+	"previousVersions": []
+}


### PR DESCRIPTION
## Summary

- add a root Context7 configuration that targets the Vocs product documentation in `docs/node/pages`
- exclude internal root reports and contributor material, including the large `review.md` and `fix-report.md` files, so they do not degrade indexed snippets
- add current 1.0-era guidance for the viem-compatible memory client, `tevm/common`, and Solidity imports

## Validation

- `python3 -m json.tool context7.json`
- `bunx biome check context7.json`
- validation against `https://context7.com/schema/context7.json` with AJV

## Context7 rollout

After merging, a maintainer must submit `https://github.com/evmts/tevm-monorepo` at https://context7.com/add-library?tab=github to trigger the initial crawl. Adding this configuration alone does not perform that one-time submission.

After indexing, verify the result with:

```sh
curl -s 'https://context7.com/api/v1/search?query=tevm'
```

The response should contain an `/evmts/tevm-monorepo` entry with `state: finalized`.

## Merge timing

Tevm 1.0.0 final has not shipped yet; `tevm@1.0.0-rc.153` is currently the latest release candidate. Also, the latest maintainer note on #2058 says to leave the integration open but not implement it for now. This draft is intentionally framed as ready to merge if and when roninjin10 wants to trial Context7.

Closes #2058

Thanks to @PaulRBerg for the report.

<prompt>
Support Context7 docs for issue #2058.
</prompt>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project configuration for documentation folders, excluded files, project metadata, usage guidance, and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->